### PR TITLE
set coq-compcert.2.7.1 Coq dependency to version 8.5.2 only

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.2.7.1/files/fix-coq-version.patch
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/files/fix-coq-version.patch
@@ -1,0 +1,11 @@
+--- configure	2016-07-18 03:14:10.000000000 -0500
++++ configure.new	2017-01-02 13:57:44.089376511 -0600
+@@ -271,7 +271,7 @@ missingtools=false
+ echo "Testing Coq... " | tr -d '\n'
+ coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
+ case "$coq_ver" in
+-  8.5pl2)
++  8.5pl2|8.5pl3)
+         echo "version $coq_ver -- good!";;
+   ?.*)
+         echo "version $coq_ver -- UNSUPPORTED"

--- a/released/packages/coq-compcert/coq-compcert.2.7.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/opam
@@ -21,6 +21,7 @@ remove: [
   ["rm" "%{share}%/compcert.ini"]
 ]
 depends: [
-  "coq" {= "8.5.2"}
+  "coq" {>= "8.5.2" & < "8.6~"}
   "menhir" {>= "20160303"}
 ]
+patches: "fix-coq-version.patch"

--- a/released/packages/coq-compcert/coq-compcert.2.7.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/opam
@@ -21,6 +21,6 @@ remove: [
   ["rm" "%{share}%/compcert.ini"]
 ]
 depends: [
-  "coq" {>= "8.5.2" & < "8.6~"}
+  "coq" {= "8.5.2"}
   "menhir" {>= "20160303"}
 ]


### PR DESCRIPTION
The `configure` script of the 2.7.1 release of CompCert [prevents](https://github.com/AbsInt/CompCert/blob/73c4de2d46fff171883965aafdac1ab5b2bb330e/configure#L274) any systems with Coq version other than 8.5pl2 from compiling, including those with 8.5pl3. While 8.5pl3 was subsequently made possible to use in the CompCert github repo, there has been no release so far that includes this fix. To prevent OPAM coq-compcert.2.7.1 installations from failing with 8.5pl3, this fix sets the correct dependency.