### PR TITLE
Add bmsherman/topology package as coq-formal-topology

### DIFF
--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/descr
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/descr
@@ -1,0 +1,1 @@
+A programming language for topology and probability in Coq.

--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/opam
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+authors: [
+  "Ben Sherman <sherm@mit.edu>"
+]
+maintainer: "Ben Sherman <sherm@mit.edu>"
+homepage: "https://github.com/bmsherman/topology"
+bug-reports: "https://github.com/bmsherman/topology/issues"
+license: "MIT"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prob"]
+depends: [
+  "coq" {= "8.6.dev"}
+  "coq-corn"
+]
+dev-repo: "https://github.com/bmsherman/topology.git"

--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/url
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/bmsherman/topology.git#predicative"

--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/descr
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/descr
@@ -1,0 +1,1 @@
+A programming language for topology and probability in Coq.

--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/opam
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+authors: [
+  "Ben Sherman <sherm@mit.edu>"
+]
+maintainer: "Ben Sherman <sherm@mit.edu>"
+homepage: "https://github.com/bmsherman/topology"
+bug-reports: "https://github.com/bmsherman/topology/issues"
+license: "MIT"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Prob"]
+depends: [
+  "coq" {= "dev"}
+  "coq-corn"
+]
+dev-repo: "https://github.com/bmsherman/topology.git"

--- a/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/url
+++ b/extra-dev/packages/coq-formal-topology/coq-formal-topology.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/bmsherman/topology.git#predicative"


### PR DESCRIPTION
This development of @bmsherman tests universe polymorphism and setoid rewriting in type, and should build with v8.6 and trunk.  It's primarily for the bench.