### PR TITLE
Update of coq packages wrt ocaml versions

### DIFF
--- a/core-dev/packages/coq.8.5.dev/opam
+++ b/core-dev/packages/coq.8.5.dev/opam
@@ -18,4 +18,5 @@ build: [
 ]
 depends: [
   "camlp5"
+  "num"
 ]

--- a/core-dev/packages/coq.8.5.dev/opam
+++ b/core-dev/packages/coq.8.5.dev/opam
@@ -1,6 +1,8 @@
-opam-version: "1.1"
+opam-version: "1.2"
+authors: [ "The Coq Development Team" ]
 maintainer: "dev@clarus.me"
 homepage: "http://coq.inria.fr/"
+dev-repo: "https://github.com/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 license: "LGPL 2"
 build: [
@@ -20,3 +22,6 @@ depends: [
   "camlp5"
   "num"
 ]
+available: [ocaml-version >= "3.12.1" & ocaml-version != "4.02.0"]
+# Checked it works for e.g. 4.06.0
+# Version 4.02.0 would work but with severe performance issues in compilation time

--- a/core-dev/packages/coq.8.6.dev/opam
+++ b/core-dev/packages/coq.8.6.dev/opam
@@ -25,4 +25,5 @@ dev-repo: "https://scm.gforge.inria.fr/anonscm/git/coq/coq.git"
 depends: [
   "ocamlfind"
   "camlp5"
+  "num"
 ]

--- a/core-dev/packages/coq.8.6.dev/opam
+++ b/core-dev/packages/coq.8.6.dev/opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 authors: [ "The Coq Development Team" ]
 maintainer: "coqdev@inria.fr"
 homepage: "http://coq.inria.fr/"
+dev-repo: "https://github.com/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 license: "LGPL 2"
 build: [
@@ -21,7 +22,6 @@ remove: [
   ["rm" "-R" "%{lib}%/coq"]
   ["rm" "-R" "%{share}%/coq"]
 ]
-dev-repo: "https://scm.gforge.inria.fr/anonscm/git/coq/coq.git"
 depends: [
   "ocamlfind"
   "camlp5"


### PR DESCRIPTION
These are mini-fixes for some coq "dev" packages:

- more precise ocaml version requirements
- new need for `num` since OCaml 4.06.0
- ~~`make -j` not working on some old versions~~

~~I may update it further in the next hours, but, to minimize possible worries regarding the different ways to get Coq in relation with the ocaml 4.06 + coq 8.6 [coq-club](https://sympa.inria.fr/sympa/arc/coq-club/2017-12/msg00033.html) discussion, a confirmation that someone will merge it by tomorrow say noon would be good (note that for 8.6.dev, it is only about the `num` dependency).~~

(Edited to reflect the new state of the PR).