### PR TITLE
Unified format for the date tag

### DIFF
--- a/extra-dev/packages/coq-algebra/coq-algebra.8.4.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 99" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
 authors: [ "Loïc Pottier <>" ]

--- a/extra-dev/packages/coq-algebra/coq-algebra.8.4.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:1999-03" ]
 authors: [ "Loïc Pottier <>" ]

--- a/extra-dev/packages/coq-algebra/coq-algebra.8.5.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:1999-03" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/extra-dev/packages/coq-algebra/coq-algebra.8.5.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 99" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/extra-dev/packages/coq-algebra/coq-algebra.8.6.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 99" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/extra-dev/packages/coq-algebra/coq-algebra.8.6.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:1999-03" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/extra-dev/packages/coq-algebra/coq-algebra.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 99" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
 authors: [ "Loïc Pottier <>" ]

--- a/extra-dev/packages/coq-algebra/coq-algebra.dev/opam
+++ b/extra-dev/packages/coq-algebra/coq-algebra.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:1999-03" ]
 authors: [ "Loïc Pottier <>" ]

--- a/extra-dev/packages/coq-amm11262/coq-amm11262.8.4.dev/opam
+++ b/extra-dev/packages/coq-amm11262/coq-amm11262.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AMM11262"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:american mathematical monthly problem 11262" "date:April 2007" ]
+tags: [ "keyword:american mathematical monthly problem 11262" "date:2007-04" ]
 authors: [ "Tonny Hurkens (paper proof) <hurkens@sci.kun.nl>" "Milad Niqui (Coq files) <milad@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-amm11262/coq-amm11262.8.5.dev/opam
+++ b/extra-dev/packages/coq-amm11262/coq-amm11262.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AMM11262"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:american mathematical monthly problem 11262" "date:April 2007" ]
+tags: [ "keyword:american mathematical monthly problem 11262" "date:2007-04" ]
 authors: [ "Tonny Hurkens (paper proof) <hurkens@sci.kun.nl>" "Milad Niqui (Coq files) <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/amm11262/issues"
 dev-repo: "https://github.com/coq-contribs/amm11262.git"

--- a/extra-dev/packages/coq-amm11262/coq-amm11262.8.6.dev/opam
+++ b/extra-dev/packages/coq-amm11262/coq-amm11262.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AMM11262"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:american mathematical monthly problem 11262" "date:April 2007" ]
+tags: [ "keyword:american mathematical monthly problem 11262" "date:2007-04" ]
 authors: [ "Tonny Hurkens (paper proof) <hurkens@sci.kun.nl>" "Milad Niqui (Coq files) <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/amm11262/issues"
 dev-repo: "https://github.com/coq-contribs/amm11262.git"

--- a/extra-dev/packages/coq-amm11262/coq-amm11262.dev/opam
+++ b/extra-dev/packages/coq-amm11262/coq-amm11262.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AMM11262"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:american mathematical monthly problem 11262" "date:April 2007" ]
+tags: [ "keyword:american mathematical monthly problem 11262" "date:2007-04" ]
 authors: [ "Tonny Hurkens (paper proof) <hurkens@sci.kun.nl>" "Milad Niqui (Coq files) <milad@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-angles/coq-angles.8.4.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 janvier 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-angles/coq-angles.8.4.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:2002-01-15" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-angles/coq-angles.8.5.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:2002-01-15" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/extra-dev/packages/coq-angles/coq-angles.8.5.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 janvier 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/extra-dev/packages/coq-angles/coq-angles.8.6.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 janvier 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/extra-dev/packages/coq-angles/coq-angles.8.6.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:2002-01-15" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/extra-dev/packages/coq-angles/coq-angles.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:2002-01-15" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-angles/coq-angles.dev/opam
+++ b/extra-dev/packages/coq-angles/coq-angles.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 janvier 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-atbr/coq-atbr.8.4.dev/opam
+++ b/extra-dev/packages/coq-atbr/coq-atbr.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ATBR"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:June 2009" ]
+tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2009-06" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]

--- a/extra-dev/packages/coq-atbr/coq-atbr.8.5.dev/opam
+++ b/extra-dev/packages/coq-atbr/coq-atbr.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ATBR"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:June 2009" ]
+tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2009-06" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/atbr/issues"
 dev-repo: "https://github.com/coq-contribs/atbr.git"

--- a/extra-dev/packages/coq-atbr/coq-atbr.8.6.dev/opam
+++ b/extra-dev/packages/coq-atbr/coq-atbr.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ATBR"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:June 2009" ]
+tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2009-06" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/atbr/issues"
 dev-repo: "https://github.com/coq-contribs/atbr.git"

--- a/extra-dev/packages/coq-atbr/coq-atbr.dev/opam
+++ b/extra-dev/packages/coq-atbr/coq-atbr.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ATBR"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:June 2009" ]
+tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2009-06" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.4.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:May 22nd, 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.4.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2006-05-22" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.5.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2006-05-22" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.5.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:May 22nd, 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.6.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2006-05-22" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/extra-dev/packages/coq-cantor/coq-cantor.8.6.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:May 22nd, 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/extra-dev/packages/coq-cantor/coq-cantor.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:May 22nd, 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-cantor/coq-cantor.dev/opam
+++ b/extra-dev/packages/coq-cantor/coq-cantor.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2006-05-22" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.4.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:2004-10-10" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.4.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:October 10th 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:October 10th 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:2004-10-10" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.6.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:2004-10-10" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.6.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:October 10th 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:2004-10-10" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.dev/opam
+++ b/extra-dev/packages/coq-cats-in-zfc/coq-cats-in-zfc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:October 10th 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.4.dev/opam
+++ b/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coalgebras"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:October 2008" ]
+tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:2008-10" ]
 authors: [ "Milad Niqui <M.Niqui@cwi.nl>" ]

--- a/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.5.dev/opam
+++ b/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coalgebras"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:October 2008" ]
+tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:2008-10" ]
 authors: [ "Milad Niqui <M.Niqui@cwi.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coalgebras/issues"
 dev-repo: "https://github.com/coq-contribs/coalgebras.git"

--- a/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.6.dev/opam
+++ b/extra-dev/packages/coq-coalgebras/coq-coalgebras.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coalgebras"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:October 2008" ]
+tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:2008-10" ]
 authors: [ "Milad Niqui <M.Niqui@cwi.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coalgebras/issues"
 dev-repo: "https://github.com/coq-contribs/coalgebras.git"

--- a/extra-dev/packages/coq-coalgebras/coq-coalgebras.dev/opam
+++ b/extra-dev/packages/coq-coalgebras/coq-coalgebras.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coalgebras"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:October 2008" ]
+tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:2008-10" ]
 authors: [ "Milad Niqui <M.Niqui@cwi.nl>" ]

--- a/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.4.dev/opam
+++ b/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-qarith-stern-brocot" {= "8.4.dev"}
 ]
-tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:24 April 2007" ]
+tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:2007-04-24" ]
 authors: [ "Milad Niqui <milad@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.5.dev/opam
+++ b/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-qarith-stern-brocot" {= "8.5.dev"}
 ]
-tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:24 April 2007" ]
+tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:2007-04-24" ]
 authors: [ "Milad Niqui <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coinductive-reals/issues"
 dev-repo: "https://github.com/coq-contribs/coinductive-reals.git"

--- a/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.6.dev/opam
+++ b/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-qarith-stern-brocot"
 ]
-tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:24 April 2007" ]
+tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:2007-04-24" ]
 authors: [ "Milad Niqui <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coinductive-reals/issues"
 dev-repo: "https://github.com/coq-contribs/coinductive-reals.git"

--- a/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.dev/opam
+++ b/extra-dev/packages/coq-coinductive-reals/coq-coinductive-reals.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-qarith-stern-brocot" {= "dev"}
 ]
-tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:24 April 2007" ]
+tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:2007-04-24" ]
 authors: [ "Milad Niqui <milad@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.4.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2003-09-19" ]
 authors: [ "Jasper Stein <>" ]

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.4.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 september 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
 authors: [ "Jasper Stein <>" ]

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.5.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2003-09-19" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.5.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 september 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.6.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 september 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.8.6.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2003-09-19" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2003-09-19" ]
 authors: [ "Jasper Stein <>" ]

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 september 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
 authors: [ "Jasper Stein <>" ]

--- a/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.4.dev/opam
+++ b/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CTLTCTL"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <>" ]

--- a/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.5.dev/opam
+++ b/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CTLTCTL"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <>" ]
 bug-reports: "https://github.com/coq-contribs/ctltctl/issues"
 dev-repo: "https://github.com/coq-contribs/ctltctl.git"

--- a/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.6.dev/opam
+++ b/extra-dev/packages/coq-ctltctl/coq-ctltctl.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CTLTCTL"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <>" ]
 bug-reports: "https://github.com/coq-contribs/ctltctl/issues"
 dev-repo: "https://github.com/coq-contribs/ctltctl.git"

--- a/extra-dev/packages/coq-ctltctl/coq-ctltctl.dev/opam
+++ b/extra-dev/packages/coq-ctltctl/coq-ctltctl.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CTLTCTL"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <>" ]

--- a/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.4.dev/opam
+++ b/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/DescenteInfinie"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:February 2010" ]
+tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:2010-02" ]
 authors: [ "Li Mengran <limengra@comp.nus.edu.sg>" "Razvan Voicu <razvan@comp.nus.edu.sg>" ]

--- a/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.5.dev/opam
+++ b/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/DescenteInfinie"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:February 2010" ]
+tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:2010-02" ]
 authors: [ "Li Mengran <limengra@comp.nus.edu.sg>" "Razvan Voicu <razvan@comp.nus.edu.sg>" ]
 bug-reports: "https://github.com/coq-contribs/descente-infinie/issues"
 dev-repo: "https://github.com/coq-contribs/descente-infinie.git"

--- a/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.6.dev/opam
+++ b/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/DescenteInfinie"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:February 2010" ]
+tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:2010-02" ]
 authors: [ "Li Mengran <limengra@comp.nus.edu.sg>" "Razvan Voicu <razvan@comp.nus.edu.sg>" ]
 bug-reports: "https://github.com/coq-contribs/descente-infinie/issues"
 dev-repo: "https://github.com/coq-contribs/descente-infinie.git"

--- a/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.dev/opam
+++ b/extra-dev/packages/coq-descente-infinie/coq-descente-infinie.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/DescenteInfinie"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:February 2010" ]
+tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:2010-02" ]
 authors: [ "Li Mengran <limengra@comp.nus.edu.sg>" "Razvan Voicu <razvan@comp.nus.edu.sg>" ]

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.4.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:2003-02-6" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.4.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:Feb 6 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.5.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:2003-02-6" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.5.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:Feb 6 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.6.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:2003-02-6" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.6.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:Feb 6 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:2003-02-6" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-dictionaries/coq-dictionaries.dev/opam
+++ b/extra-dev/packages/coq-dictionaries/coq-dictionaries.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:Feb 6 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.4.dev/opam
+++ b/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/EulerFormula"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:September 2006" ]
+tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:2006-09" ]
 authors: [ "Jean-François Dufourd <dufourd@dpt-info.u-strasbg.fr>" ]

