### PR TITLE
adding "coq-fiat-crypto" to "extra-dev"

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat.

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Fiat"]
+depends: [
+  "coq" {= "8.6.dev"}
+]
+dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#master"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat.

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Fiat"]
+depends: [
+  "coq" {= "dev"}
+]
+dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#master"


### PR DESCRIPTION
Hi @andres-erbsen

I would like to add `fiat-crypto` as an OPAM package to "extra-dev"  repository.
Do you think it is OK to go ahead like this?