### PR TITLE
Depends on Coq>=8.6

### DIFF
--- a/released/packages/coq-math-classes/coq-math-classes.1.0.6/opam
+++ b/released/packages/coq-math-classes/coq-math-classes.1.0.6/opam
@@ -15,5 +15,5 @@ build: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MathClasses"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.6"}
 ]


### PR DESCRIPTION
This package does not work with Coq-8.5 so I've bumped up version in dependency. Related bug: https://github.com/math-classes/math-classes/issues/35