--- a/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.5.dev/opam
+++ b/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/EulerFormula"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:September 2006" ]
+tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:2006-09" ]
 authors: [ "Jean-François Dufourd <dufourd@dpt-info.u-strasbg.fr>" ]
 bug-reports: "https://github.com/coq-contribs/euler-formula/issues"
 dev-repo: "https://github.com/coq-contribs/euler-formula.git"

--- a/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.6.dev/opam
+++ b/extra-dev/packages/coq-euler-formula/coq-euler-formula.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/EulerFormula"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:September 2006" ]
+tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:2006-09" ]
 authors: [ "Jean-François Dufourd <dufourd@dpt-info.u-strasbg.fr>" ]
 bug-reports: "https://github.com/coq-contribs/euler-formula/issues"
 dev-repo: "https://github.com/coq-contribs/euler-formula.git"

--- a/extra-dev/packages/coq-euler-formula/coq-euler-formula.dev/opam
+++ b/extra-dev/packages/coq-euler-formula/coq-euler-formula.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/EulerFormula"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:September 2006" ]
+tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:2006-09" ]
 authors: [ "Jean-François Dufourd <dufourd@dpt-info.u-strasbg.fr>" ]

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.4.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:2005-12-15" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.4.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15/12/2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.5.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15/12/2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.5.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:2005-12-15" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.6.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:2005-12-15" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.8.6.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15/12/2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:2005-12-15" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-fairisle/coq-fairisle.dev/opam
+++ b/extra-dev/packages/coq-fairisle/coq-fairisle.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15/12/2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-fermat4/coq-fermat4.8.4.dev/opam
+++ b/extra-dev/packages/coq-fermat4/coq-fermat4.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fermat4"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:July 2005" ]
+tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-07" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]

--- a/extra-dev/packages/coq-fermat4/coq-fermat4.8.5.dev/opam
+++ b/extra-dev/packages/coq-fermat4/coq-fermat4.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fermat4"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:July 2005" ]
+tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-07" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/fermat4/issues"
 dev-repo: "https://github.com/coq-contribs/fermat4.git"

--- a/extra-dev/packages/coq-fermat4/coq-fermat4.8.6.dev/opam
+++ b/extra-dev/packages/coq-fermat4/coq-fermat4.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fermat4"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:July 2005" ]
+tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-07" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/fermat4/issues"
 dev-repo: "https://github.com/coq-contribs/fermat4.git"

--- a/extra-dev/packages/coq-fermat4/coq-fermat4.dev/opam
+++ b/extra-dev/packages/coq-fermat4/coq-fermat4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fermat4"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:July 2005" ]
+tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-07" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]

--- a/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.4.dev/opam
+++ b/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/finger-tree"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:February 2009" ]
+tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:2009-02" ]
 authors: [ "Matthieu Sozeau <mattam@mattam.org>" ]

--- a/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.5.dev/opam
+++ b/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FingerTree"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:February 2009" ]
+tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:2009-02" ]
 authors: [ "Matthieu Sozeau <mattam@mattam.org>" ]
 bug-reports: "https://github.com/coq-contribs/finger-tree/issues"
 dev-repo: "https://github.com/coq-contribs/finger-tree.git"

--- a/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.6.dev/opam
+++ b/extra-dev/packages/coq-finger-tree/coq-finger-tree.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FingerTree"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:February 2009" ]
+tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:2009-02" ]
 authors: [ "Matthieu Sozeau <mattam@mattam.org>" ]
 bug-reports: "https://github.com/coq-contribs/finger-tree/issues"
 dev-repo: "https://github.com/coq-contribs/finger-tree.git"

--- a/extra-dev/packages/coq-finger-tree/coq-finger-tree.dev/opam
+++ b/extra-dev/packages/coq-finger-tree/coq-finger-tree.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FingerTree"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:February 2009" ]
+tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:2009-02" ]
 authors: [ "Matthieu Sozeau <mattam@mattam.org>" ]

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.4.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:2002-04-24" ]
 authors: [ "Maximiliano Cristiá <>" ]

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.4.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24/04/02" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
 authors: [ "Maximiliano Cristiá <>" ]

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.5.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24/04/02" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.5.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:2002-04-24" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.6.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24/04/02" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.6.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:2002-04-24" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:2002-04-24" ]
 authors: [ "Maximiliano Cristiá <>" ]

--- a/extra-dev/packages/coq-fssec-model/coq-fssec-model.dev/opam
+++ b/extra-dev/packages/coq-fssec-model/coq-fssec-model.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24/04/02" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
 authors: [ "Maximiliano Cristiá <>" ]

--- a/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.4.dev/opam
+++ b/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FunctionsInZFC"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:April 2001" ]
+tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:2001-04" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.5.dev/opam
+++ b/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FunctionsInZFC"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:April 2001" ]
+tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:2001-04" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/functions-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/functions-in-zfc.git"

--- a/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.6.dev/opam
+++ b/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FunctionsInZFC"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:April 2001" ]
+tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:2001-04" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/functions-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/functions-in-zfc.git"

--- a/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.dev/opam
+++ b/extra-dev/packages/coq-functions-in-zfc/coq-functions-in-zfc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FunctionsInZFC"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:April 2001" ]
+tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:2001-04" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.4.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008-02-1" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.4.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008/02/01" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008/02/01" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008-02-1" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.6.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008/02/01" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.6.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008-02-1" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008/02/01" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.dev/opam
+++ b/extra-dev/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008-02-1" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-gc/coq-gc.8.4.dev/opam
+++ b/extra-dev/packages/coq-gc/coq-gc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GC"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 Mai 2003" ]
+tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 May 2003" ]
 authors: [ "Solange Coupet-Grimal <>" "Catherine Nouvet <>" ]

--- a/extra-dev/packages/coq-gc/coq-gc.8.4.dev/opam
+++ b/extra-dev/packages/coq-gc/coq-gc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GC"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 May 2003" ]
+tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:2003-05-9" ]
 authors: [ "Solange Coupet-Grimal <>" "Catherine Nouvet <>" ]

--- a/extra-dev/packages/coq-gc/coq-gc.dev/opam
+++ b/extra-dev/packages/coq-gc/coq-gc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GC"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 Mai 2003" ]
+tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 May 2003" ]
 authors: [ "Solange Coupet-Grimal <>" "Catherine Nouvet <>" ]

--- a/extra-dev/packages/coq-gc/coq-gc.dev/opam
+++ b/extra-dev/packages/coq-gc/coq-gc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GC"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:9 May 2003" ]
+tags: [ "keyword:linear temporal logic" "keyword:finite sets" "keyword:coinduction" "keyword:garbage collection" "category:Computer Science/Semantics and Compilation/Compilation" "date:2003-05-9" ]
 authors: [ "Solange Coupet-Grimal <>" "Catherine Nouvet <>" ]

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.4.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-pocklington" {= "8.4.dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.4.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-pocklington" {= "8.4.dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.5.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-pocklington" {= "8.5.dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.5.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-pocklington" {= "8.5.dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.6.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-pocklington"
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/extra-dev/packages/coq-goedel/coq-goedel.8.6.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-pocklington"
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/extra-dev/packages/coq-goedel/coq-goedel.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-pocklington" {= "dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]

--- a/extra-dev/packages/coq-goedel/coq-goedel.dev/opam
+++ b/extra-dev/packages/coq-goedel/coq-goedel.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-pocklington" {= "dev"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]

--- a/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.4.dev/opam
+++ b/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GraphBasics"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:April 2001" ]
+tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:2001-04" ]
 authors: [ "Jean Duprat <>" ]

--- a/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.5.dev/opam
+++ b/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GraphBasics"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:April 2001" ]
+tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:2001-04" ]
 authors: [ "Jean Duprat <>" ]
 bug-reports: "https://github.com/coq-contribs/graph-basics/issues"
 dev-repo: "https://github.com/coq-contribs/graph-basics.git"

--- a/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.6.dev/opam
+++ b/extra-dev/packages/coq-graph-basics/coq-graph-basics.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GraphBasics"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:April 2001" ]
+tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:2001-04" ]
 authors: [ "Jean Duprat <>" ]
 bug-reports: "https://github.com/coq-contribs/graph-basics/issues"
 dev-repo: "https://github.com/coq-contribs/graph-basics.git"

--- a/extra-dev/packages/coq-graph-basics/coq-graph-basics.dev/opam
+++ b/extra-dev/packages/coq-graph-basics/coq-graph-basics.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GraphBasics"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:April 2001" ]
+tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:2001-04" ]
 authors: [ "Jean Duprat <>" ]

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.4.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20/04/2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
 authors: [ "Sébastien Briais <>" ]

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.4.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2004-04-20" ]
 authors: [ "Sébastien Briais <>" ]

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.5.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20/04/2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.5.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2004-04-20" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.6.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20/04/2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/extra-dev/packages/coq-hedges/coq-hedges.8.6.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2004-04-20" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/extra-dev/packages/coq-hedges/coq-hedges.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2004-04-20" ]
 authors: [ "Sébastien Briais <>" ]

--- a/extra-dev/packages/coq-hedges/coq-hedges.dev/opam
+++ b/extra-dev/packages/coq-hedges/coq-hedges.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20/04/2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
 authors: [ "Sébastien Briais <>" ]

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.4.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:January 2004" ]
+tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.5.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:January 2004" ]
+tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/high-school-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/high-school-geometry.git"

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.6.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:January 2004" ]
+tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/high-school-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/high-school-geometry.git"

--- a/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
+++ b/extra-dev/packages/coq-high-school-geometry/coq-high-school-geometry.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:January 2004" ]
+tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.4.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14/09/2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.4.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:2007-09-14" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.5.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:2007-09-14" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.5.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14/09/2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.6.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:2007-09-14" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.8.6.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14/09/2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14/09/2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-higman-s/coq-higman-s.dev/opam
+++ b/extra-dev/packages/coq-higman-s/coq-higman-s.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:2007-09-14" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-huffman/coq-huffman.8.4.dev/opam
+++ b/extra-dev/packages/coq-huffman/coq-huffman.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Huffman"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:October 2003" ]
+tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:2003-10" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-huffman/coq-huffman.8.5.dev/opam
+++ b/extra-dev/packages/coq-huffman/coq-huffman.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Huffman"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:October 2003" ]
+tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:2003-10" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/huffman/issues"
 dev-repo: "https://github.com/coq-contribs/huffman.git"

--- a/extra-dev/packages/coq-huffman/coq-huffman.8.6.dev/opam
+++ b/extra-dev/packages/coq-huffman/coq-huffman.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Huffman"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:October 2003" ]
+tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:2003-10" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/huffman/issues"
 dev-repo: "https://github.com/coq-contribs/huffman.git"

