### PR TITLE
Update LtacProf

### DIFF
--- a/core-dev/packages/coq.8.4.dev+ltacprof/files/ltac-profiling-0.8.patch
+++ b/core-dev/packages/coq.8.4.dev+ltacprof/files/ltac-profiling-0.8.patch
@@ -95,7 +95,7 @@ index 5cbb7bd..30a6c11 100644
      | "-R" :: s :: t :: rem -> parse (cfiles,t::s::"-R"::args) rem
  
 -    | ("-notactics"|"-debug"|"-nolib"|"-boot"|"-time"
-+    | ("-notactics"|"-debug"|"-nolib"|"-boot"|"-time"|"-profileltac"
++    | ("-notactics"|"-debug"|"-nolib"|"-boot"|"-time"|"-profile-ltac"
        |"-batch"|"-nois"|"-noglob"|"-no-glob"
        |"-q"|"-full"|"-profile"|"-just-parsing"|"-echo" |"-unsafe"|"-quiet"
        |"-silent"|"-m"|"-xml"|"-v7"|"-v8"|"-beautify"|"-strict-implicit"
@@ -113,17 +113,17 @@ new file mode 100644
 index 0000000..d874a46
 --- /dev/null
 +++ b/tactics/profile_ltac.ml
-@@ -0,0 +1,233 @@
+@@ -0,0 +1,218 @@
 +open Pp
 +open Printer
 +open Util
 +
 +(** [is_profiling] and the profiling info ([stack]) should be synchronized with the document; the rest of the ref cells are either local to individual tactic invocations, or global flags, and need not be synchronized, since no document-level backtracking happens within tactics.  We synchronize is_profiling via an option. *)
 +let is_profiling = ref false
-+let set_profiling b = is_profiling := b
-+let get_profiling() = !is_profiling
-+
 +let should_display_profile_at_close = ref false
++
++let set_profiling b = is_profiling := b
++let get_profiling() = !is_profiling || !should_display_profile_at_close
 +let set_display_profile_at_close b = should_display_profile_at_close := b
 +
 +
@@ -144,22 +144,7 @@ index 0000000..d874a46
 +let deepcopy_entry {total; local; ncalls; max_total} =
 +  {total; local; ncalls; max_total}
 +
-+let rec deepcopy_treenode {entry; children} =
-+  {entry = deepcopy_entry entry;
-+   children =
-+      (let children' = Hashtbl.create (Hashtbl.length children) in
-+       Hashtbl.iter
-+	 (fun key subtree -> Hashtbl.add children' key (deepcopy_treenode subtree))
-+	 children;
-+       children')}
-+
 +let stack = ref [{entry=empty_entry(); children=Hashtbl.create 20}]
-+
-+let _ = Summary.declare_summary "LtacProf-stack"
-+          { Summary.freeze_function = (fun () ->
-+                                         List.map deepcopy_treenode !stack);
-+            Summary.unfreeze_function = (fun stack_val -> stack := stack_val);
-+            Summary.init_function = (fun () -> stack := [{entry=empty_entry(); children=Hashtbl.create 20}]) }
 +
 +let on_stack = Hashtbl.create 5
 +
@@ -393,12 +378,12 @@ index 0000000..ff6250f
 +
 +let _ =
 +  Goptions.declare_bool_option
-+    { optsync  = true;
-+      optdepr  = false;
-+      optname  = "Ltac Profiling";
-+      optkey   = ["Ltac"; "Profiling"];
-+      optread  = get_profiling;
-+      optwrite = set_profiling }
++    { Goptions.optsync  = true;
++      Goptions.optdepr  = false;
++      Goptions.optname  = "Ltac Profiling";
++      Goptions.optkey   = ["Ltac"; "Profiling"];
++      Goptions.optread  = get_profiling;
++      Goptions.optwrite = set_profiling }
 +
 +VERNAC COMMAND EXTEND ResetLtacProfiling
 + [ "Reset" "Ltac" "Profile" ] -> [ reset_profile() ]
@@ -474,7 +459,7 @@ index 02dd1f2..c2934d6 100644
  
      | "-time" :: rem -> Vernac.time := true; parse rem
  
-+    | "-profileltac" :: rem -> Profile_ltac.set_profiling true; Profile_ltac.set_display_profile_at_close true; parse rem
++    | "-profile-ltac" :: rem -> Profile_ltac.set_profiling true; Profile_ltac.set_display_profile_at_close true; parse rem
 +
      | "-compat" :: v :: rem ->
          Flags.compat_version := get_compat_version v; parse rem
@@ -487,7 +472,7 @@ index dac3573..2d055a8 100644
  \n  -quality               improve the legibility of the proof terms produced by\
  \n                         some tactics\
  \n  -time                  display the time taken by each command\
-+\n  -profileltac           display the time taken by each (sub)tactic\
++\n  -profile-ltac          display the time taken by each (sub)tactic\
  \n  -h, --help             print this list of options\
  \n"
  

--- a/core-dev/packages/coq.8.4.dev+ltacprof/opam
+++ b/core-dev/packages/coq.8.4.dev+ltacprof/opam
@@ -12,5 +12,5 @@ depends: [
   "camlp5"
 ]
 patches: [
-  "ltac-profiling-0.5.patch"
+  "ltac-profiling-0.8.patch"
 ]

--- a/core-dev/packages/coq.8.5.dev+ltacprof/files/ltac-profiling-0.8-8.5.patch
+++ b/core-dev/packages/coq.8.5.dev+ltacprof/files/ltac-profiling-0.8-8.5.patch
@@ -102,7 +102,7 @@ new file mode 100644
 index 0000000..59568cb
 --- /dev/null
 +++ b/tactics/profile_ltac.ml
-@@ -0,0 +1,296 @@
+@@ -0,0 +1,283 @@
 +open Pp
 +open Printer
 +open Util
@@ -145,20 +145,7 @@ index 0000000..59568cb
 +
 +type treenode = {entry : entry; children : (string, treenode) Hashtbl.t}
 +
-+(** Tobias Tebbi wrote some tricky code involving mutation.  Rather than rewriting it in a functional style, we simply freeze the state when we need to by issuing a deep copy of the profiling data. *)
-+let deepcopy_entry {total; local; ncalls; max_total} =
-+  {total; local; ncalls; max_total}
-+
-+let rec deepcopy_treenode {entry; children} =
-+  {entry = deepcopy_entry entry;
-+   children =
-+      (let children' = Hashtbl.create (Hashtbl.length children) in
-+       Hashtbl.iter
-+	 (fun key subtree -> Hashtbl.add children' key (deepcopy_treenode subtree))
-+	 children;
-+       children')}
-+
-+let stack = Summary.ref ~freeze:(fun _ -> List.map deepcopy_treenode) [{entry=empty_entry(); children=Hashtbl.create 20}] ~name:"LtacProf-stack"
++let stack = ref [{entry=empty_entry(); children=Hashtbl.create 20}]
 +
 +let on_stack = Hashtbl.create 5
 +
@@ -427,7 +414,7 @@ new file mode 100644
 index 0000000..5d96787
 --- /dev/null
 +++ b/tactics/profile_ltac_tactics.ml4
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +(*i camlp4deps: "grammar/grammar.cma" i*)
 +
 +open Profile_ltac
@@ -447,7 +434,8 @@ index 0000000..5d96787
 +END;;
 +
 +let _ =
-+  Goptions.declare_bool_option
++  let open Goptions in
++  declare_bool_option
 +    { optsync  = true;
 +      optdepr  = false;
 +      optname  = "Ltac Profiling";

--- a/core-dev/packages/coq.8.5.dev+ltacprof/files/ltac-profiling-0.9-8.5.patch
+++ b/core-dev/packages/coq.8.5.dev+ltacprof/files/ltac-profiling-0.9-8.5.patch
@@ -418,6 +418,7 @@ index 0000000..5d96787
 +(*i camlp4deps: "grammar/grammar.cma" i*)
 +
 +open Profile_ltac
++open Goptions
 +
 +DECLARE PLUGIN "profile_ltac_plugin"
 +
@@ -434,7 +435,6 @@ index 0000000..5d96787
 +END;;
 +
 +let _ =
-+  let open Goptions in
 +  declare_bool_option
 +    { optsync  = true;
 +      optdepr  = false;

--- a/core-dev/packages/coq.8.5.dev+ltacprof/opam
+++ b/core-dev/packages/coq.8.5.dev+ltacprof/opam
@@ -20,5 +20,5 @@ depends: [
   "camlp5"
 ]
 patches: [
-  "ltac-profiling-0.6-8.5.patch"
+  "ltac-profiling-0.8-8.5.patch"
 ]


### PR DESCRIPTION
This uniformizes the flags in accordance with 8.6 (-profile-ltac), and makes
the flag actually work by making the LtacProf state not synchronized
with the document.

I expect this to be the final update to LtacProf, given that it's now been integrated into v8.6.