### PR TITLE
Minor fix in dev packages, do not put core-dev in the official opam index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COQWEB=~/COQ/www/
-SUITES= core-dev  extra-dev  released
+SUITES= extra-dev  released
 H=@
 COQV=8.6
 OCAMLV=4.01.0

--- a/core-dev/packages/coq.8.7+beta1/opam
+++ b/core-dev/packages/coq.8.7+beta1/opam
@@ -3,7 +3,7 @@ authors: [ "The Coq Development Team" ]
 maintainer: "coqdev@inria.fr"
 homepage: "http://coq.inria.fr/"
 bug-reports: "https://coq.inria.fr/bugs/"
-license: "LGPL 2"
+license: "LGPL 2.1"
 build: [
   ["./configure"
     "-configdir" "%{lib}%/coq/config"

--- a/core-dev/packages/coq.8.7.dev/opam
+++ b/core-dev/packages/coq.8.7.dev/opam
@@ -12,8 +12,7 @@ build: [
     "-prefix" prefix
     "-usecamlp5"
     "-camlp5dir" "%{lib}%/camlp5"
-    "-coqide" "no"
-    "-debug"]
+    "-coqide" "no"]
   [make "-j%{jobs}%"]
 ]
 install: [make "install"]


### PR DESCRIPTION
Solves issues #99 and #182 