--- a/extra-dev/packages/coq-huffman/coq-huffman.dev/opam
+++ b/extra-dev/packages/coq-huffman/coq-huffman.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Huffman"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:October 2003" ]
+tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:2003-10" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-icharate/coq-icharate.8.4.dev/opam
+++ b/extra-dev/packages/coq-icharate/coq-icharate.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Icharate"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006." ]
+tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006" ]
 authors: [ "Houda Anoun <anoun@labri.fr>" "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-icharate/coq-icharate.8.5.dev/opam
+++ b/extra-dev/packages/coq-icharate/coq-icharate.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Icharate"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006." ]
+tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006" ]
 authors: [ "Houda Anoun <anoun@labri.fr>" "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/icharate/issues"
 dev-repo: "https://github.com/coq-contribs/icharate.git"

--- a/extra-dev/packages/coq-icharate/coq-icharate.8.6.dev/opam
+++ b/extra-dev/packages/coq-icharate/coq-icharate.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Icharate"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006." ]
+tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006" ]
 authors: [ "Houda Anoun <anoun@labri.fr>" "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/icharate/issues"
 dev-repo: "https://github.com/coq-contribs/icharate.git"

--- a/extra-dev/packages/coq-icharate/coq-icharate.dev/opam
+++ b/extra-dev/packages/coq-icharate/coq-icharate.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Icharate"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006." ]
+tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006" ]
 authors: [ "Houda Anoun <anoun@labri.fr>" "Pierre Castéran <casteran@labri.fr>" ]

--- a/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.4.dev/opam
+++ b/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IdxAssoc"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:April 2001" ]
+tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:2001-04" ]
 authors: [ "Dominique Quatravaux <>" "Gérald Macinenti <>" "François-René Ridaux <>" ]

--- a/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.5.dev/opam
+++ b/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IdxAssoc"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:April 2001" ]
+tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:2001-04" ]
 authors: [ "Dominique Quatravaux <>" "Gérald Macinenti <>" "François-René Ridaux <>" ]
 bug-reports: "https://github.com/coq-contribs/idxassoc/issues"
 dev-repo: "https://github.com/coq-contribs/idxassoc.git"

--- a/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.6.dev/opam
+++ b/extra-dev/packages/coq-idxassoc/coq-idxassoc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IdxAssoc"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:April 2001" ]
+tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:2001-04" ]
 authors: [ "Dominique Quatravaux <>" "Gérald Macinenti <>" "François-René Ridaux <>" ]
 bug-reports: "https://github.com/coq-contribs/idxassoc/issues"
 dev-repo: "https://github.com/coq-contribs/idxassoc.git"

--- a/extra-dev/packages/coq-idxassoc/coq-idxassoc.dev/opam
+++ b/extra-dev/packages/coq-idxassoc/coq-idxassoc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IdxAssoc"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:April 2001" ]
+tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:2001-04" ]
 authors: [ "Dominique Quatravaux <>" "Gérald Macinenti <>" "François-René Ridaux <>" ]

--- a/extra-dev/packages/coq-izf/coq-izf.8.4.dev/opam
+++ b/extra-dev/packages/coq-izf/coq-izf.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IZF"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:intuitionistic set theory" "keyword:pointed graphs" "keyword:type theory" "keyword:intuitionistic choice operator" "keyword:set theory" "keyword:zermelo fraenkel" "category:Mathematics/Logic/Set theory" "date:February 2003" ]
+tags: [ "keyword:intuitionistic set theory" "keyword:pointed graphs" "keyword:type theory" "keyword:intuitionistic choice operator" "keyword:set theory" "keyword:zermelo fraenkel" "category:Mathematics/Logic/Set theory" "date:2003-02" ]
 authors: [ "Alexandre Miquel <Alexandre.Miquel@pps.jussieu.fr>" ]

--- a/extra-dev/packages/coq-izf/coq-izf.dev/opam
+++ b/extra-dev/packages/coq-izf/coq-izf.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IZF"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:intuitionistic set theory" "keyword:pointed graphs" "keyword:type theory" "keyword:intuitionistic choice operator" "keyword:set theory" "keyword:zermelo fraenkel" "category:Mathematics/Logic/Set theory" "date:February 2003" ]
+tags: [ "keyword:intuitionistic set theory" "keyword:pointed graphs" "keyword:type theory" "keyword:intuitionistic choice operator" "keyword:set theory" "keyword:zermelo fraenkel" "category:Mathematics/Logic/Set theory" "date:2003-02" ]
 authors: [ "Alexandre Miquel <Alexandre.Miquel@pps.jussieu.fr>" ]

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.4.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.4.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.5.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.5.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.6.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.6.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-karatsuba/coq-karatsuba.dev/opam
+++ b/extra-dev/packages/coq-karatsuba/coq-karatsuba.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-kildall/coq-kildall.8.4.dev/opam
+++ b/extra-dev/packages/coq-kildall/coq-kildall.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Kildall"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 2005" ]
+tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:2005-07" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@cmi.univ-mrs.fr>" "William Delobel <delobel@cmi.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-kildall/coq-kildall.8.5.dev/opam
+++ b/extra-dev/packages/coq-kildall/coq-kildall.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Kildall"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 2005" ]
+tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:2005-07" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@cmi.univ-mrs.fr>" "William Delobel <delobel@cmi.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/kildall/issues"
 dev-repo: "https://github.com/coq-contribs/kildall.git"

--- a/extra-dev/packages/coq-kildall/coq-kildall.8.6.dev/opam
+++ b/extra-dev/packages/coq-kildall/coq-kildall.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Kildall"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 2005" ]
+tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:2005-07" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@cmi.univ-mrs.fr>" "William Delobel <delobel@cmi.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/kildall/issues"
 dev-repo: "https://github.com/coq-contribs/kildall.git"

--- a/extra-dev/packages/coq-kildall/coq-kildall.dev/opam
+++ b/extra-dev/packages/coq-kildall/coq-kildall.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Kildall"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 2005" ]
+tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:2005-07" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@cmi.univ-mrs.fr>" "William Delobel <delobel@cmi.univ-mrs.fr>" ]

--- a/extra-dev/packages/coq-lc/coq-lc.8.4.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-09" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]

--- a/extra-dev/packages/coq-lc/coq-lc.8.4.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-9" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]

--- a/extra-dev/packages/coq-lc/coq-lc.8.5.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-9" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/extra-dev/packages/coq-lc/coq-lc.8.5.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-09" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/extra-dev/packages/coq-lc/coq-lc.8.6.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-09" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/extra-dev/packages/coq-lc/coq-lc.8.6.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-9" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/extra-dev/packages/coq-lc/coq-lc.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-9" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]

--- a/extra-dev/packages/coq-lc/coq-lc.dev/opam
+++ b/extra-dev/packages/coq-lc/coq-lc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-09" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.4.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-algebra" {= "8.4.dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 spetember 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.4.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-algebra" {= "8.4.dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:2003-09-19" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.5.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-algebra" {= "8.5.dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:2003-09-19" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.5.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-algebra" {= "8.5.dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 spetember 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.6.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-algebra"
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 spetember 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.6.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-algebra"
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:2003-09-19" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-algebra" {= "dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:2003-09-19" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]

--- a/extra-dev/packages/coq-lin-alg/coq-lin-alg.dev/opam
+++ b/extra-dev/packages/coq-lin-alg/coq-lin-alg.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-algebra" {= "dev"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 spetember 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]

--- a/extra-dev/packages/coq-ltl/coq-ltl.8.4.dev/opam
+++ b/extra-dev/packages/coq-ltl/coq-ltl.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LTL"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:July 2002" ]
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:2002-07" ]
 authors: [ "Solange Coupet-Grimal <>" ]

--- a/extra-dev/packages/coq-ltl/coq-ltl.8.5.dev/opam
+++ b/extra-dev/packages/coq-ltl/coq-ltl.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LTL"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:July 2002" ]
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:2002-07" ]
 authors: [ "Solange Coupet-Grimal <>" ]
 bug-reports: "https://github.com/coq-contribs/ltl/issues"
 dev-repo: "https://github.com/coq-contribs/ltl.git"

--- a/extra-dev/packages/coq-ltl/coq-ltl.8.6.dev/opam
+++ b/extra-dev/packages/coq-ltl/coq-ltl.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LTL"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:July 2002" ]
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:2002-07" ]
 authors: [ "Solange Coupet-Grimal <>" ]
 bug-reports: "https://github.com/coq-contribs/ltl/issues"
 dev-repo: "https://github.com/coq-contribs/ltl.git"

--- a/extra-dev/packages/coq-ltl/coq-ltl.dev/opam
+++ b/extra-dev/packages/coq-ltl/coq-ltl.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LTL"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:July 2002" ]
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:2002-07" ]
 authors: [ "Solange Coupet-Grimal <>" ]

--- a/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.4.dev/opam
+++ b/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MapleMode"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]

--- a/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.5.dev/opam
+++ b/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MapleMode"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/maple-mode/issues"
 dev-repo: "https://github.com/coq-contribs/maple-mode.git"

--- a/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.6.dev/opam
+++ b/extra-dev/packages/coq-maple-mode/coq-maple-mode.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MapleMode"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/maple-mode/issues"
 dev-repo: "https://github.com/coq-contribs/maple-mode.git"

--- a/extra-dev/packages/coq-maple-mode/coq-maple-mode.dev/opam
+++ b/extra-dev/packages/coq-maple-mode/coq-maple-mode.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MapleMode"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]

--- a/extra-dev/packages/coq-markov/coq-markov.8.4.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:January 5, 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-markov/coq-markov.8.4.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-markov/coq-markov.8.5.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/extra-dev/packages/coq-markov/coq-markov.8.5.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:January 5, 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/extra-dev/packages/coq-markov/coq-markov.8.6.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:January 5, 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/extra-dev/packages/coq-markov/coq-markov.8.6.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/extra-dev/packages/coq-markov/coq-markov.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-markov/coq-markov.dev/opam
+++ b/extra-dev/packages/coq-markov/coq-markov.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:January 5, 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-matrices/coq-matrices.8.4.dev/opam
+++ b/extra-dev/packages/coq-matrices/coq-matrices.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Matrices"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:March 2003" ]
+tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:2003-03" ]
 authors: [ "Nicolas Magaud <>" ]

--- a/extra-dev/packages/coq-matrices/coq-matrices.8.5.dev/opam
+++ b/extra-dev/packages/coq-matrices/coq-matrices.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Matrices"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:March 2003" ]
+tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:2003-03" ]
 authors: [ "Nicolas Magaud <>" ]
 bug-reports: "https://github.com/coq-contribs/matrices/issues"
 dev-repo: "https://github.com/coq-contribs/matrices.git"

--- a/extra-dev/packages/coq-matrices/coq-matrices.8.6.dev/opam
+++ b/extra-dev/packages/coq-matrices/coq-matrices.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Matrices"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:March 2003" ]
+tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:2003-03" ]
 authors: [ "Nicolas Magaud <>" ]
 bug-reports: "https://github.com/coq-contribs/matrices/issues"
 dev-repo: "https://github.com/coq-contribs/matrices.git"

