### PR TITLE
update Verdi-related 8.7.dev packages

### DIFF
--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/opam
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.6.dev/opam
@@ -14,7 +14,6 @@ install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Cheerios'" ]
 depends: [
   "coq" {= "8.6.dev"}
-  "coq-mathcomp-ssreflect" {= "dev"}
   "coq-struct-tact" {= "8.6.dev"}
 ]
 

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.7.dev/opam
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/uwplse/cheerios"
 dev-repo: "https://github.com/uwplse/cheerios.git"
@@ -8,14 +8,12 @@ license: "BSD"
 
 build: [
   [ "./configure" ]
-  [ "bash" "-c" "sed -i '1i From Coq Require Extraction.' extraction/*.v runtime/coq/{ExtractPositiveSerializer.v,ExtractTreeSerializer.v}" ]
   [ make "-j%{jobs}%" ]
 ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Cheerios'" ]
 depends: [
   "coq" {= "8.7.dev"}
-  "coq-mathcomp-ssreflect" {= "8.7.dev"}
   "coq-struct-tact" {= "8.7.dev"}
 ]
 

--- a/extra-dev/packages/coq-cheerios/coq-cheerios.8.7.dev/url
+++ b/extra-dev/packages/coq-cheerios/coq-cheerios.8.7.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/uwplse/cheerios.git#master"
+git: "https://github.com/uwplse/cheerios.git#v8.7"

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.7.dev/opam
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/DistributedComponents/verdi-cheerios"
 dev-repo: "https://github.com/DistributedComponents/verdi-cheerios.git"
@@ -14,7 +14,6 @@ install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiCheerios'" ]
 depends: [
   "coq" {= "8.7.dev"}
-  "coq-mathcomp-ssreflect" {= "8.7.dev"}
   "coq-struct-tact" {= "8.7.dev"}
   "coq-cheerios" {= "8.7.dev"}
   "coq-verdi" {= "8.7.dev"}

--- a/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.7.dev/url
+++ b/extra-dev/packages/coq-verdi-cheerios/coq-verdi-cheerios.8.7.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/DistributedComponents/verdi-cheerios.git#master"
+git: "https://github.com/DistributedComponents/verdi-cheerios.git#v8.7"

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.7.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "palmskog@gmail.com"
 
 homepage: "https://github.com/uwplse/verdi-raft"
 dev-repo: "https://github.com/uwplse/verdi-raft.git"
@@ -8,7 +8,6 @@ license: "BSD"
 
 build: [
   [ "./configure" ]
-  [ "bash" "-c" "sed -i -e '1i Require Import FunInd.' raft/CommonTheorems.v" ]
   [ make "-j%{jobs}%" ]
 ]
 install: [ make "install" ]

--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.7.dev/url
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.8.7.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/uwplse/verdi-raft.git#master"
+git: "https://github.com/uwplse/verdi-raft.git#v8.7"


### PR DESCRIPTION
We have introduced new git branches for some Verdi-related packages to support the 8.7 alpha. Here are updated packages that use those branches. I've tested locally that they build properly.