### PR TITLE
updated supported coq version

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.0.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.0.1/opam
@@ -23,6 +23,6 @@ remove: [
   ["rm" "%{share}%/compcert.ini"]
 ]
 depends: [
-  "coq" {>= "8.6" & < "8.7~"}
+  "coq" {= "8.6"}
   "menhir" {>= "20160303"}
 ]


### PR DESCRIPTION
Current version does not support Coq 8.6.1 and compilation fails with:

    # Testing Coq... version 8.6.1 -- UNSUPPORTED