### PR TITLE
Update coq-bits & coq-bitset to Coq 8.5 / SSR 1.6

### DIFF
--- a/extra-dev/packages/coq-bits/coq-bits.dev/opam
+++ b/extra-dev/packages/coq-bits/coq-bits.dev/opam
@@ -16,6 +16,7 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bits"]
 depends: [
-"coq" {>= "8.5~beta2"}
-"coq-math-comp" {>= "1.5.1~beta2"}
+"coq" {>= "8.5"}
+"coq-mathcomp-algebra" {>= "1.6"}
+"coq-mathcomp-ssreflect" {>= "1.6"}
 ]

--- a/extra-dev/packages/coq-bitset/coq-bitset.dev/opam
+++ b/extra-dev/packages/coq-bitset/coq-bitset.dev/opam
@@ -15,7 +15,8 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bitset"]
 depends: [
-"coq" {>= "8.5~beta2"}
-"coq-math-comp" {>= "1.5.1~beta2"}
+"coq" {>= "8.5"}
+"coq-mathcomp-algebra" {>= "1.6"}
+"coq-mathcomp-ssreflect" {>= "1.6"}
 "coq-bits"
 ]


### PR DESCRIPTION
As promised (although a bit late), I updated my libraries coq-bits and coq-bitset to use the latest Coq / MathComp packages, and updated the dependency lists for this change.