### PR TITLE
add coq-msets-extra version 1.0.0

### DIFF
--- a/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/descr
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/descr
@@ -1,0 +1,17 @@
+Extensions of MSets for Efficient Execution
+
+Coq's MSet library provides various, reasonably efficient finite set
+implementations. Nevertheless, FireEye was nevertheless struggling
+with performance issues.
+
+This library contains extensions to Coq's MSet library that helped
+the FireEye Formal Methods team (formal-methods@fireeye.com),
+solve these performance issues. There are
+
+- Fold With Abort
+  efficient folding with possibility to  start late and stop early
+
+- Interval Sets
+  a memory efficient representation of sets of numbers
+  
+- Unsorted Lists with Duplicates

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/descr
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/descr
@@ -1,15 +1,13 @@
 Extensions of MSets for Efficient Execution
 
 Coq's MSet library provides various, reasonably efficient finite set
-implementations. Nevertheless, FireEye was nevertheless struggling
-with performance issues.
-
-This library contains extensions to Coq's MSet library that helped
-the FireEye Formal Methods team (formal-methods@fireeye.com),
+implementations. Nevertheless, FireEye was struggling with performance
+issues. This library contains extensions to Coq's MSet library that
+helped the FireEye Formal Methods team (formal-methods@fireeye.com),
 solve these performance issues. There are
 
 - Fold With Abort
-  efficient folding with possibility to  start late and stop early
+  efficient folding with possibility to start late and stop early
 
 - Interval Sets
   a memory efficient representation of sets of numbers

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/opam
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "thomas@tuerk-brechen.de"
+homepage: "https://github.com/thtuerk/MSetsExtra"
+dev-repo: "https://github.com/thtuerk/MSetsExtra.git"
+bug-reports: "https://github.com/thtuerk/MSetsExtra/issues"
+authors: ["FireEye Formal Methods Team <formal-methods@fireeye.com>" "Thomas Tuerk <thomas@tuerk-brechen.de>"]
+license: "LGPL 2.1"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MSetsExtra"]
+depends: [
+  "coq" {>= "8.4.5"}
+]

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/opam
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/opam
@@ -14,5 +14,13 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MSetsExtra"]
 depends: [
-  "coq" {>= "8.4.5"}
+  "coq" {>= "8.4.5" & < "8.5~"}
+  "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
+tags: [ "keyword:finite sets"
+        "keyword:fold with abort"
+        "keyword:extracting efficient code"
+        "keyword:data structures"
+        "category:CS/Data Types and Data Structures"
+        "category:Misc/Extracted/Data structures"
+        "date:2016-10-04" ]

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/url
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/thtuerk/MSetsExtra/archive/1.0.0.tar.gz"
+checksum: "297a95b8ca4157760862e5812e8addd3"


### PR DESCRIPTION
First addition of MSetsExtra, an extension of the finite set library MSets, which focuses on efficient execution. This lib was presented at the Coq workshop at ITP 2016. Please see

https://github.com/thtuerk/MSetsExtra/blob/master/doc/mset.pdf

for high level documentation.