### PR TITLE
coq-msets-extra 1.1.0, adaptation to Coq 5.3

### DIFF
--- a/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/descr
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/descr
@@ -1,0 +1,15 @@
+Extensions of MSets for Efficient Execution
+
+Coq's MSet library provides various, reasonably efficient finite set
+implementations. Nevertheless, FireEye was struggling with performance
+issues. This library contains extensions to Coq's MSet library that
+helped the FireEye Formal Methods team (formal-methods@fireeye.com),
+solve these performance issues. There are
+
+- Fold With Abort
+  efficient folding with possibility to start late and stop early
+
+- Interval Sets
+  a memory efficient representation of sets of numbers
+  
+- Unsorted Lists with Duplicates

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/opam
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "thomas@tuerk-brechen.de"
+homepage: "https://github.com/thtuerk/MSetsExtra"
+dev-repo: "https://github.com/thtuerk/MSetsExtra.git"
+bug-reports: "https://github.com/thtuerk/MSetsExtra/issues"
+authors: ["FireEye Formal Methods Team <formal-methods@fireeye.com>" "Thomas Tuerk <thomas@tuerk-brechen.de>"]
+license: "LGPL 2.1"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MSetsExtra"]
+depends: [
+  "coq" {>= "8.5" & < "8.6~"}
+  "coq-mathcomp-ssreflect" {>= "1.6"}
+]
+tags: [ "keyword:finite sets"
+        "keyword:fold with abort"
+        "keyword:extracting efficient code"
+        "keyword:data structures"
+        "category:CS/Data Types and Data Structures"
+        "category:Misc/Extracted/Data structures"
+        "date:2016-10-04" ]

--- a/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/url
+++ b/released/packages/coq-msets-extra/coq-msets-extra.1.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/thtuerk/MSetsExtra/archive/1.1.0.tar.gz"
+checksum: "38cfbe97a0a688cb8b3a86e93be52709"


### PR DESCRIPTION
Add version 1.1.0 of the coq-msets-extra library. This new version is an adaptation to Coq 5.3.
Release https://github.com/thtuerk/MSetsExtra/archive/1.1.0.tar.gz