### PR TITLE
Adding development packages for Coq 8.0, 8.1 and 8.2.

### DIFF
--- a/core-dev/packages/coq.8.0.dev/descr
+++ b/core-dev/packages/coq.8.0.dev/descr
@@ -1,0 +1,11 @@
+Coq is a formal proof management system.
+
+It provides a formal language to write mathematical definitions,
+executable algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs. Typical
+applications are certified programming, mathematical proof
+development, and teaching.
+
+This package includes CoqIDE.
+
+

--- a/core-dev/packages/coq.8.0.dev/opam
+++ b/core-dev/packages/coq.8.0.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.1"
+maintainer: "hugo.herbelin@inria.fr"
+authors: ["The Coq Development Team"]
+homepage: "http://coq.inria.fr/"
+bug-reports: "https://coq.inria.fr/bugs/"
+license: "LGPL 2"
+build: [
+  ["./configure" "-opt" "-camlp5dir" "%{lib}%/camlp5" "-prefix" prefix "-lablgtkdir" "%{lib}%/lablgtk2" "-reals" "all"]
+  [make "world"]
+  [make "install"]
+]
+depends: [
+  "camlp5" {>= "5.01" } # This is what INSTALL says; checked for 6.02.3, 6.14
+  "lablgtk" {>= "2.10" } # This is what INSTALL says; checked for 2.18.3
+]
+ocaml-version: [>= "3.06"] # This is what INSTALL says; checked it worked for 3.08.4, 3.12.1, 4.01.0, 4.02.3

--- a/core-dev/packages/coq.8.0.dev/url
+++ b/core-dev/packages/coq.8.0.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/coq/coq#v8.0"

--- a/core-dev/packages/coq.8.1.dev/descr
+++ b/core-dev/packages/coq.8.1.dev/descr
@@ -1,0 +1,11 @@
+Coq is a formal proof management system.
+
+It provides a formal language to write mathematical definitions,
+executable algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs. Typical
+applications are certified programming, mathematical proof
+development, and teaching.
+
+This package includes CoqIDE.
+
+

--- a/core-dev/packages/coq.8.1.dev/opam
+++ b/core-dev/packages/coq.8.1.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.1"
+maintainer: "hugo.herbelin@inria.fr"
+authors: ["The Coq Development Team"]
+homepage: "http://coq.inria.fr/"
+bug-reports: "https://coq.inria.fr/bugs/"
+license: "LGPL 2"
+build: [
+  ["./configure" "-opt" "-camlp5dir" "%{lib}%/camlp5" "-prefix" prefix "-lablgtkdir" "%{lib}%/lablgtk2" "-reals" "all"]
+  [make "world"]
+  [make "install"]
+]
+depends: [
+  "camlp5" {>= "5.01" } # This is what INSTALL says; checked for 6.02.3, 6.14
+  "lablgtk" {>= "2.10" } # This is what INSTALL says; checked for 2.18.3
+]
+ocaml-version: [>= "3.07"] # This is what INSTALL says; checked it worked for 3.08.4, 3.12.1, 4.01.0, 4.02.3

--- a/core-dev/packages/coq.8.1.dev/url
+++ b/core-dev/packages/coq.8.1.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/coq/coq#v8.1"

--- a/core-dev/packages/coq.8.2.dev/descr
+++ b/core-dev/packages/coq.8.2.dev/descr
@@ -1,0 +1,11 @@
+Coq is a formal proof management system.
+
+It provides a formal language to write mathematical definitions,
+executable algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs. Typical
+applications are certified programming, mathematical proof
+development, and teaching.
+
+This package includes CoqIDE.
+
+

--- a/core-dev/packages/coq.8.2.dev/opam
+++ b/core-dev/packages/coq.8.2.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.1"
+maintainer: "hugo.herbelin@inria.fr"
+authors: ["The Coq Development Team"]
+homepage: "http://coq.inria.fr/"
+bug-reports: "https://coq.inria.fr/bugs/"
+license: "LGPL 2"
+build: [
+  ["./configure" "-opt" "-camlp5dir" "%{lib}%/camlp5" "-prefix" prefix "-with-doc" "no" "-lablgtkdir" "%{lib}%/lablgtk2"]
+  [make "-j%{jobs}%"]
+  [make "install"]
+]
+depends: [
+  "camlp5" {>= "5.01" } # This is what INSTALL says; checked for 6.02.3, 6.14
+  "lablgtk" {>= "2.10" } # This is what INSTALL says; checked for 2.18.3
+]
+available: [ocaml-version >= "3.07" & ocaml-version != "3.08.3" ]
+# This is what INSTALL says;
+# Checked it works for 3.08.4, 3.12.1, 4.01.0, 4.02.3
+# It loops (or takes very very long time) when using 3.08.3

--- a/core-dev/packages/coq.8.2.dev/url
+++ b/core-dev/packages/coq.8.2.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/coq/coq#v8.2"


### PR DESCRIPTION
I made development packages for Coq 8.0, 8.1 and 8.2. They compile with 4.02.3 (but also tested with 3.08.4, 3.12.1, 4.01.0, though for 3.08.4, there is currently no compatible lablgtk opam package, so I had to compile my own labgltk package). To my knowledge, there are all without known critical bugs.