--- a/extra-dev/packages/coq-matrices/coq-matrices.dev/opam
+++ b/extra-dev/packages/coq-matrices/coq-matrices.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Matrices"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:March 2003" ]
+tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:2003-03" ]
 authors: [ "Nicolas Magaud <>" ]

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.4.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.4.dev/opam
@@ -13,5 +13,5 @@ depends: [
   "coq-algebra" {= "8.4.dev"}
   "coq-lin-alg" {= "8.4.dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.4.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.4.dev/opam
@@ -13,5 +13,5 @@ depends: [
   "coq-algebra" {= "8.4.dev"}
   "coq-lin-alg" {= "8.4.dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:January 5, 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.5.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.5.dev/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra" {= "8.5.dev"}
   "coq-lin-alg" {= "8.5.dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:January 5, 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.5.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.5.dev/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra" {= "8.5.dev"}
   "coq-lin-alg" {= "8.5.dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.6.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.6.dev/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra"
   "coq-lin-alg"
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:January 5, 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.6.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.8.6.dev/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra"
   "coq-lin-alg"
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.dev/opam
@@ -13,5 +13,5 @@ depends: [
   "coq-algebra" {= "dev"}
   "coq-lin-alg" {= "dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:January 5, 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-orb-stab/coq-orb-stab.dev/opam
+++ b/extra-dev/packages/coq-orb-stab/coq-orb-stab.dev/opam
@@ -13,5 +13,5 @@ depends: [
   "coq-algebra" {= "dev"}
   "coq-lin-alg" {= "dev"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.4.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:1998-09-30" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.4.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:Sept 30 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.5.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:Sept 30 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.5.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:1998-09-30" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.6.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:Sept 30 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.8.6.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:1998-09-30" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:1998-09-30" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]

--- a/extra-dev/packages/coq-param-pi/coq-param-pi.dev/opam
+++ b/extra-dev/packages/coq-param-pi/coq-param-pi.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:Sept 30 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]

--- a/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.4.dev/opam
+++ b/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PiCalc"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:July 1998" ]
+tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:1998-07" ]
 authors: [ "Ivan Scagnetto <scagnett@dimi.uniud.it>" ]

--- a/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.5.dev/opam
+++ b/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PiCalc"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:July 1998" ]
+tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:1998-07" ]
 authors: [ "Ivan Scagnetto <scagnett@dimi.uniud.it>" ]
 bug-reports: "https://github.com/coq-contribs/pi-calc/issues"
 dev-repo: "https://github.com/coq-contribs/pi-calc.git"

--- a/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.6.dev/opam
+++ b/extra-dev/packages/coq-pi-calc/coq-pi-calc.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PiCalc"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:July 1998" ]
+tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:1998-07" ]
 authors: [ "Ivan Scagnetto <scagnett@dimi.uniud.it>" ]
 bug-reports: "https://github.com/coq-contribs/pi-calc/issues"
 dev-repo: "https://github.com/coq-contribs/pi-calc.git"

--- a/extra-dev/packages/coq-pi-calc/coq-pi-calc.dev/opam
+++ b/extra-dev/packages/coq-pi-calc/coq-pi-calc.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PiCalc"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:July 1998" ]
+tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:1998-07" ]
 authors: [ "Ivan Scagnetto <scagnett@dimi.uniud.it>" ]

--- a/extra-dev/packages/coq-pocklington/coq-pocklington.8.4.dev/opam
+++ b/extra-dev/packages/coq-pocklington/coq-pocklington.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Pocklington"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:November 2000" ]
+tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2000-11" ]
 authors: [ "Martijn Oostdijk <>" "Olga Caprotti <>" ]

--- a/extra-dev/packages/coq-pocklington/coq-pocklington.8.5.dev/opam
+++ b/extra-dev/packages/coq-pocklington/coq-pocklington.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Pocklington"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:November 2000" ]
+tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2000-11" ]
 authors: [ "Martijn Oostdijk <>" "Olga Caprotti <>" ]
 bug-reports: "https://github.com/coq-contribs/pocklington/issues"
 dev-repo: "https://github.com/coq-contribs/pocklington.git"

--- a/extra-dev/packages/coq-pocklington/coq-pocklington.8.6.dev/opam
+++ b/extra-dev/packages/coq-pocklington/coq-pocklington.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Pocklington"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:November 2000" ]
+tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2000-11" ]
 authors: [ "Martijn Oostdijk <>" "Olga Caprotti <>" ]
 bug-reports: "https://github.com/coq-contribs/pocklington/issues"
 dev-repo: "https://github.com/coq-contribs/pocklington.git"

--- a/extra-dev/packages/coq-pocklington/coq-pocklington.dev/opam
+++ b/extra-dev/packages/coq-pocklington/coq-pocklington.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Pocklington"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:November 2000" ]
+tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2000-11" ]
 authors: [ "Martijn Oostdijk <>" "Olga Caprotti <>" ]

--- a/extra-dev/packages/coq-presburger/coq-presburger.8.4.dev/opam
+++ b/extra-dev/packages/coq-presburger/coq-presburger.8.4.dev/opam
@@ -12,5 +12,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Presburger"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:March 2002" ]
+tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-presburger/coq-presburger.8.5.dev/opam
+++ b/extra-dev/packages/coq-presburger/coq-presburger.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Presburger"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:March 2002" ]
+tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/presburger/issues"
 dev-repo: "https://github.com/coq-contribs/presburger.git"

--- a/extra-dev/packages/coq-presburger/coq-presburger.8.6.dev/opam
+++ b/extra-dev/packages/coq-presburger/coq-presburger.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Presburger"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:March 2002" ]
+tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/presburger/issues"
 dev-repo: "https://github.com/coq-contribs/presburger.git"

--- a/extra-dev/packages/coq-presburger/coq-presburger.dev/opam
+++ b/extra-dev/packages/coq-presburger/coq-presburger.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Presburger"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:March 2002" ]
+tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-prfx/coq-prfx.8.4.dev/opam
+++ b/extra-dev/packages/coq-prfx/coq-prfx.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:April 15, 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April2005" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-prfx/coq-prfx.8.5.dev/opam
+++ b/extra-dev/packages/coq-prfx/coq-prfx.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:April 15, 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April2005" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/prfx/issues"
 dev-repo: "https://github.com/coq-contribs/prfx.git"

--- a/extra-dev/packages/coq-prfx/coq-prfx.8.6.dev/opam
+++ b/extra-dev/packages/coq-prfx/coq-prfx.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:April 15, 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April2005" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/prfx/issues"
 dev-repo: "https://github.com/coq-contribs/prfx.git"

--- a/extra-dev/packages/coq-prfx/coq-prfx.dev/opam
+++ b/extra-dev/packages/coq-prfx/coq-prfx.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:April 15, 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April2005" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]

--- a/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.4.dev/opam
+++ b/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ProjectiveGeometry"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:October 2009" ]
+tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:2009-10" ]
 authors: [ "Nicolas Magaud <Nicolas.Magaud@lsiit-cnrs.unistra.fr>" "Julien Narboux <Julien.Narboux@lsiit-cnrs.unistra.fr>" "Pascal Schreck <Pascal.Schreck@lsiit-cnrs.unistra.fr>" ]

--- a/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.5.dev/opam
+++ b/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ProjectiveGeometry"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:October 2009" ]
+tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:2009-10" ]
 authors: [ "Nicolas Magaud <Nicolas.Magaud@lsiit-cnrs.unistra.fr>" "Julien Narboux <Julien.Narboux@lsiit-cnrs.unistra.fr>" "Pascal Schreck <Pascal.Schreck@lsiit-cnrs.unistra.fr>" ]
 bug-reports: "https://github.com/coq-contribs/projective-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/projective-geometry.git"

--- a/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.6.dev/opam
+++ b/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ProjectiveGeometry"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:October 2009" ]
+tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:2009-10" ]
 authors: [ "Nicolas Magaud <Nicolas.Magaud@lsiit-cnrs.unistra.fr>" "Julien Narboux <Julien.Narboux@lsiit-cnrs.unistra.fr>" "Pascal Schreck <Pascal.Schreck@lsiit-cnrs.unistra.fr>" ]
 bug-reports: "https://github.com/coq-contribs/projective-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/projective-geometry.git"

--- a/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.dev/opam
+++ b/extra-dev/packages/coq-projective-geometry/coq-projective-geometry.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ProjectiveGeometry"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:October 2009" ]
+tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:2009-10" ]
 authors: [ "Nicolas Magaud <Nicolas.Magaud@lsiit-cnrs.unistra.fr>" "Julien Narboux <Julien.Narboux@lsiit-cnrs.unistra.fr>" "Pascal Schreck <Pascal.Schreck@lsiit-cnrs.unistra.fr>" ]

--- a/extra-dev/packages/coq-pts/coq-pts.8.4.dev/opam
+++ b/extra-dev/packages/coq-pts/coq-pts.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PTS"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:March 2007" ]
+tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:2007-03" ]
 authors: [ "Bruno Barras <>" ]

--- a/extra-dev/packages/coq-pts/coq-pts.8.5.dev/opam
+++ b/extra-dev/packages/coq-pts/coq-pts.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PTS"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:March 2007" ]
+tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:2007-03" ]
 authors: [ "Bruno Barras <>" ]
 bug-reports: "https://github.com/coq-contribs/pts/issues"
 dev-repo: "https://github.com/coq-contribs/pts.git"

--- a/extra-dev/packages/coq-pts/coq-pts.8.6.dev/opam
+++ b/extra-dev/packages/coq-pts/coq-pts.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PTS"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:March 2007" ]
+tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:2007-03" ]
 authors: [ "Bruno Barras <>" ]
 bug-reports: "https://github.com/coq-contribs/pts/issues"
 dev-repo: "https://github.com/coq-contribs/pts.git"

--- a/extra-dev/packages/coq-pts/coq-pts.dev/opam
+++ b/extra-dev/packages/coq-pts/coq-pts.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PTS"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:March 2007" ]
+tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:2007-03" ]
 authors: [ "Bruno Barras <>" ]

--- a/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.4.dev/opam
+++ b/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/QuicksortComplexity"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:June 2010" ]
+tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2010-06" ]
 authors: [ "Eelis <>" ]

--- a/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.5.dev/opam
+++ b/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/QuicksortComplexity"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:June 2010" ]
+tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2010-06" ]
 authors: [ "Eelis <>" ]
 bug-reports: "https://github.com/coq-contribs/quicksort-complexity/issues"
 dev-repo: "https://github.com/coq-contribs/quicksort-complexity.git"

--- a/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.6.dev/opam
+++ b/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/QuicksortComplexity"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:June 2010" ]
+tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2010-06" ]
 authors: [ "Eelis <>" ]
 bug-reports: "https://github.com/coq-contribs/quicksort-complexity/issues"
 dev-repo: "https://github.com/coq-contribs/quicksort-complexity.git"

--- a/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.dev/opam
+++ b/extra-dev/packages/coq-quicksort-complexity/coq-quicksort-complexity.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/QuicksortComplexity"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:June 2010" ]
+tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2010-06" ]
 authors: [ "Eelis <>" ]

