### PR TITLE
Add coq-bedrock

### DIFF
--- a/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/descr
@@ -1,0 +1,1 @@
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "src" "platform" "facade" "examples" "facade-all" "qsfacade" "qsfacade-impl" "qsfacade-compiler"]
+install: [make "install-src" "install-platform" "install-facade" "install-examples" "install-facade-all" "install-qsfacade" "install-qsfacade-impl" "install-qsfacade-compiler"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "8.6.dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#dev"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock.dev/descr
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.dev/descr
@@ -1,0 +1,1 @@
+[PORTING IN PROGRESS] Mostly automated verification of higher-order programs with higher-order separation logic, with a small trusted code base.  Note that somet things are still broken with 8.6, and this is primarily for benchmarking/compatibility testing purposes, at the moment.

--- a/extra-dev/packages/coq-bedrock/coq-bedrock.dev/opam
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+authors: [
+  "Adam Chlipala <adamc@csail.mit.edu>"
+  "Gregory Malecha <gmalecha@cs.harvard.edu>"
+  "Thomas Braibant <thomas.braibant@inria.fr>"
+  "Patrick Hulin <phulin@mit.edu>"
+  "Edward Z. Yang <ezyang@mit.edu>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://plv.csail.mit.edu/bedrock/"
+bug-reports: "https://github.com/JasonGross/bedrock/issues"
+license: "BSD"
+build: [make "-j%{jobs}%" "src" "platform" "facade" "examples" "facade-all" "qsfacade" "qsfacade-impl" "qsfacade-compiler"]
+install: [make "install-src" "install-platform" "install-facade" "install-examples" "install-facade-all" "install-qsfacade" "install-qsfacade-impl" "install-qsfacade-compiler"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Bedrock"]
+depends: [
+  "coq" {= "dev"}
+]
+dev-repo: "https://github.com/JasonGross/bedrock.git"

--- a/extra-dev/packages/coq-bedrock/coq-bedrock.dev/url
+++ b/extra-dev/packages/coq-bedrock/coq-bedrock.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/JasonGross/bedrock.git#dev"


### PR DESCRIPTION
This is the bulk of bedrock (all the targets at the tip of master that
build with 8.4).  In trunk, it takes a bit over 21 hours of user time to
build on my machine.  There are still some admits, because the porting
is a work in progress, but I think there's enough now to make it worth
benchmarking (when you're willing to wait 21 hours).