### PR TITLE
switch maintainer for coq-aac-tactics-8.6.1

### DIFF
--- a/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/opam
+++ b/released/packages/coq-aac-tactics/coq-aac-tactics.8.6.1/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "matej.kosik@inria.fr"
+maintainer: "palmskog@gmail.com"
 homepage: "https://github.com/coq-contribs/aac-tactics"
 license: "LGPL"
 build: [make "-j%{jobs}%"]


### PR DESCRIPTION
As per earlier [discussion](https://github.com/coq/opam-coq-archive/pull/170) with @matejkosik - here is a change in maintainer (to myself) for the package `coq-aac-tactics-8.6.1`.