### PR TITLE
add coq-ott.0.26 package

### DIFF
--- a/released/packages/coq-ott/coq-ott.0.26/descr
+++ b/released/packages/coq-ott/coq-ott.0.26/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/released/packages/coq-ott/coq-ott.0.26/opam
+++ b/released/packages/coq-ott/coq-ott.0.26/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+  "date:2017-09-21"
+]

--- a/released/packages/coq-ott/coq-ott.0.26/url
+++ b/released/packages/coq-ott/coq-ott.0.26/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ott-lang/ott/archive/0.26.tar.gz"
+checksum: "8aee607f1a386b3e12b1dfe0c2cf7ca1"


### PR DESCRIPTION
The [Ott tool](http://www.cl.cam.ac.uk/~pes20/ott/) just had a new release that contains OPAM-friendly scripts for building and installing the auxiliary Coq library which Ott-generated vernacular files depend on. This package for Coq complements the regular Ott package that has been submitted as a [pull request](https://github.com/ocaml/opam-repository/pull/10320) to the regular official OPAM repository.