### PR TITLE
coq-ext-lib compatible with 8.7

### DIFF
--- a/released/packages/coq-ext-lib/coq-ext-lib.0.9.5/opam
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.9.5/opam
@@ -15,5 +15,5 @@ remove: [
   ["rm" "-R" "%{lib}%/coq/user-contrib/ExtLib"]
 ]
 depends: [
-  "coq" {>= "8.6~"}
+  "coq" {>= "8.6~" < "8.7~"}
 ]

--- a/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/descr
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/descr
@@ -1,0 +1,2 @@
+A basic library of basic Coq datatypes, definitions, theorems, and
+tactics meant to extend the standard library.

--- a/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/opam
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/opam
@@ -15,5 +15,5 @@ remove: [
   ["rm" "-R" "%{lib}%/coq/user-contrib/ExtLib"]
 ]
 depends: [
-  "coq" {>= "8.5.0" < "8.6~"}
+  "coq" {>= "8.7" < "8.8~"}
 ]

--- a/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/url
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.9.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/coq-ext-lib/coq-ext-lib/archive/v0.9.7.tar.gz"
+checksum: "930e4b98ca7fec8a4ed977958d688f0c"


### PR DESCRIPTION
Also bumping version constraints on older versions to prevent them from being pulled in.