### PR TITLE
add coq-ott extra-dev packages

### DIFF
--- a/extra-dev/packages/coq-ott/coq-ott.8.6.dev/descr
+++ b/extra-dev/packages/coq-ott/coq-ott.8.6.dev/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/extra-dev/packages/coq-ott/coq-ott.8.6.dev/opam
+++ b/extra-dev/packages/coq-ott/coq-ott.8.6.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {= "8.6.dev"} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+]

--- a/extra-dev/packages/coq-ott/coq-ott.8.6.dev/url
+++ b/extra-dev/packages/coq-ott/coq-ott.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/ott-lang/ott.git"

--- a/extra-dev/packages/coq-ott/coq-ott.8.7.dev/descr
+++ b/extra-dev/packages/coq-ott/coq-ott.8.7.dev/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/extra-dev/packages/coq-ott/coq-ott.8.7.dev/opam
+++ b/extra-dev/packages/coq-ott/coq-ott.8.7.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {= "8.7.dev"} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+]

--- a/extra-dev/packages/coq-ott/coq-ott.8.7.dev/url
+++ b/extra-dev/packages/coq-ott/coq-ott.8.7.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/ott-lang/ott.git"

--- a/extra-dev/packages/coq-ott/coq-ott.dev/descr
+++ b/extra-dev/packages/coq-ott/coq-ott.dev/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/extra-dev/packages/coq-ott/coq-ott.dev/opam
+++ b/extra-dev/packages/coq-ott/coq-ott.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {= "dev"} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+]

--- a/extra-dev/packages/coq-ott/coq-ott.dev/url
+++ b/extra-dev/packages/coq-ott/coq-ott.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/ott-lang/ott.git"


### PR DESCRIPTION
To enable testing Coq projects dependent on the [Ott](http://www.cl.cam.ac.uk/~pes20/ott/) tool against Coq development versions (in particular the `v8.7` branch), here are `extra-dev` packages for the auxiliary Ott files for Coq. I have tested locally that all packages build.