### PR TITLE
coq-extensible-records 1.2.0

### DIFF
--- a/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/descr
+++ b/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/descr
@@ -1,0 +1,1 @@
+Definitional (canonical) extensible records in Coq with string keys and arbitrary (non-dependent) types.

--- a/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/opam
+++ b/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "gmalecha@gmail.com"
+homepage: "https://github.com/gmalecha/coq-extensible-records"
+dev-repo: "https://github.com/gmalecha/coq-extensible-records.git"
+bug-reports: "https://github.com/gmalecha/coq-extensible-records/issues"
+authors: ["Gregory Malecha"]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "-R" "%{lib}%/coq/user-contrib/Records"]
+]
+depends: [
+  "coq" {>= "8.5.0"}
+]

--- a/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/url
+++ b/released/packages/coq-extensible-records/coq-extensible-records.1.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/gmalecha/coq-extensible-records/archive/1.2.0.tar.gz"
+checksum: "3794e13edcfde118d1cc61bc0858ac6d"


### PR DESCRIPTION
Release: https://github.com/gmalecha/coq-extensible-records/releases/tag/1.2.0