### PR TITLE
added coq-dblib 8.6.0 to released

### DIFF
--- a/released/packages/coq-dblib/coq-dblib.8.6.0/descr
+++ b/released/packages/coq-dblib/coq-dblib.8.6.0/descr
@@ -1,0 +1,3 @@
+dblib.
+
+The dblib library offers facilities for working with de Bruijn indices.

--- a/released/packages/coq-dblib/coq-dblib.8.6.0/opam
+++ b/released/packages/coq-dblib/coq-dblib.8.6.0/opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+maintainer: "matej.kosik@inria.fr"
+homepage: "https://github.com/coq-contribs/dblib"
+license: "GPL"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Dblib"]
+depends: [
+  "coq" {>= "8.6" & < "8.7~"}
+]
+tags: [ "keyword:abstract syntax" "keyword:binders" "keyword:de bruijn indices" "keyword:shift" "keyword:lift" "keyword:substitution" "category:Computer Science/Lambda Calculi" ]
+authors: [ "Francois Pottier <francois.pottier@inria.fr>" ]
+bug-reports: "https://github.com/coq-contribs/dblib/issues"
+dev-repo: "https://github.com/coq-contribs/dblib.git"

--- a/released/packages/coq-dblib/coq-dblib.8.6.0/opam
+++ b/released/packages/coq-dblib/coq-dblib.8.6.0/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "matej.kosik@inria.fr"
+maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-contribs/dblib"
 license: "GPL"
 build: [make "-j%{jobs}%"]

--- a/released/packages/coq-dblib/coq-dblib.8.6.0/url
+++ b/released/packages/coq-dblib/coq-dblib.8.6.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/coq-contribs/dblib/archive/v8.6.0.tar.gz"
+checksum: "12c880f61010aa9c1c4700fb6a143326"


### PR DESCRIPTION
I'm using dblib in one of my developments and it would be convenient to have an 8.6-compatible OPAM packaged version under released. These files are copied from Matej Kosik's previous closed PR.