### PR TITLE
A plugin and a tool to produce dependency graphs between objects in Coq

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/descr
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/descr
@@ -1,0 +1,2 @@
+Computing dependencies between Coq objects (definitions, theorems)
+

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+
+maintainer: "yves.bertot@inria.fr"
+license: "LGPL 2.1"
+
+homepage: "https://github.com/ybertot/coq-dpdgraph"
+build: [
+  ["./configure"]
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+ ]
+remove: [
+  ["rm" "%{bin}%/dpd2dot"]
+  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
+]
+
+depends: [
+   "coq" {>= "8.5"}
+]
+
+authors: [ "Anne Pacalet" "Yves Bertot"]

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/opam
@@ -16,6 +16,7 @@ remove: [
 
 depends: [
    "coq" {>= "8.5"}
+   "ocamlgraph"
 ]
 
 authors: [ "Anne Pacalet" "Yves Bertot"]

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/url
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ybertot/coq-dpdgraph/archive/release-for-8.5-0.4-rc1.zip"
+checksum: "fe9f172750906b2acfea71661e408906"

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/descr
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/descr
@@ -1,0 +1,4 @@
+Compute dependencies between Coq objects (definitions, theorems)
+and produce graphs
+
+

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+
+maintainer: "yves.bertot@inria.fr"
+license: "LGPL 2.1"
+
+homepage: "https://github.com/karmaki/coq-dpdgraph"
+build: [
+  ["./configure"]
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+ ]
+remove: [
+  ["rm" "%{bin}%/dpd2dot"]
+  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
+]
+
+depends: [
+   "coq" {>= "8.5"}
+   "ocamlgraph"
+]
+
+authors: [ "Anne Pacalet" "Yves Bertot"]

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/url
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.5/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ybertot/coq-dpdgraph/archive/coq-dpdgraph-0.5-rc2.zip"
+checksum: "d9614264c394080c2734638befaf0483"


### PR DESCRIPTION
The two commits of Feb. 24 and Feb. 25 can be discarded.  They produce a version 0.4 which
is slightly wrong.