--- a/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.4.dev/opam
+++ b/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RailroadCrossing"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <http://www.fing.edu.uy/~cluna>" ]

--- a/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.5.dev/opam
+++ b/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RailroadCrossing"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <http://www.fing.edu.uy/~cluna>" ]
 bug-reports: "https://github.com/coq-contribs/railroad-crossing/issues"
 dev-repo: "https://github.com/coq-contribs/railroad-crossing.git"

--- a/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.6.dev/opam
+++ b/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RailroadCrossing"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <http://www.fing.edu.uy/~cluna>" ]
 bug-reports: "https://github.com/coq-contribs/railroad-crossing/issues"
 dev-repo: "https://github.com/coq-contribs/railroad-crossing.git"

--- a/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.dev/opam
+++ b/extra-dev/packages/coq-railroad-crossing/coq-railroad-crossing.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RailroadCrossing"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <http://www.fing.edu.uy/~cluna>" ]

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.4.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:05/2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.4.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:2005-05" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:2005-05" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:05/2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.6.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:2005-05" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.6.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:05/2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:2005-05" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]

--- a/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.dev/opam
+++ b/extra-dev/packages/coq-reflexive-first-order/coq-reflexive-first-order.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:05/2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]

--- a/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.4.dev/opam
+++ b/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RulerCompassGeometry"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:November 2007" ]
+tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:2007-11" ]
 authors: [ "Jean Duprat <Jean.Duprat@ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.5.dev/opam
+++ b/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RulerCompassGeometry"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:November 2007" ]
+tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:2007-11" ]
 authors: [ "Jean Duprat <Jean.Duprat@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/ruler-compass-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/ruler-compass-geometry.git"

--- a/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.6.dev/opam
+++ b/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RulerCompassGeometry"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:November 2007" ]
+tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:2007-11" ]
 authors: [ "Jean Duprat <Jean.Duprat@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/ruler-compass-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/ruler-compass-geometry.git"

--- a/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.dev/opam
+++ b/extra-dev/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RulerCompassGeometry"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:November 2007" ]
+tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidian geometry" "keyword:hilbert's axioms" "category:Mathematics/Geometry/General" "date:2007-11" ]
 authors: [ "Jean Duprat <Jean.Duprat@ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.4.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.4.dev/opam
@@ -12,5 +12,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/semantics"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 5, 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.4.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.4.dev/opam
@@ -12,5 +12,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/semantics"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:2007-07-5" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.5.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 5, 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.5.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:2007-07-5" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.6.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 5, 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/extra-dev/packages/coq-semantics/coq-semantics.8.6.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:2007-07-5" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/extra-dev/packages/coq-semantics/coq-semantics.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:2007-07-5" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-semantics/coq-semantics.dev/opam
+++ b/extra-dev/packages/coq-semantics/coq-semantics.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 5, 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-smc/coq-smc.8.4.dev/opam
+++ b/extra-dev/packages/coq-smc/coq-smc.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-int-map" {= "8.4.dev"}
 ]
-tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:November 2002" ]
+tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-11" ]
 authors: [ "Kumar Neeraj Verma <verma@lsv.ens-cachan.fr>" ]

--- a/extra-dev/packages/coq-smc/coq-smc.8.5.dev/opam
+++ b/extra-dev/packages/coq-smc/coq-smc.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-int-map" {= "8.5.dev"}
 ]
-tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:November 2002" ]
+tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-11" ]
 authors: [ "Kumar Neeraj Verma <verma@lsv.ens-cachan.fr>" ]
 bug-reports: "https://github.com/coq-contribs/smc/issues"
 dev-repo: "https://github.com/coq-contribs/smc.git"

--- a/extra-dev/packages/coq-smc/coq-smc.8.6.dev/opam
+++ b/extra-dev/packages/coq-smc/coq-smc.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-int-map"
 ]
-tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:November 2002" ]
+tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-11" ]
 authors: [ "Kumar Neeraj Verma <verma@lsv.ens-cachan.fr>" ]
 bug-reports: "https://github.com/coq-contribs/smc/issues"
 dev-repo: "https://github.com/coq-contribs/smc.git"

--- a/extra-dev/packages/coq-smc/coq-smc.dev/opam
+++ b/extra-dev/packages/coq-smc/coq-smc.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-int-map" {= "dev"}
 ]
-tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:November 2002" ]
+tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-11" ]
 authors: [ "Kumar Neeraj Verma <verma@lsv.ens-cachan.fr>" ]

--- a/extra-dev/packages/coq-string/coq-string.8.4.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-string/coq-string.8.4.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:Mars 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-string/coq-string.8.5.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:Mars 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/extra-dev/packages/coq-string/coq-string.8.5.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/extra-dev/packages/coq-string/coq-string.8.6.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/extra-dev/packages/coq-string/coq-string.8.6.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:Mars 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/extra-dev/packages/coq-string/coq-string.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-string/coq-string.dev/opam
+++ b/extra-dev/packages/coq-string/coq-string.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:Mars 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.8.4.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:February 2006" ]
+tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2006-02" ]
 authors: [ "Laurent Théry <thery@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.8.5.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:February 2006" ]
+tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2006-02" ]
 authors: [ "Laurent Théry <thery@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/sudoku/issues"
 dev-repo: "https://github.com/coq-contribs/sudoku.git"

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.8.6.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:February 2006" ]
+tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2006-02" ]
 authors: [ "Laurent Théry <thery@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/sudoku/issues"
 dev-repo: "https://github.com/coq-contribs/sudoku.git"

--- a/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
+++ b/extra-dev/packages/coq-sudoku/coq-sudoku.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:February 2006" ]
+tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2006-02" ]
 authors: [ "Laurent Théry <thery@sophia.inria.fr>" ]

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.4.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2004-12-13" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.4.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13/12/2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2004-12-13" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13/12/2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.6.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2004-12-13" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.6.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13/12/2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2004-12-13" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
+++ b/extra-dev/packages/coq-sum-of-two-square/coq-sum-of-two-square.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13/12/2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
 authors: [ "Laurent Théry <>" ]

--- a/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.4.dev/opam
+++ b/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TortoiseHareAlgorithm"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:February 2007" ]
+tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2007-02" ]
 authors: [ "Jean-Christophe Filliâtre <>" ]

--- a/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.5.dev/opam
+++ b/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TortoiseHareAlgorithm"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:February 2007" ]
+tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2007-02" ]
 authors: [ "Jean-Christophe Filliâtre <>" ]
 bug-reports: "https://github.com/coq-contribs/tortoise-hare-algorithm/issues"
 dev-repo: "https://github.com/coq-contribs/tortoise-hare-algorithm.git"

--- a/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.6.dev/opam
+++ b/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TortoiseHareAlgorithm"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:February 2007" ]
+tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2007-02" ]
 authors: [ "Jean-Christophe Filliâtre <>" ]
 bug-reports: "https://github.com/coq-contribs/tortoise-hare-algorithm/issues"
 dev-repo: "https://github.com/coq-contribs/tortoise-hare-algorithm.git"

