### PR TITLE
add dev and 8.6.dev packages for all coq-verdi-raft dependencies

### DIFF
--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/descr
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/descr
@@ -1,0 +1,1 @@
+Cheerios is a Coq library for serialization.

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/opam
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/cheerios"
+dev-repo: "https://github.com/uwplse/cheerios.git"
+bug-reports: "https://github.com/uwplse/cheerios/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Cheerios'" ]
+depends: [
+  "coq" {= "8.6.dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
+  "coq-struct-tact" {= "8.6.dev"}
+]
+
+tags: [ "keyword:serialization" ]
+authors: [
+  "Keith Simmons <>"
+  "Doug Woos <>"
+  "James Wilcox <>"
+  "Justin Adsuara <>"
+  "Karl Palmskog <>"
+]

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/url
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/cheerios.git#master"

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.dev/descr
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.dev/descr
@@ -1,0 +1,1 @@
+Cheerios is a Coq library for serialization.

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.dev/opam
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.dev/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/cheerios"
+dev-repo: "https://github.com/uwplse/cheerios.git"
+bug-reports: "https://github.com/uwplse/cheerios/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Cheerios'" ]
+depends: [
+  "coq" {= "dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
+  "coq-struct-tact" {= "dev"}
+]
+
+tags: [ "keyword:serialization" ]
+authors: [
+  "Keith Simmons <>"
+  "Doug Woos <>"
+  "James Wilcox <>"
+  "Justin Adsuara <>"
+  "Karl Palmskog <>"
+]

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.dev/url
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/uwplse/cheerios.git#master"

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/descr
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/descr
@@ -1,0 +1,1 @@
+A verified system transformer for serialization of Verdi systems using the Cheerios library.

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/opam
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/verdi-cheerios"
+dev-repo: "https://github.com/DistributedComponents/verdi-cheerios.git"
+bug-reports: "https://github.com/DistributedComponents/verdi-cheerios/issues"
+license: "Proprietary"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiCheerios'" ]
+depends: [
+  "coq" {= "8.6.dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
+  "coq-struct-tact" {= "8.6.dev"}
+  "coq-cheerios" {= "8.6.dev"}
+  "coq-verdi" {= "8.6.dev"}
+]
+
+tags: [ "keyword:serialization" ]
+authors: [
+  "Keith Simmons <>"
+  "Karl Palmskog <>"
+]

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/url
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/DistributedComponents/verdi-cheerios.git#master"

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/descr
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/descr
@@ -1,0 +1,1 @@
+A verified system transformer for serialization of Verdi systems using the Cheerios library.

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/opam
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/DistributedComponents/verdi-cheerios"
+dev-repo: "https://github.com/DistributedComponents/verdi-cheerios.git"
+bug-reports: "https://github.com/DistributedComponents/verdi-cheerios/issues"
+license: "Proprietary"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiCheerios'" ]
+depends: [
+  "coq" {= "dev"}
+  "coq-mathcomp-ssreflect" {= "dev"}
+  "coq-struct-tact" {= "dev"}
+  "coq-cheerios" {= "dev"}
+  "coq-verdi" {= "dev"}
+]
+
+tags: [ "keyword:serialization" ]
+authors: [
+  "Keith Simmons <>"
+  "Karl Palmskog <>"
+]

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/url
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/DistributedComponents/verdi-cheerios.git#master"

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.6.dev/opam
@@ -16,6 +16,8 @@ depends: [
   "coq" {= "8.6.dev"}
   "coq-verdi" {= "8.6.dev"}
   "coq-struct-tact" {= "8.6.dev"}
+  "coq-cheerios" {= "8.6.dev"}
+  "coq-verdi-cheerios" {= "8.6.dev"}
 ]
 tags: [
   "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
@@ -31,4 +33,5 @@ authors: [
   "Steve Anton <>"
   "Karl Palmskog <>"
   "Ryan Doenges <>"
+  "Justin Adsuara <>"
 ]

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
@@ -16,6 +16,8 @@ depends: [
   "coq" {= "dev"}
   "coq-verdi" {= "dev"}
   "coq-struct-tact" {= "dev"}
+  "coq-cheerios" {= "dev"}
+  "coq-verdi-cheerios" {= "dev"}
 ]
 tags: [
   "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
@@ -31,4 +33,5 @@ authors: [
   "Steve Anton <>"
   "Karl Palmskog <>"
   "Ryan Doenges <>"
+  "Justin Adsuara <>"
 ]


### PR DESCRIPTION
We recently added some more of our projects as dependencies to Verdi Raft, which is in `extra-dev`. To keep these projects building from OPAM, the new packages need to be added and dependency data updated for existing packages.

I have tested these new and updated packages for the `8.6.dev` version of Coq, but the `dev` package currently does not build - because it [passes](https://github.com/coq/opam-coq-archive/blob/9aa89a4fb11a0625752c447b5b8c12eac0234843/core-dev/packages/coq.dev/opam#L10) the no longer supported `-nodoc` option to `configure`, which should be `-with-doc no`.

I would like to submit packages for `8.7.dev`, but the `coq-mathcomp-ssreflect` package, which we depend on, does not build against that version due to a `< "8.7~"` [clause](https://github.com/coq/opam-coq-archive/blob/9aa89a4fb11a0625752c447b5b8c12eac0234843/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam#L13).