### PR TITLE
coq2html documentation generator

### DIFF
--- a/released/packages/coq-coq2html/coq-coq2html.1.0/descr
+++ b/released/packages/coq-coq2html/coq-coq2html.1.0/descr
@@ -1,0 +1,1 @@
+Generates HTML documentation from Coq source files.  Alternative to coqdoc.

--- a/released/packages/coq-coq2html/coq-coq2html.1.0/opam
+++ b/released/packages/coq-coq2html/coq-coq2html.1.0/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Xavier Leroy <xavier.leroy@inria.fr>"
+homepage: "https://github.com/xavierleroy/coq2html"
+dev-repo: "https://github.com/xavierleroy/coq2html.git"
+bug-reports: "https://github.com/xavierleroy/coq2html/issues"
+license: "GPL v2 or later"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "BINDIR=%{bin}%" "install"]
+]
+remove: [
+  ["rm" "%{bin}%/coq2html"]
+]
+
+depends: [
+  "coq" {>= "8.5"}
+]

--- a/released/packages/coq-coq2html/coq-coq2html.1.0/url
+++ b/released/packages/coq-coq2html/coq-coq2html.1.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/xavierleroy/coq2html/archive/v1.0.tar.gz"
+checksum: "33d6c09ba1015b3181b2d46c56f9759b"


### PR DESCRIPTION
This is a first cut at an OPAM-Coq package for the coq2html documentation generator (of CompCert fame), which is now available as a standalone project (https://github.com/xavierleroy/coq2html).
