### PR TITLE
Add beta2 version of equations (for 8.6 and 8.7)

### DIFF
--- a/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/descr
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/descr
@@ -1,0 +1,1 @@
+A function definition package for Coq

--- a/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/opam
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Cyprien Mangin <cyprien.mangin@m4x.org>" ]
+dev-repo: "https://github.com/mattam82/Coq-Equations.git"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://mattam82.github.io/Coq-Equations"
+bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
+license: "LGPL 2.1"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Equations"]
+depends: [
+  "coq" {>= "8.7" & < "8.8"}
+]

--- a/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/url
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mattam82/Coq-Equations/archive/v1.0-8.7-beta2.tar.gz"
+checksum: "d281835d0762424b23c9aebf4a6d8921"

--- a/released/packages/coq-equations/coq-equations.1.0~beta2/descr
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2/descr
@@ -1,0 +1,1 @@
+A function definition package for Coq

--- a/released/packages/coq-equations/coq-equations.1.0~beta2/opam
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2/opam
@@ -16,4 +16,3 @@ remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Equations"]
 depends: [
   "coq" {>= "8.6" & < "8.7"}
 ]
-available: [ocaml-version > "4.02.3"]

--- a/released/packages/coq-equations/coq-equations.1.0~beta2/url
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/mattam82/Coq-Equations/archive/v1.0-8.6-beta2.tar.gz"
+checksum: "983f6580b9fcf5aaa6dce7e05bc37efe"


### PR DESCRIPTION
This fixes incompatibilities with ocaml 4.02.3 and other Coq packages (notations conflicts arose)