### PR TITLE
add dev and 8.6.dev packages for Verdi Raft and its dependencies

### DIFF
--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/descr
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/descr
@@ -1,0 +1,1 @@
+InfSeqExt is a collection of Coq libraries for reasoning inductively and coinductively on infinite sequences, using modal operators similar to those in linear temporal logic (LTL).

--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/opam
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/InfSeqExt"
+dev-repo: "https://github.com/DistributedComponents/InfSeqExt.git"
+bug-reports: "https://github.com/DistributedComponents/InfSeqExt/issues"
+license: "Proprietary"
+
+build: [ [ "./configure" ] [ make "-j%{jobs}%" ] ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/InfSeqExt'" ]
+depends: [ "coq" {= "8.6.dev"} ]
+
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" ]
+authors: [ "Yuxin Deng <>" "Jean-Francois Monin <>" "Karl Palmskog <>" ]

--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/url
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/DistributedComponents/InfSeqExt.git#master"

--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/descr
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/descr
@@ -1,0 +1,1 @@
+InfSeqExt is a collection of Coq libraries for reasoning inductively and coinductively on infinite sequences, using modal operators similar to those in linear temporal logic (LTL).

--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/opam
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/InfSeqExt"
+dev-repo: "https://github.com/DistributedComponents/InfSeqExt.git"
+bug-reports: "https://github.com/DistributedComponents/InfSeqExt/issues"
+license: "Proprietary"
+
+build: [ [ "./configure" ] [ make "-j%{jobs}%" ] ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/InfSeqExt'" ]
+depends: [ "coq" {= "dev"} ]
+
+tags: [ "keyword:temporal logic" "keyword:infinite transition systems" "keyword:coinduction" "category:Mathematics/Logic/Modal logic" ]
+authors: [ "Yuxin Deng <>" "Jean-Francois Monin <>" "Karl Palmskog <>" ]

--- a/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/url
+++ b/extra-dev/packages/coq-inf-seq-ext/coq-inf-seq-ext.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/DistributedComponents/InfSeqExt.git#master"

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/descr
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/descr
@@ -1,0 +1,1 @@
+StructTact is a Coq library of "structural tactics" as well as Coq libraries containing lemmas about lists and finite types that use the tactics library.

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/opam
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/StructTact"
+dev-repo: "https://github.com/uwplse/StructTact.git"
+bug-reports: "https://github.com/uwplse/StructTact/issues"
+license: "BSD"
+
+build: [ [ "./configure" ] [ make "-j%{jobs}%" ] ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/StructTact'" ]
+depends: [ "coq" {= "8.6.dev"} ]
+
+tags: [ "keyword:proof automation" ]
+authors: [ "Ryan Doenges <>" "Karl Palmskog <>" "Keith Simmons <>" "James Wilcox <>" "Doug Woos <>"]

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/url
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/StructTact.git#master"

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/descr
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/descr
@@ -1,0 +1,1 @@
+StructTact is a Coq library of "structural tactics" as well as Coq libraries containing lemmas about lists and finite types that use the tactics library.

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/opam
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/StructTact"
+dev-repo: "https://github.com/uwplse/StructTact.git"
+bug-reports: "https://github.com/uwplse/StructTact/issues"
+license: "BSD"
+
+build: [ [ "./configure" ] [ make "-j%{jobs}%" ] ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/StructTact'" ]
+depends: [ "coq" {= "dev"} ]
+
+tags: [ "keyword:proof automation" ]
+authors: [ "Ryan Doenges <>" "Karl Palmskog <>" "Keith Simmons <>" "James Wilcox <>" "Doug Woos <>"]

--- a/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/url
+++ b/extra-dev/packages/coq-struct-tact/coq-struct-tact.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/StructTact.git#master"

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/descr
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/descr
@@ -1,0 +1,1 @@
+Verdi Raft is a verified implementation of the Raft distributed consensus protocol in Coq.

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi-raft"
+dev-repo: "https://github.com/uwplse/verdi-raft.git"
+bug-reports: "https://github.com/uwplse/verdi-raft/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiRaft'" ]
+depends: [
+  "coq" {= "8.6.dev"}
+  "coq-verdi" {= "8.6.dev"}
+  "coq-struct-tact" {= "8.6.dev"}
+]
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+  "keyword:raft"
+]
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/url
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/verdi-raft.git#master"

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/descr
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/descr
@@ -1,0 +1,1 @@
+Verdi Raft is a verified implementation of the Raft distributed consensus protocol in Coq.

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
@@ -1,0 +1,34 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi-raft"
+dev-repo: "https://github.com/uwplse/verdi-raft.git"
+bug-reports: "https://github.com/uwplse/verdi-raft/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiRaft'" ]
+depends: [
+  "coq" {= "dev"}
+  "coq-verdi" {= "dev"}
+  "coq-struct-tact" {= "dev"}
+]
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+  "keyword:raft"
+]
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/url
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/verdi-raft.git#master"

--- a/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/descr
+++ b/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/descr
@@ -1,0 +1,1 @@
+Verdi is a framework for verification of implementations of distributed systems in Coq.

--- a/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/opam
+++ b/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi"
+dev-repo: "https://github.com/uwplse/verdi.git"
+bug-reports: "https://github.com/uwplse/verdi/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Verdi'" ]
+depends: [
+  "coq" {= "8.6.dev"}
+  "coq-mathcomp-ssreflect" {= "8.6.dev"}
+  "coq-inf-seq-ext" {= "8.6.dev"}
+  "coq-struct-tact" {= "8.6.dev"}
+]
+
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+]
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/url
+++ b/extra-dev/packages/coq-verdi/coq-verdi.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/verdi.git#master"

--- a/extra-dev/packages/coq-verdi/coq-verdi.dev/descr
+++ b/extra-dev/packages/coq-verdi/coq-verdi.dev/descr
@@ -1,0 +1,1 @@
+Verdi is a framework for verification of implementations of distributed systems in Coq.

--- a/extra-dev/packages/coq-verdi/coq-verdi.dev/opam
+++ b/extra-dev/packages/coq-verdi/coq-verdi.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi"
+dev-repo: "https://github.com/uwplse/verdi.git"
+bug-reports: "https://github.com/uwplse/verdi/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Verdi'" ]
+depends: [
+  "coq" {= "dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
+  "coq-inf-seq-ext" {= "dev"}
+  "coq-struct-tact" {= "dev"}
+]
+
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+]
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/extra-dev/packages/coq-verdi/coq-verdi.dev/url
+++ b/extra-dev/packages/coq-verdi/coq-verdi.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/verdi.git#master"


### PR DESCRIPTION
As per a request from Matej Kosik, here is a PR with all packages required to build [Verdi Raft](https://github.com/uwplse/verdi-raft) against trunk and 8.6.dev. We tested a day or so ago that everything builds.