### PR TITLE
Fix coq-hott.8.6.dev package, which is the only hott package working

### DIFF
--- a/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
@@ -1,4 +1,6 @@
 opam-version: "1.2"
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "https://github.com/HoTT/HoTT.git"
 maintainer: "Matej Košík <matej.kosik@inria.fr>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "http://homotopytypetheory.org/"
@@ -9,11 +11,8 @@ build: [
   ["%{make}%" "-j%{jobs}%"]
 ]
 install: ["%{make}%" "install"]
-remove: ["rm" "-R" "%{share}%/hott"]
+remove: ["rm" "-Rf" "%{share}%/hott"]
 depends: [
   "ocamlfind" {build}
-  "coq" {= "8.6.dev"}
+  "coq" { >= "8.6" & < "8.7" }
 ]
-authors: ["The UniMath Development Team"]
-dev-repo: "https://github.com/HoTT/HoTT.git"
-patches: ["no_clone.diff"]


### PR DESCRIPTION
with Coq 8.6. @JasonGross Am I right that released 8.6 is expected to work with this package always? Shouldn't we rather have a release package for HoTT on 8.6?