### PR TITLE
add coq-ott.0.27 package

### DIFF
--- a/released/packages/coq-ott/coq-ott.0.27/descr
+++ b/released/packages/coq-ott/coq-ott.0.27/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/released/packages/coq-ott/coq-ott.0.27/opam
+++ b/released/packages/coq-ott/coq-ott.0.27/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~"))} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+  "date:2017-11-27"
+]

--- a/released/packages/coq-ott/coq-ott.0.27/url
+++ b/released/packages/coq-ott/coq-ott.0.27/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ott-lang/ott/archive/0.27.tar.gz"
+checksum: "e05eea1b975d8612c68feec068c4b963"


### PR DESCRIPTION
Add released package for the Coq library in the Ott tool, version 0.27. Now with Coq 8.7 support. I've tested locally that the package builds with 8.5.3, 8.6.1 and 8.7.0.