### PR TITLE
[coq-io-system-ocaml] Add a lower-bound on lwt

### DIFF
--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.0/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.0/opam
@@ -14,6 +14,6 @@ install: [
 remove: [make "uninstall"]
 depends: [
   "ocamlfind"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 available: [ocaml-version >= "4.00.0"]


### PR DESCRIPTION
`Lwt.fail_with` isn't in `2.4.5` which my system seems to be defaulting to for some reason (even though `opam show lwt` shows that newer versions are available). But while I'm dealing with that, there should probably be a lower bound here anyway.