### PR TITLE
coq-mathcomp-finmap.8.7.dev should point to the mathcomp repository

### DIFF
--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/descr
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/descr
@@ -1,0 +1,7 @@
+Finite sets, finite maps, finitely supported functions.
+
+This library is under developpment and an extension of mathematical
+component in order to support finite sets and finite maps on
+choicetypes (rather that finite types). This includes support for
+functions with finite support. Multisets are still experimental.
+There also an embryo of generic order and set libary... very experimental.

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "coq-mathcomp-finmap"
+version: "dev"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "http://www.cyrilcohen.fr"
+bug-reports: "Cyril Cohen <cyril.cohen@inria.fr>"
+license: "CeCILL-B"
+
+build: [ make "-j" "%{jobs}%" ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/finmap'" ]
+depends: [ "coq-mathcomp-ssreflect" { = "dev" } ]
+
+tags: [ "keyword:finmap" "keyword:finset" "keyword:multiset"]
+authors: [ "Cyril Cohen <cyril.cohen@inria.fr>" ]

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/url
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.8.7.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/math-comp/finmap.git"


### PR DESCRIPTION
https://github.com/math-comp/finmap is a few commits ahead of  https://github.com/Barbichu/finmap.git
=> updated the git link to the *correct* repository.