--- a/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.dev/opam
+++ b/extra-dev/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TortoiseHareAlgorithm"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:February 2007" ]
+tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2007-02" ]
 authors: [ "Jean-Christophe Filliâtre <>" ]

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.4.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-int-map" {= "8.4.dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:september 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.4.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.4.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "8.4.dev"}
   "coq-int-map" {= "8.4.dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.5.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-int-map" {= "8.5.dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:september 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.5.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.5.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.5.dev"}
   "coq-int-map" {= "8.5.dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.6.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-int-map"
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.6.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.8.6.dev/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-int-map"
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:september 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-int-map" {= "dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:september 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]

--- a/extra-dev/packages/coq-tree-automata/coq-tree-automata.dev/opam
+++ b/extra-dev/packages/coq-tree-automata/coq-tree-automata.dev/opam
@@ -12,5 +12,5 @@ depends: [
   "coq" {= "dev"}
   "coq-int-map" {= "dev"}
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.4.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005/02/22" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.4.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.4.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.4.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005-02-22" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.5.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005/02/22" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.5.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.5.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.5.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005-02-22" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.6.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005-02-22" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.6.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.8.6.dev/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "8.6.dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005/02/22" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005/02/22" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]

--- a/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.dev/opam
+++ b/extra-dev/packages/coq-weak-up-to/coq-weak-up-to.dev/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {= "dev"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005-02-22" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]

--- a/released/packages/coq-algebra/coq-algebra.8.5.0/opam
+++ b/released/packages/coq-algebra/coq-algebra.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 99" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/released/packages/coq-algebra/coq-algebra.8.5.0/opam
+++ b/released/packages/coq-algebra/coq-algebra.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Algebra"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:March 1999" ]
+tags: [ "keyword:algebra" "category:Mathematics/Algebra" "date:1999-03" ]
 authors: [ "Loïc Pottier <>" ]
 bug-reports: "https://github.com/coq-contribs/algebra/issues"
 dev-repo: "https://github.com/coq-contribs/algebra.git"

--- a/released/packages/coq-amm11262/coq-amm11262.8.5.0/opam
+++ b/released/packages/coq-amm11262/coq-amm11262.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AMM11262"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:american mathematical monthly problem 11262" "date:April 2007" ]
+tags: [ "keyword:american mathematical monthly problem 11262" "date:2007-04" ]
 authors: [ "Tonny Hurkens (paper proof) <hurkens@sci.kun.nl>" "Milad Niqui (Coq files) <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/amm11262/issues"
 dev-repo: "https://github.com/coq-contribs/amm11262.git"

--- a/released/packages/coq-angles/coq-angles.8.5.0/opam
+++ b/released/packages/coq-angles/coq-angles.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 janvier 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/released/packages/coq-angles/coq-angles.8.5.0/opam
+++ b/released/packages/coq-angles/coq-angles.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Angles"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:15 January 2002" ]
+tags: [ "keyword:pcoq" "keyword:geometry" "keyword:plane geometry" "keyword:oriented angles" "category:Mathematics/Geometry/General" "date:2002-01-15" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/angles/issues"
 dev-repo: "https://github.com/coq-contribs/angles.git"

--- a/released/packages/coq-atbr/coq-atbr.8.5.0/opam
+++ b/released/packages/coq-atbr/coq-atbr.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ATBR"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:June 2009" ]
+tags: [ "keyword:kleene algebra" "keyword:finite automata" "keyword:semiring" "keyword:matrices" "keyword:decision procedure" "keyword:reflexive tactic" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2009-06" ]
 authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/atbr/issues"
 dev-repo: "https://github.com/coq-contribs/atbr.git"

--- a/released/packages/coq-cantor/coq-cantor.8.5.0/opam
+++ b/released/packages/coq-cantor/coq-cantor.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2006-05-22" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/released/packages/coq-cantor/coq-cantor.8.5.0/opam
+++ b/released/packages/coq-cantor/coq-cantor.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cantor"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:May 22nd, 2006" ]
+tags: [ "keyword:ordinals" "keyword:well foundedness" "keyword:termination" "keyword:rpo" "keyword:goodstein sequences" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:22 May 2006" ]
 authors: [ "Évelyne Contejean <contejea@lri.fr>" "Pierre Castéran <pierre.casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "https://github.com/coq-contribs/cantor.git"

--- a/released/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.0/opam
+++ b/released/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:October 10th 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/released/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.0/opam
+++ b/released/packages/coq-cats-in-zfc/coq-cats-in-zfc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CatsInZFC"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:10 October 2004" ]
+tags: [ "keyword:set theory" "keyword:ordinals" "keyword:cardinals" "keyword:category theory" "keyword:functors" "keyword:natural transformation" "keyword:limit" "keyword:colimit" "category:Mathematics/Logic/Set theory" "category:Mathematics/Category Theory" "date:2004-10-10" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/cats-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/cats-in-zfc.git"

--- a/released/packages/coq-coalgebras/coq-coalgebras.8.5.0/opam
+++ b/released/packages/coq-coalgebras/coq-coalgebras.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coalgebras"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:October 2008" ]
+tags: [ "keyword:coalgebra" "keyword:bisimulation" "keyword:weakly final" "keyword:coiteration" "keyword:coinductive types" "category:Mathematics/Category Theory" "date:2008-10" ]
 authors: [ "Milad Niqui <M.Niqui@cwi.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coalgebras/issues"
 dev-repo: "https://github.com/coq-contribs/coalgebras.git"

--- a/released/packages/coq-coinductive-reals/coq-coinductive-reals.8.5.0/opam
+++ b/released/packages/coq-coinductive-reals/coq-coinductive-reals.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-qarith-stern-brocot" {= "8.5.0"}
 ]
-tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:24 April 2007" ]
+tags: [ "keyword:real numbers" "keyword:coinductive types" "keyword:co recursion" "keyword:exact arithmetic" "category:Mathematics/Arithmetic and Number Theory/Real numbers" "date:2007-04-24" ]
 authors: [ "Milad Niqui <milad@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/coinductive-reals/issues"
 dev-repo: "https://github.com/coq-contribs/coinductive-reals.git"

--- a/released/packages/coq-color/coq-color.1.2.0/opam
+++ b/released/packages/coq-color/coq-color.1.2.0/opam
@@ -101,7 +101,7 @@ tags: [
   "category:Type theory"
   "category:Misc/Extracted/Type checking unification and normalization"
 
-  "date:26 January 2016"
+  "date:2016-01-26"
   
   "logpath:CoLoR"
 ]

--- a/released/packages/coq-color/coq-color.1.2.0/opam
+++ b/released/packages/coq-color/coq-color.1.2.0/opam
@@ -101,7 +101,7 @@ tags: [
   "category:Type theory"
   "category:Misc/Extracted/Type checking unification and normalization"
 
-  "date:2016-01-26"
+  "date:26 January 2016"
   
   "logpath:CoLoR"
 ]

--- a/released/packages/coq-coqoban/coq-coqoban.8.5.0/opam
+++ b/released/packages/coq-coqoban/coq-coqoban.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2003-09-19" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/released/packages/coq-coqoban/coq-coqoban.8.5.0/opam
+++ b/released/packages/coq-coqoban/coq-coqoban.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 september 2003" ]
+tags: [ "keyword:sokoban" "keyword:puzzles" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:19 September 2003" ]
 authors: [ "Jasper Stein <>" ]
 bug-reports: "https://github.com/coq-contribs/coqoban/issues"
 dev-repo: "https://github.com/coq-contribs/coqoban.git"

--- a/released/packages/coq-ctltctl/coq-ctltctl.8.5.0/opam
+++ b/released/packages/coq-ctltctl/coq-ctltctl.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/CTLTCTL"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:reactive systems" "keyword:temporal logic" "keyword:timed automatas" "keyword:timed graphs" "keyword:discrete time" "keyword:modal logic" "category:Mathematics/Logic/Modal logic" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <>" ]
 bug-reports: "https://github.com/coq-contribs/ctltctl/issues"
 dev-repo: "https://github.com/coq-contribs/ctltctl.git"

--- a/released/packages/coq-descente-infinie/coq-descente-infinie.8.5.0/opam
+++ b/released/packages/coq-descente-infinie/coq-descente-infinie.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/DescenteInfinie"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:February 2010" ]
+tags: [ "keyword:induction" "keyword:infinite descent" "category:Miscellaneous/Coq Extensions" "date:2010-02" ]
 authors: [ "Li Mengran <limengra@comp.nus.edu.sg>" "Razvan Voicu <razvan@comp.nus.edu.sg>" ]
 bug-reports: "https://github.com/coq-contribs/descente-infinie/issues"
 dev-repo: "https://github.com/coq-contribs/descente-infinie.git"

--- a/released/packages/coq-dictionaries/coq-dictionaries.8.5.0/opam
+++ b/released/packages/coq-dictionaries/coq-dictionaries.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:2003-02-6" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/released/packages/coq-dictionaries/coq-dictionaries.8.5.0/opam
+++ b/released/packages/coq-dictionaries/coq-dictionaries.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dictionaries"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:Feb 6 2003" ]
+tags: [ "keyword:modules  functors search trees" "category:Computer Science/Data Types and Data Structures" "category:Miscellaneous/Extracted Programs/Data structures" "date:6 February 2003" ]
 authors: [ "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/dictionaries/issues"
 dev-repo: "https://github.com/coq-contribs/dictionaries.git"

--- a/released/packages/coq-euler-formula/coq-euler-formula.8.5.0/opam
+++ b/released/packages/coq-euler-formula/coq-euler-formula.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/EulerFormula"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:September 2006" ]
+tags: [ "keyword:polyhedron" "keyword:hypermap" "keyword:genus" "keyword:euler formula" "keyword:assisted proofs" "category:Mathematics/Geometry/General" "date:2006-09" ]
 authors: [ "Jean-François Dufourd <dufourd@dpt-info.u-strasbg.fr>" ]
 bug-reports: "https://github.com/coq-contribs/euler-formula/issues"
 dev-repo: "https://github.com/coq-contribs/euler-formula.git"

--- a/released/packages/coq-fairisle/coq-fairisle.8.5.0/opam
+++ b/released/packages/coq-fairisle/coq-fairisle.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:2005-12-15" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/released/packages/coq-fairisle/coq-fairisle.8.5.0/opam
+++ b/released/packages/coq-fairisle/coq-fairisle.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fairisle"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15/12/2005" ]
+tags: [ "keyword:circuits" "keyword:automata" "keyword:coinduction" "keyword:dependent types" "category:Computer Science/Architecture" "date:15 December 2005" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@lif.univ-mrs.fr>" "Line Jakubiec-Jamet <Line.Jakubiec@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fairisle/issues"
 dev-repo: "https://github.com/coq-contribs/fairisle.git"

--- a/released/packages/coq-fermat4/coq-fermat4.8.5.0/opam
+++ b/released/packages/coq-fermat4/coq-fermat4.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Fermat4"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:July 2005" ]
+tags: [ "keyword:diophantus" "keyword:fermat" "keyword:arithmetic" "keyword:infinite descent" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-07" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/fermat4/issues"
 dev-repo: "https://github.com/coq-contribs/fermat4.git"

--- a/released/packages/coq-finger-tree/coq-finger-tree.8.5.0/opam
+++ b/released/packages/coq-finger-tree/coq-finger-tree.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FingerTree"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:February 2009" ]
+tags: [ "keyword:data structures" "keyword:dependent types" "keyword:finger trees" "category:Computer Science/Data Types and Data Structures" "date:2009-02" ]
 authors: [ "Matthieu Sozeau <mattam@mattam.org>" ]
 bug-reports: "https://github.com/coq-contribs/finger-tree/issues"
 dev-repo: "https://github.com/coq-contribs/finger-tree.git"

--- a/released/packages/coq-fssec-model/coq-fssec-model.8.5.0/opam
+++ b/released/packages/coq-fssec-model/coq-fssec-model.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24/04/02" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/released/packages/coq-fssec-model/coq-fssec-model.8.5.0/opam
+++ b/released/packages/coq-fssec-model/coq-fssec-model.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FSSecModel"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:24 April 2002" ]
+tags: [ "keyword:security" "keyword:filesystem" "keyword:unix" "keyword:mls" "keyword:access control" "category:Computer Science/Operating Systems" "date:2002-04-24" ]
 authors: [ "Maximiliano Cristiá <>" ]
 bug-reports: "https://github.com/coq-contribs/fssec-model/issues"
 dev-repo: "https://github.com/coq-contribs/fssec-model.git"

--- a/released/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.5.0/opam
+++ b/released/packages/coq-functions-in-zfc/coq-functions-in-zfc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FunctionsInZFC"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:April 2001" ]
+tags: [ "keyword:set theory" "keyword:zermelo fraenkel" "keyword:functions" "category:Mathematics/Logic/Set theory" "date:2001-04" ]
 authors: [ "Carlos Simpson <carlos@math.unice.fr>" ]
 bug-reports: "https://github.com/coq-contribs/functions-in-zfc/issues"
 dev-repo: "https://github.com/coq-contribs/functions-in-zfc.git"

--- a/released/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.0/opam
+++ b/released/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008-02-1" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/released/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.0/opam
+++ b/released/packages/coq-fundamental-arithmetics/coq-fundamental-arithmetics.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FundamentalArithmetics"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:2008/02/01" ]
+tags: [ "keyword:arithmetic" "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "date:1 February 2008" ]
 authors: [ "Sébastien Briais <sebastien.briais at ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/fundamental-arithmetics/issues"
 dev-repo: "https://github.com/coq-contribs/fundamental-arithmetics.git"

--- a/released/packages/coq-goedel/coq-goedel.8.5.0/opam
+++ b/released/packages/coq-goedel/coq-goedel.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-pocklington" {= "8.5.0"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/released/packages/coq-goedel/coq-goedel.8.5.0/opam
+++ b/released/packages/coq-goedel/coq-goedel.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-pocklington" {= "8.5.0"}
 ]
-tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:2007-04-13" ]
+tags: [ "keyword:goedel" "keyword:rosser" "keyword:incompleteness" "keyword:logic" "keyword:hilbert" "category:Mathematics/Logic/Foundations" "date:13 April 2007" ]
 authors: [ "Russell O'Connor <roconnor@alumni.uwaterloo.ca>" ]
 bug-reports: "https://github.com/coq-contribs/goedel/issues"
 dev-repo: "https://github.com/coq-contribs/goedel.git"

--- a/released/packages/coq-graph-basics/coq-graph-basics.8.5.0/opam
+++ b/released/packages/coq-graph-basics/coq-graph-basics.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GraphBasics"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:April 2001" ]
+tags: [ "keyword:graph theory" "keyword:curry howard's isomorphism" "keyword:inductive" "keyword:definitions" "category:Mathematics/Combinatorics and Graph Theory" "date:2001-04" ]
 authors: [ "Jean Duprat <>" ]
 bug-reports: "https://github.com/coq-contribs/graph-basics/issues"
 dev-repo: "https://github.com/coq-contribs/graph-basics.git"

