### PR TITLE
Adds coq-dpdgraph.0.6

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/descr
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/descr
@@ -1,0 +1,4 @@
+Compute dependencies between Coq objects (definitions, theorems)
+and produce graphs
+
+

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+
+maintainer: "yves.bertot@inria.fr"
+license: "LGPL 2.1"
+
+homepage: "https://github.com/karmaki/coq-dpdgraph"
+build: [
+  ["./configure"]
+  ["echo" "%{jobs}%" "jobs for the linter"]
+  [make]
+  [make "install" "BINDIR=%{bin}%"]
+ ]
+remove: [
+  ["rm" "%{bin}%/dpd2dot"]
+  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
+]
+
+depends: [
+   "coq" {>= "8.5"}
+   "ocamlgraph"
+]
+
+authors: [ "Anne Pacalet" "Yves Bertot"]

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/opam
@@ -4,14 +4,23 @@ maintainer: "yves.bertot@inria.fr"
 license: "LGPL 2.1"
 
 homepage: "https://github.com/karmaki/coq-dpdgraph"
+
 build: [
   ["./configure"]
   ["echo" "%{jobs}%" "jobs for the linter"]
   [make]
-  [make "install" "BINDIR=%{bin}%"]
  ]
+
+bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
+
+dev-repo: "https://github.com/karmaki/coq-dpdgraph"
+
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+
 remove: [
-  ["rm" "%{bin}%/dpd2dot"]
+  ["rm" "%{bin}%/dpd2dot" "%{bin}%/dpdusage"]
   ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
 ]
 

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/url
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/ybertot/coq-dpdgraph/archive/coq-dpdgraph-0.6.rc1.zip"
+checksum: "959e3fbe425fc8c4189635db736fbc9e"


### PR DESCRIPTION
This release has the following changes:
- a new command _dpdusage_
-  support for universe polymorphic constants
-  support for primitive projections
-  tests that are a little less brittle (no dependence on Coq version or date of compilation)