### PR TITLE
Added UniveseComparator plugin to the 'extra-dev' repository.

### DIFF
--- a/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/descr
+++ b/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/descr
@@ -1,0 +1,1 @@
+A tool to compare universe levels in Coq.

--- a/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/opam
+++ b/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.1" 
+maintainer: "amin.timany@cs.kuleuven.be"
+homepage: "https://amintimany.github.io/UniverseComparator/html/test.html"
+bug-reports: "https://github.com/amintimany/UniverseComparator/issues"
+authors: ["Amin Timany"]
+license: "MIT"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/UniverseComparator"]
+depends: [
+  "coq" {>= "8.5~beta2"}
+]

--- a/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/url
+++ b/extra-dev/packages/coq:universe-comparator/coq:universe-comparator.dev/url
@@ -1,0 +1,1 @@
+http: "https://github.com/amintimany/UniverseComparator/archive/master.tar.gz"


### PR DESCRIPTION
Hi, I added the plugin I wrote during Coq coding sprint to the 'extra-dev' repository of opam. Would it make sense to also add a release version? Or should we wait for the release of Coq8.5!?