### PR TITLE
[RFC] Remove upper bound on coq-io

### DIFF
--- a/released/packages/coq-io/coq-io.3.2.0/opam
+++ b/released/packages/coq-io/coq-io.3.2.0/opam
@@ -14,5 +14,5 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io"]
 depends: [
-  "coq" {>= "8.4pl4" & < "8.5~"}
+  "coq" {>= "8.4pl4" & < "8.6~"}
 ]


### PR DESCRIPTION
/cc @clarus for comments/review. But `coq-io` seems to work just fine with 8.5:

```
$ coqc --version
The Coq Proof Assistant, version 8.5pl1 (May 2016)
compiled on May 24 2016 23:23:22 with OCaml 4.02.1
```

...and it would make installing it much easier if 8.5 users could grab it from the repo. (I went the silly route of installing a bunch of deps manually to get the hello world example working, because I don't know enough about `opam` to tell it to not worry about the upper-bound constraint here).

Thoughts?