### PR TITLE
Fix a dependency in coq-squiggle-eq.dev and correct compcert arch dependencies

### DIFF
--- a/extra-dev/packages/coq-squiggle-eq/coq-squiggle-eq.dev/opam
+++ b/extra-dev/packages/coq-squiggle-eq/coq-squiggle-eq.dev/opam
@@ -14,4 +14,5 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SquiggleEq"]
 depends: [
   "coq" {>= "8.5.0"}
+  "coq-ext-lib"
 ]

--- a/released/packages/coq-compcert/coq-compcert.2.7.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/opam
@@ -6,7 +6,10 @@ dev-repo: "https://github.com/AbsInt/CompCert.git"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
 build: [
-  ["./configure" "ia32-linux" "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"]
+  ["./configure" "ia32-linux" {os = "linux"}
+  		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+  		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"]
   [make "-j%{jobs}%"]
 ]
 install: [


### PR DESCRIPTION
CompCert 2.7.1 compiles fine on osx with the right target.