### PR TITLE
add coq-hammer version 1.0.3

### DIFF
--- a/released/packages/coq-hammer/coq-hammer.1.0.3/descr
+++ b/released/packages/coq-hammer/coq-hammer.1.0.3/descr
@@ -1,0 +1,1 @@
+Automation for Dependent Type Theory

--- a/released/packages/coq-hammer/coq-hammer.1.0.3/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "Julien Narboux <julien@narboux.fr>"
+homepage: "http://cl-informatik.uibk.ac.at/cek/coqhammer/"
+bug-reports: "mailto://lukaszcz@mimuw.edu.pl"
+authors: ["Ł. Czajka"
+ 	  "Cezary Kaliszyk"]
+license: "LGPL 2.1"
+build: [
+  ["sed" "-i" "s|usr\\/local|%{prefix}%|g" "_CoqProject"]
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+	["rm" "-R" "%{lib}%/coq/user-contrib/Hammer"]
+	["rm" "%{prefix}%/bin/predict"]
+]
+depends: [
+  "coq" { (>= "8.6" & < "8.7~") }
+]
+tags: [ "keyword:automation"
+	"category:Misc/Coq Extensions"
+	"date:2017-09-30"  ]

--- a/released/packages/coq-hammer/coq-hammer.1.0.3/url
+++ b/released/packages/coq-hammer/coq-hammer.1.0.3/url
@@ -1,0 +1,2 @@
+http: "http://cl-informatik.uibk.ac.at/cek/coqhammer/coqhammer-1.0.3-coq8.6.tar.gz"
+checksum: "4d0fb044c9ddecac60b6aea7310a2379"


### PR DESCRIPTION
It seems that the external dependencies (Vampire, Eprover, and z3_tptp) are not available as packages in ubuntu.