### PR TITLE
Bedrock (src and facade targets)

### DIFF
--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/descr
@@ -1,0 +1,1 @@
+Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/descr
@@ -1,1 +1,1 @@
-Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "facade"]
+install: [make "install-facade"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "8.6.dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#master"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/descr
@@ -1,0 +1,1 @@
+Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/descr
@@ -1,1 +1,1 @@
-Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "src"]
+install: [make "install-src"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "8.6.dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#master"


### PR DESCRIPTION
Add packages for the facade and src targets of bedrock

Primarily for the bench.  Version that checks with trunk (as-of econstr) is currently blocked on @ppedrot fixing https://coq.inria.fr/bugs/show_bug.cgi?id=5476.