--- a/released/packages/coq-hedges/coq-hedges.8.5.0/opam
+++ b/released/packages/coq-hedges/coq-hedges.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20/04/2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/released/packages/coq-hedges/coq-hedges.8.5.0/opam
+++ b/released/packages/coq-hedges/coq-hedges.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Hedges"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:20 April 2004" ]
+tags: [ "keyword:bisimulation" "keyword:spi calculus" "keyword:hedges" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2004-04-20" ]
 authors: [ "Sébastien Briais <>" ]
 bug-reports: "https://github.com/coq-contribs/hedges/issues"
 dev-repo: "https://github.com/coq-contribs/hedges.git"

--- a/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
+++ b/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
@@ -11,5 +11,5 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
   "coq" {>= "8.5"}
 ]
-tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:January 2004" ]
+tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/released/packages/coq-higman-s/coq-higman-s.8.5.0/opam
+++ b/released/packages/coq-higman-s/coq-higman-s.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:2007-09-14" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/released/packages/coq-higman-s/coq-higman-s.8.5.0/opam
+++ b/released/packages/coq-higman-s/coq-higman-s.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HigmanS"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14/09/2007" ]
+tags: [ "keyword:higman's lemma" "keyword:well quasi ordering" "category:Mathematics/Combinatorics and Graph Theory" "date:14 September 2007" ]
 authors: [ "William Delobel <william.delobel@lif.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/higman-s/issues"
 dev-repo: "https://github.com/coq-contribs/higman-s.git"

--- a/released/packages/coq-huffman/coq-huffman.8.5.0/opam
+++ b/released/packages/coq-huffman/coq-huffman.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Huffman"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:October 2003" ]
+tags: [ "keyword:data compression" "keyword:code" "keyword:huffman tree" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "category:Miscellaneous/Extracted Programs/Combinatorics" "date:2003-10" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/huffman/issues"
 dev-repo: "https://github.com/coq-contribs/huffman.git"

--- a/released/packages/coq-icharate/coq-icharate.8.5.0/opam
+++ b/released/packages/coq-icharate/coq-icharate.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Icharate"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006." ]
+tags: [ "keyword:multimodal categorial grammars" "keyword:syntax/semantics interface" "keyword:higher order logic" "keyword:meta linguistics" "category:Computer Science/Formal Languages Theory and Automata" "date:2003-2006" ]
 authors: [ "Houda Anoun <anoun@labri.fr>" "Pierre Castéran <casteran@labri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/icharate/issues"
 dev-repo: "https://github.com/coq-contribs/icharate.git"

--- a/released/packages/coq-idxassoc/coq-idxassoc.8.5.0/opam
+++ b/released/packages/coq-idxassoc/coq-idxassoc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/IdxAssoc"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:April 2001" ]
+tags: [ "keyword:associative arrays" "keyword:search operator" "keyword:data structures" "category:Computer Science/Data Types and Data Structures" "date:2001-04" ]
 authors: [ "Dominique Quatravaux <>" "Gérald Macinenti <>" "François-René Ridaux <>" ]
 bug-reports: "https://github.com/coq-contribs/idxassoc/issues"
 dev-repo: "https://github.com/coq-contribs/idxassoc.git"

--- a/released/packages/coq-karatsuba/coq-karatsuba.8.5.0/opam
+++ b/released/packages/coq-karatsuba/coq-karatsuba.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/released/packages/coq-karatsuba/coq-karatsuba.8.5.0/opam
+++ b/released/packages/coq-karatsuba/coq-karatsuba.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Karatsuba"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2005-09-15" ]
+tags: [ "keyword:karatsuba multiplication" "keyword:binary ring" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:15 September 2005" ]
 authors: [ "Russell O'Connor <r.oconnor@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/karatsuba/issues"
 dev-repo: "https://github.com/coq-contribs/karatsuba.git"

--- a/released/packages/coq-kildall/coq-kildall.8.5.0/opam
+++ b/released/packages/coq-kildall/coq-kildall.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Kildall"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 2005" ]
+tags: [ "keyword:kildall" "keyword:data flow analysis" "keyword:bytecode verification" "category:Computer Science/Semantics and Compilation/Semantics" "date:2005-07" ]
 authors: [ "Solange Coupet-Grimal <Solange.Coupet@cmi.univ-mrs.fr>" "William Delobel <delobel@cmi.univ-mrs.fr>" ]
 bug-reports: "https://github.com/coq-contribs/kildall/issues"
 dev-repo: "https://github.com/coq-contribs/kildall.git"

--- a/released/packages/coq-lc/coq-lc.8.5.0/opam
+++ b/released/packages/coq-lc/coq-lc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-09" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/released/packages/coq-lc/coq-lc.8.5.0/opam
+++ b/released/packages/coq-lc/coq-lc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/lc"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:9 September 2008" ]
+tags: [ "keyword:module" "keyword:monads" "keyword:category theory" "keyword:lambda calculus" "keyword:higher order syntax" "category:Computer Science/Lambda Calculi" "date:2008-09-9" ]
 authors: [ "André Hirschowitz <ah@math.unice.fr>" "Marco Maggesi <maggesi@math.unifi.it>" ]
 bug-reports: "https://github.com/coq-contribs/lc/issues"
 dev-repo: "https://github.com/coq-contribs/lc.git"

--- a/released/packages/coq-lin-alg/coq-lin-alg.8.5.0/opam
+++ b/released/packages/coq-lin-alg/coq-lin-alg.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-algebra" {= "8.5.0"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:2003-09-19" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/released/packages/coq-lin-alg/coq-lin-alg.8.5.0/opam
+++ b/released/packages/coq-lin-alg/coq-lin-alg.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-algebra" {= "8.5.0"}
 ]
-tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 spetember 2003" ]
+tags: [ "keyword:linear algebra" "category:Mathematics/Algebra" "date:19 September 2003" ]
 authors: [ "Jasper Stein <jasper@cs.kun.nl>" ]
 bug-reports: "https://github.com/coq-contribs/lin-alg/issues"
 dev-repo: "https://github.com/coq-contribs/lin-alg.git"

--- a/released/packages/coq-ltl/coq-ltl.8.5.0/opam
+++ b/released/packages/coq-ltl/coq-ltl.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LTL"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:July 2002" ]
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" "date:2002-07" ]
 authors: [ "Solange Coupet-Grimal <>" ]
 bug-reports: "https://github.com/coq-contribs/ltl/issues"
 dev-repo: "https://github.com/coq-contribs/ltl.git"

--- a/released/packages/coq-maple-mode/coq-maple-mode.8.5.0/opam
+++ b/released/packages/coq-maple-mode/coq-maple-mode.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MapleMode"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:maple" "keyword:simplification" "keyword:field tactic" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "David Delahaye <>" "Micaela Mayero <>" ]
 bug-reports: "https://github.com/coq-contribs/maple-mode/issues"
 dev-repo: "https://github.com/coq-contribs/maple-mode.git"

--- a/released/packages/coq-markov/coq-markov.8.5.0/opam
+++ b/released/packages/coq-markov/coq-markov.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/released/packages/coq-markov/coq-markov.8.5.0/opam
+++ b/released/packages/coq-markov/coq-markov.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Markov"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:January 5, 2008" ]
+tags: [ "keyword:probability theory" "keyword:markov" "keyword:lebesgue integral" "keyword:measures" "keyword:sigma algebras" "keyword:measurability" "keyword:borel" "category:Mathematics/Real Calculus and Topology" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/markov/issues"
 dev-repo: "https://github.com/coq-contribs/markov.git"

--- a/released/packages/coq-matrices/coq-matrices.8.5.0/opam
+++ b/released/packages/coq-matrices/coq-matrices.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Matrices"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:March 2003" ]
+tags: [ "keyword:matrices" "keyword:vectors" "keyword:linear algebra" "keyword:coq modules" "category:Mathematics/Algebra" "date:2003-03" ]
 authors: [ "Nicolas Magaud <>" ]
 bug-reports: "https://github.com/coq-contribs/matrices/issues"
 dev-repo: "https://github.com/coq-contribs/matrices.git"

--- a/released/packages/coq-orb-stab/coq-orb-stab.8.5.0/opam
+++ b/released/packages/coq-orb-stab/coq-orb-stab.8.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra" {= "8.5.0"}
   "coq-lin-alg" {= "8.5.0"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:January 5, 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/released/packages/coq-orb-stab/coq-orb-stab.8.5.0/opam
+++ b/released/packages/coq-orb-stab/coq-orb-stab.8.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "coq-algebra" {= "8.5.0"}
   "coq-lin-alg" {= "8.5.0"}
 ]
-tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:5 January 2008" ]
+tags: [ "keyword:orbit" "keyword:stabilizer" "keyword:inclusion exclusion" "category:Mathematics/Algebra" "date:2008-01-5" ]
 authors: [ "Robert Kam <rkam2001@hotmail.com>" ]
 bug-reports: "https://github.com/coq-contribs/orb-stab/issues"
 dev-repo: "https://github.com/coq-contribs/orb-stab.git"

--- a/released/packages/coq-param-pi/coq-param-pi.8.5.0/opam
+++ b/released/packages/coq-param-pi/coq-param-pi.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:1998-09-30" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/released/packages/coq-param-pi/coq-param-pi.8.5.0/opam
+++ b/released/packages/coq-param-pi/coq-param-pi.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ParamPi"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:Sept 30 1998" ]
+tags: [ "keyword:pi calculus" "category:Computer Science/Lambda Calculi" "date:30 September 1998" ]
 authors: [ "Loïc Henry-Gréard <lhenrygr@cma.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/param-pi/issues"
 dev-repo: "https://github.com/coq-contribs/param-pi.git"

--- a/released/packages/coq-pi-calc/coq-pi-calc.8.5.0/opam
+++ b/released/packages/coq-pi-calc/coq-pi-calc.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PiCalc"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:July 1998" ]
+tags: [ "keyword:process algebra" "keyword:pi calculus" "keyword:concurrency" "keyword:formal verification" "keyword:higher order syntax" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:1998-07" ]
 authors: [ "Ivan Scagnetto <scagnett@dimi.uniud.it>" ]
 bug-reports: "https://github.com/coq-contribs/pi-calc/issues"
 dev-repo: "https://github.com/coq-contribs/pi-calc.git"

--- a/released/packages/coq-pocklington/coq-pocklington.8.5.0/opam
+++ b/released/packages/coq-pocklington/coq-pocklington.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Pocklington"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:November 2000" ]
+tags: [ "keyword:pocklington" "keyword:number theory" "keyword:prime numbers" "keyword:primality" "keyword:fermat's little theorem" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2000-11" ]
 authors: [ "Martijn Oostdijk <>" "Olga Caprotti <>" ]
 bug-reports: "https://github.com/coq-contribs/pocklington/issues"
 dev-repo: "https://github.com/coq-contribs/pocklington.git"

--- a/released/packages/coq-presburger/coq-presburger.8.5.0/opam
+++ b/released/packages/coq-presburger/coq-presburger.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Presburger"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:March 2002" ]
+tags: [ "keyword:integers" "keyword:arithmetic" "keyword:decision procedure" "keyword:presburger" "category:Mathematics/Logic/Foundations" "category:Mathematics/Arithmetic and Number Theory/Miscellaneous" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/presburger/issues"
 dev-repo: "https://github.com/coq-contribs/presburger.git"

--- a/released/packages/coq-prfx/coq-prfx.8.5.0/opam
+++ b/released/packages/coq-prfx/coq-prfx.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:2005-04-15" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/prfx/issues"
 dev-repo: "https://github.com/coq-contribs/prfx.git"

--- a/released/packages/coq-prfx/coq-prfx.8.5.0/opam
+++ b/released/packages/coq-prfx/coq-prfx.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prfx"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:April 15, 2005" ]
+tags: [ "keyword:first order logic" "keyword:natural deduction" "keyword:reflection" "keyword:proof terms" "keyword:de bruijn indices" "keyword:permutative conversions" "category:Mathematics/Logic/Foundations" "date:15 April 2005" ]
 authors: [ "Dimitri Hendriks <hendriks@cs.ru.nl>" ]
 bug-reports: "https://github.com/coq-contribs/prfx/issues"
 dev-repo: "https://github.com/coq-contribs/prfx.git"

