### PR TITLE
build clightgen for coq-compcert.2.7.1

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.2.7.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/opam
@@ -9,7 +9,8 @@ build: [
   ["./configure" "ia32-linux" {os = "linux"}
   		 "ia32-macosx" {os = "darwin"}
 		 "ia32-cygwin" {os = "cygwin"}
-  		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"]
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
   [make "-j%{jobs}%"]
 ]
 install: [
@@ -17,6 +18,7 @@ install: [
 ]
 remove: [
   ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
   ["rm" "-R" "%{lib}%/compcert"]
   ["rm" "%{share}%/compcert.ini"]
 ]


### PR DESCRIPTION
`clightgen` is an optionally-built CompCert binary used by other projects such as the Verified Software Toolchain to enable reasoning about C programs in Coq. Due to its usefulness, I believe it should be built by default whenever CompCert is installed. 

I have tested locally that the binary is properly generated during installation and removed when the package is uninstalled.