### PR TITLE
adding some more coq-compcert packages

### DIFF
--- a/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/descr
+++ b/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/descr
@@ -1,0 +1,1 @@
+The CompCert C compiler.

--- a/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/opam
+++ b/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
+  ["rm" "-R" "%{lib}%/compcert"]
+  ["rm" "%{share}%/compcert.ini"]
+]
+depends: [
+  "coq" {= "8.6.dev"}
+  "menhir" {>= "20160303"}
+]

--- a/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/url
+++ b/extra-dev/packages/coq-compcert/coq-compcert.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/AbsInt/CompCert.git"

--- a/extra-dev/packages/coq-compcert/coq-compcert.dev/descr
+++ b/extra-dev/packages/coq-compcert/coq-compcert.dev/descr
@@ -1,0 +1,1 @@
+The CompCert C compiler.

--- a/extra-dev/packages/coq-compcert/coq-compcert.dev/files/fix-coq-version.diff
+++ b/extra-dev/packages/coq-compcert/coq-compcert.dev/files/fix-coq-version.diff
@@ -1,0 +1,21 @@
+diff -crN CompCert.old/configure CompCert.new/configure
+*** CompCert.old/configure	2017-03-19 19:23:17.418501680 +0100
+--- CompCert.new/configure	2017-03-20 09:18:59.807144359 +0100
+***************
+*** 411,417 ****
+  echo "Testing Coq... " | tr -d '\n'
+  coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
+  case "$coq_ver" in
+!   8.6)
+          echo "version $coq_ver -- good!";;
+    ?.*)
+          echo "version $coq_ver -- UNSUPPORTED"
+--- 411,417 ----
+  echo "Testing Coq... " | tr -d '\n'
+  coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
+  case "$coq_ver" in
+!   trunk)
+          echo "version $coq_ver -- good!";;
+    ?.*)
+          echo "version $coq_ver -- UNSUPPORTED"
+Binary files CompCert.old/.git/index and CompCert.new/.git/index differ

--- a/extra-dev/packages/coq-compcert/coq-compcert.dev/opam
+++ b/extra-dev/packages/coq-compcert/coq-compcert.dev/opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
+  ["rm" "-R" "%{lib}%/compcert"]
+  ["rm" "%{share}%/compcert.ini"]
+]
+depends: [
+  "coq" {= "dev"}
+  "menhir" {>= "20160303"}
+]
+patches: "fix-coq-version.diff"

--- a/extra-dev/packages/coq-compcert/coq-compcert.dev/url
+++ b/extra-dev/packages/coq-compcert/coq-compcert.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/AbsInt/CompCert.git"

--- a/released/packages/coq-compcert/coq-compcert.3.0.0/descr
+++ b/released/packages/coq-compcert/coq-compcert.3.0.0/descr
@@ -1,0 +1,1 @@
+The CompCert C compiler.

--- a/released/packages/coq-compcert/coq-compcert.3.0.0/files/fix-coq-version.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.0.0/files/fix-coq-version.patch
@@ -1,0 +1,11 @@
+--- configure	2016-07-18 03:14:10.000000000 -0500
++++ configure.new	2017-01-02 13:57:44.089376511 -0600
+@@ -271,7 +271,7 @@ missingtools=false
+ echo "Testing Coq... " | tr -d '\n'
+ coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
+ case "$coq_ver" in
+-  8.5pl2)
++  8.5pl2|8.5pl3)
+         echo "version $coq_ver -- good!";;
+   ?.*)
+         echo "version $coq_ver -- UNSUPPORTED"

--- a/released/packages/coq-compcert/coq-compcert.3.0.0/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
+  ["rm" "-R" "%{lib}%/compcert"]
+  ["rm" "%{share}%/compcert.ini"]
+]
+depends: [
+  "coq" {>= "8.5" & < "8.6~"}
+  "menhir" {>= "20160303"}
+]

--- a/released/packages/coq-compcert/coq-compcert.3.0.0/url
+++ b/released/packages/coq-compcert/coq-compcert.3.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AbsInt/CompCert/archive/v3.0.tar.gz"
+checksum: "8590239f6219f8bbc48c4e91f5d16921"

--- a/released/packages/coq-compcert/coq-compcert.3.0.1/descr
+++ b/released/packages/coq-compcert/coq-compcert.3.0.1/descr
@@ -1,0 +1,1 @@
+The CompCert C compiler.

--- a/released/packages/coq-compcert/coq-compcert.3.0.1/files/fix-coq-version.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.0.1/files/fix-coq-version.patch
@@ -1,0 +1,11 @@
+--- configure	2016-07-18 03:14:10.000000000 -0500
++++ configure.new	2017-01-02 13:57:44.089376511 -0600
+@@ -271,7 +271,7 @@ missingtools=false
+ echo "Testing Coq... " | tr -d '\n'
+ coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
+ case "$coq_ver" in
+-  8.5pl2)
++  8.5pl2|8.5pl3)
+         echo "version $coq_ver -- good!";;
+   ?.*)
+         echo "version $coq_ver -- UNSUPPORTED"

--- a/released/packages/coq-compcert/coq-compcert.3.0.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
+  ["rm" "-R" "%{lib}%/compcert"]
+  ["rm" "%{share}%/compcert.ini"]
+]
+depends: [
+  "coq" {>= "8.6" & < "8.7~"}
+  "menhir" {>= "20160303"}
+]

--- a/released/packages/coq-compcert/coq-compcert.3.0.1/url
+++ b/released/packages/coq-compcert/coq-compcert.3.0.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AbsInt/CompCert/archive/v3.0.1.tar.gz"
+checksum: "76af0b470261df6b19053a60474fc84a"


### PR DESCRIPTION
For the sake of [benchmarking](https://gist.githubusercontent.com/matejkosik/9795adb83b40c295a49e852b4dcbf669/raw/9c19dd92ed9a837b77169497bde801814dc66ef1/gistfile1.txt) it makes sense to define the following packages:
- `coq-compcert.8.6.dev`
- `coq-compcert.dev`

I've also added these packages:
- `coq-compcert.3.0.0` ... CompCert release for Coq 8.5
- `coq-compcert.3.0.1` ... CompCert release for Coq 8.6

as it probably makes sense to define them.