--- a/released/packages/coq-projective-geometry/coq-projective-geometry.8.5.0/opam
+++ b/released/packages/coq-projective-geometry/coq-projective-geometry.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ProjectiveGeometry"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:October 2009" ]
+tags: [ "keyword:geometry" "keyword:projective" "keyword:fano" "keyword:homogeneous coordinates model" "keyword:flat" "keyword:rank" "keyword:desargues" "keyword:moulton" "category:Mathematics/Geometry/General" "date:2009-10" ]
 authors: [ "Nicolas Magaud <Nicolas.Magaud@lsiit-cnrs.unistra.fr>" "Julien Narboux <Julien.Narboux@lsiit-cnrs.unistra.fr>" "Pascal Schreck <Pascal.Schreck@lsiit-cnrs.unistra.fr>" ]
 bug-reports: "https://github.com/coq-contribs/projective-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/projective-geometry.git"

--- a/released/packages/coq-pts/coq-pts.8.5.0/opam
+++ b/released/packages/coq-pts/coq-pts.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PTS"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:March 2007" ]
+tags: [ "keyword:calculus of constructions" "keyword:coq" "keyword:pure type systems" "keyword:metatheory" "category:Computer Science/Lambda Calculi" "date:2007-03" ]
 authors: [ "Bruno Barras <>" ]
 bug-reports: "https://github.com/coq-contribs/pts/issues"
 dev-repo: "https://github.com/coq-contribs/pts.git"

--- a/released/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.5.0/opam
+++ b/released/packages/coq-quicksort-complexity/coq-quicksort-complexity.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/QuicksortComplexity"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:June 2010" ]
+tags: [ "keyword:quicksort" "keyword:complexity" "keyword:average case" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2010-06" ]
 authors: [ "Eelis <>" ]
 bug-reports: "https://github.com/coq-contribs/quicksort-complexity/issues"
 dev-repo: "https://github.com/coq-contribs/quicksort-complexity.git"

--- a/released/packages/coq-railroad-crossing/coq-railroad-crossing.8.5.0/opam
+++ b/released/packages/coq-railroad-crossing/coq-railroad-crossing.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RailroadCrossing"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000." ]
+tags: [ "keyword:ctl" "keyword:tctl" "keyword:real time systems" "keyword:timed automatas" "keyword:safety" "keyword:concurrency" "keyword:properties" "keyword:invariants" "keyword:nonzeno" "keyword:discrete time" "category:Computer Science/Concurrent Systems and Protocols/Correctness of specific protocols" "date:February-March 2000" ]
 authors: [ "Carlos Daniel Luna <http://www.fing.edu.uy/~cluna>" ]
 bug-reports: "https://github.com/coq-contribs/railroad-crossing/issues"
 dev-repo: "https://github.com/coq-contribs/railroad-crossing.git"

--- a/released/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.0/opam
+++ b/released/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:05/2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/released/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.0/opam
+++ b/released/packages/coq-reflexive-first-order/coq-reflexive-first-order.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ReflexiveFirstOrder"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:May 2005" ]
+tags: [ "keyword:computationnal reflection" "keyword:interpretation" "keyword:first order logic" "keyword:equational reasoning" "category:Miscellaneous/Coq Extensions" "date:2005-05" ]
 authors: [ "Pierre Corbineau <pierre.corbineau@lri.fr>" ]
 bug-reports: "https://github.com/coq-contribs/reflexive-first-order/issues"
 dev-repo: "https://github.com/coq-contribs/reflexive-first-order.git"

--- a/released/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.5.0/opam
+++ b/released/packages/coq-ruler-compass-geometry/coq-ruler-compass-geometry.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RulerCompassGeometry"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidean geometry" "keyword:Hilbert's axioms" "category:Mathematics/Geometry/General" "date:November 2007" ]
+tags: [ "keyword:geometry" "keyword:plane geometry" "keyword:ruler and compass geometry" "keyword:euclidean geometry" "keyword:Hilbert's axioms" "category:Mathematics/Geometry/General" "date:2007-11" ]
 authors: [ "Jean Duprat <Jean.Duprat@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/ruler-compass-geometry/issues"
 dev-repo: "https://github.com/coq-contribs/ruler-compass-geometry.git"

--- a/released/packages/coq-semantics/coq-semantics.8.5.0/opam
+++ b/released/packages/coq-semantics/coq-semantics.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:July 5, 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/released/packages/coq-semantics/coq-semantics.8.5.0/opam
+++ b/released/packages/coq-semantics/coq-semantics.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:5 July 2007" ]
+tags: [ "keyword:natural semantics" "keyword:denotational semantics" "keyword:axiomatic" "keyword:semantics" "keyword:hoare logic" "keyword:dijkstra weakest pre condition calculus" "keyword:abstract interpretation" "keyword:intervals" "category:Computer Science/Semantics and Compilation/Semantics" "date:2007-07-5" ]
 authors: [ "Yves Bertot <Yves.Bertot@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/semantics/issues"
 dev-repo: "https://github.com/coq-contribs/semantics.git"

--- a/released/packages/coq-smc/coq-smc.8.5.0/opam
+++ b/released/packages/coq-smc/coq-smc.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5" & < "8.6~"}
   "coq-int-map" {= "8.5.0"}
 ]
-tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:November 2002" ]
+tags: [ "keyword:binary decision diagrams" "keyword:classical logic" "keyword:propositional logic" "keyword:garbage collection" "keyword:modal mu calculus" "keyword:model checking" "keyword:symbolic model checking" "keyword:reflection" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "date:2002-11" ]
 authors: [ "Kumar Neeraj Verma <verma@lsv.ens-cachan.fr>" ]
 bug-reports: "https://github.com/coq-contribs/smc/issues"
 dev-repo: "https://github.com/coq-contribs/smc.git"

--- a/released/packages/coq-string/coq-string.8.5.0/opam
+++ b/released/packages/coq-string/coq-string.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:2002-03" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/released/packages/coq-string/coq-string.8.5.0/opam
+++ b/released/packages/coq-string/coq-string.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/String"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:Mars 2002" ]
+tags: [ "keyword:string" "keyword:ascii character" "category:Miscellaneous/Coq Extensions" "date:March 2002" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/string/issues"
 dev-repo: "https://github.com/coq-contribs/string.git"

--- a/released/packages/coq-sudoku/coq-sudoku.8.5.0/opam
+++ b/released/packages/coq-sudoku/coq-sudoku.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:February 2006" ]
+tags: [ "keyword:sudoku" "keyword:puzzles" "keyword:davis putnam" "category:Miscellaneous/Logical Puzzles and Entertainment" "date:2006-02" ]
 authors: [ "Laurent Théry <thery@sophia.inria.fr>" ]
 bug-reports: "https://github.com/coq-contribs/sudoku/issues"
 dev-repo: "https://github.com/coq-contribs/sudoku.git"

--- a/released/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.0/opam
+++ b/released/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13/12/2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/released/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.0/opam
+++ b/released/packages/coq-sum-of-two-square/coq-sum-of-two-square.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SumOfTwoSquare"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:13 December 2004" ]
+tags: [ "keyword:number theory" "category:Mathematics/Arithmetic and Number Theory/Number theory" "date:2004-12-13" ]
 authors: [ "Laurent Théry <>" ]
 bug-reports: "https://github.com/coq-contribs/sum-of-two-square/issues"
 dev-repo: "https://github.com/coq-contribs/sum-of-two-square.git"

--- a/released/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.5.0/opam
+++ b/released/packages/coq-tortoise-hare-algorithm/coq-tortoise-hare-algorithm.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TortoiseHareAlgorithm"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:February 2007" ]
+tags: [ "keyword:program verification" "keyword:paths" "keyword:cycle detection" "keyword:graphs" "keyword:graph theory" "keyword:finite sets" "keyword:floyd" "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date:2007-02" ]
 authors: [ "Jean-Christophe Filliâtre <>" ]
 bug-reports: "https://github.com/coq-contribs/tortoise-hare-algorithm/issues"
 dev-repo: "https://github.com/coq-contribs/tortoise-hare-algorithm.git"

--- a/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
+++ b/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5"}
   "coq-int-map"
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
+++ b/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "coq" {>= "8.5"}
   "coq-int-map"
 ]
-tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:september 1999" ]
+tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:September 1999" ]
 authors: [ "Xavier Rival <http://www.eleves.ens.fr/home/rival>" ]
 bug-reports: "https://github.com/coq-contribs/tree-automata/issues"
 dev-repo: "https://github.com/coq-contribs/tree-automata.git"

--- a/released/packages/coq-weak-up-to/coq-weak-up-to.8.5.0/opam
+++ b/released/packages/coq-weak-up-to/coq-weak-up-to.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005-02-22" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"

--- a/released/packages/coq-weak-up-to/coq-weak-up-to.8.5.0/opam
+++ b/released/packages/coq-weak-up-to/coq-weak-up-to.8.5.0/opam
@@ -8,7 +8,7 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/WeakUpTo"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]
-tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:2005/02/22" ]
+tags: [ "keyword:weak bisimulation" "keyword:up to techniques" "keyword:termination" "keyword:commutation" "keyword:newman's lemma" "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems" "date:22 February 2005" ]
 authors: [ "Damien Pous <Damien.Pous@ens-lyon.fr>" ]
 bug-reports: "https://github.com/coq-contribs/weak-up-to/issues"
 dev-repo: "https://github.com/coq-contribs/weak-up-to.git"


### PR DESCRIPTION
This patch adopts a unique format for dates, so as to improve the feeling of unity of presentation at page "https://coq.inria.fr/opam/www/".