### PR TITLE
added coq-aac-tactics 8.6.1 to released

### DIFF
--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/descr
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/descr
@@ -1,0 +1,3 @@
+AAC tactics.
+
+This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators:

--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/opam
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "matej.kosik@inria.fr"
+homepage: "https://github.com/coq-contribs/aac-tactics"
+license: "LGPL"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/AAC_tactics"]
+depends: [
+  "coq" {>= "8.6" & < "8.7~"}
+]
+tags: [ "keyword:reflexive tactic" "keyword:rewriting" "keyword:rewriting modulo associativity and commutativity" "keyword:rewriting modulo ac" "keyword:decision procedure" "category:Miscellaneous/Coq Extensions" ]
+authors: [ "Damien Pous <damien.pous@inria.fr>" "Thomas Braibant <thomas.braibant@gmail.com>" ]
+bug-reports: "coqdev@inria.fr"
+dev-repo: "https://github.com/coq-contribs/aac-tactics.git"

--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/url
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/coq-contribs/aac-tactics/archive/v8.6.1.tar.gz"
+checksum: "2d5a77e26ae85f1fb6ab0e5034787d45"


### PR DESCRIPTION
One of our developments that we're porting to 8.6 uses aac-tactics in coq-contrib. To avoid depending on development packages, it's convenient to have an OPAM package for it in release. These files are copied from Matej Kosik's previous closed PR.