### PR TITLE
Add packages for src and facade targets for bedrock for Coq trunk

### DIFF
--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/descr
@@ -1,0 +1,1 @@
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "facade"]
+install: [make "install-facade"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-facade.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#master"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/descr
@@ -1,0 +1,1 @@
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "src"]
+install: [make "install-src"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock-src.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#master"


### PR DESCRIPTION
We can do this now that https://github.com/coq/coq/pull/574 has been merged.