### PR TITLE
add 8.5.0 version of coq-aac-tactics

### DIFF
--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/descr
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/descr
@@ -1,0 +1,3 @@
+AAC tactics.
+
+This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators:

--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/opam
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.1"
+maintainer: "matej.kosik@inria.fr"
+homepage: "https://github.com/coq/aac-tactics"
+license: "LGPL"
+build: [
+  [make "-j%{jobs}%"]
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AAC_tactics"]
+depends: [
+  "coq" {>= "8.5" & < "8.6"}
+]
+tags: [ "keyword:reflexive tactic" "keyword:rewriting" "keyword:rewriting modulo associativity and commutativity" "keyword:rewriting modulo ac" "keyword:decision procedure" "category:Miscellaneous/Coq Extensions" ]
+authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]

--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/opam
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/opam
@@ -1,14 +1,14 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "matej.kosik@inria.fr"
 homepage: "https://github.com/coq/aac-tactics"
 license: "LGPL"
-build: [
-  [make "-j%{jobs}%"]
-  [make "install"]
-]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AAC_tactics"]
 depends: [
   "coq" {>= "8.5" & < "8.6"}
 ]
 tags: [ "keyword:reflexive tactic" "keyword:rewriting" "keyword:rewriting modulo associativity and commutativity" "keyword:rewriting modulo ac" "keyword:decision procedure" "category:Miscellaneous/Coq Extensions" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]
+bug-reports: "coqdev@inria.fr"
+dev-repo: "https://github.com/coq/aac-tactics"

--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/url
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.5.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/coq/aac-tactics/archive/8.5.0.tar.gz"
+checksum: "7686e0d53a2f619a51ad4ae73cafe8c6"


### PR DESCRIPTION
I am trying to add "aac-tactics" as a new package to the "released" category.

It is based on "aac-tactics*" package from "extra-dev".

I haven't done this kind of thing (creating an OPAM package) before so let me please know if everything is kosher.