### PR TITLE
Add coq-equations 8.7.dev package to extra-dev

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.8.7.dev/descr
+++ b/extra-dev/packages/coq-equations/coq-equations.8.7.dev/descr
@@ -1,0 +1,1 @@
+A function definition package for Coq

--- a/extra-dev/packages/coq-equations/coq-equations.8.7.dev/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.8.7.dev/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Cyprien Mangin <cyprien.mangin@m4x.org>" ]
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://mattam82.github.io/Coq-Equations"
+dev-repo: "https://github.com/mattam82/Coq-Equations.git"
+bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
+license: "LGPL 2.1"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Equations"]
+depends: [
+  "coq" {>= "8.7" & < "8.8~"}
+]

--- a/extra-dev/packages/coq-equations/coq-equations.8.7.dev/url
+++ b/extra-dev/packages/coq-equations/coq-equations.8.7.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mattam82/Coq-Equations#8.7"


### PR DESCRIPTION
This branch tracks the 8.7 branch of Coq.