### PR TITLE
Added the coq-bits and coq-bitset packages to extra-dev

### DIFF
--- a/extra-dev/packages/coq-bits/coq-bits.dev/descr
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/descr
@@ -1,0 +1,1 @@
+A formalization of bitset operations in Coq and the corresponding axiomatization and extraction to OCaml native integers.

--- a/extra-dev/packages/coq-bits/coq-bits.dev/opam
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "coq-bits"
+maintainer: "Arthur Blot <arthur.blot@ens-lyon.fr>"
+authors: ["Andrew Kennedy <akenn@microsoft.com>"
+          "Arthur Blot <arthur.blot@ens-lyon.fr>"
+          "Pierre-Évariste Dagand <pierre-evariste.dagand@lip6.fr>"]
+homepage: "https://github.com/artart78/coq-bits/"
+bug-reports: "https://github.com/artart78/coq-bits/"
+license: "Apache"
+build: [
+["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+[make "-j%{jobs}%"]
+]
+install: [
+[make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bits"]
+depends: [
+"coq" {>= "8.5~beta2"}
+"coq-math-comp" {>= "1.5.1~beta2"}
+]

--- a/extra-dev/packages/coq-bits/coq-bits.dev/url
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/artart78/coq-bits.git"

--- a/extra-dev/packages/coq-bitset/coq-bitset.dev/descr
+++ b/extra-dev/packages/coq-bitset/coq-bitset.dev/descr
@@ -1,0 +1,1 @@
+A library used to prove algorithms working on OCaml native integers using representations with SSReflect's finite sets.

--- a/extra-dev/packages/coq-bitset/coq-bitset.dev/opam
+++ b/extra-dev/packages/coq-bitset/coq-bitset.dev/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "coq-bitset"
+maintainer: "Arthur Blot <arthur.blot@ens-lyon.fr>"
+authors: ["Arthur Blot <arthur.blot@ens-lyon.fr>"
+          "Pierre-Évariste Dagand <pierre-evariste.dagand@lip6.fr>"]
+homepage: "https://github.com/artart78/coq-bitset"
+bug-reports: "https://github.com/artart78/coq-bitset"
+license: ""
+build: [
+["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+[make "-j%{jobs}%"]
+]
+install: [
+[make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bitset"]
+depends: [
+"coq" {>= "8.5~beta2"}
+"coq-math-comp" {>= "1.5.1~beta2"}
+"coq-bits"
+]

--- a/extra-dev/packages/coq-bitset/coq-bitset.dev/url
+++ b/extra-dev/packages/coq-bitset/coq-bitset.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/artart78/coq-bitset"


### PR DESCRIPTION
The purpose of these libraries is to prove algorithms working with OCaml native integers (with the appropriate extraction) using a finite set representation given by SSReflect/MathComp.

More details here: https://github.com/artart78/coq-bitset