### PR TITLE
Update Coq opam files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         - opam
         - aspcud
         - gcc-multilib
+        - libgtksourceview2.0-dev
   - os: osx
     osx_image: xcode7.3
     before_install:

--- a/core-dev/packages/coq.8.7.dev/opam
+++ b/core-dev/packages/coq.8.7.dev/opam
@@ -25,8 +25,8 @@ install: [
   [make "install-byte"]
 ]
 remove: [
-  ["rm" "-R" "%{lib}%/coq" "%{share}%/coq"]
-  ["rm"
+  ["rm" "-rf" "%{lib}%/coq" "%{share}%/coq"]
+  ["rm" "-f"
   "%{man}%/man1/coqc.1"
   "%{man}%/man1/coqchk.1"
   "%{man}%/man1/coqdep.1"

--- a/core-dev/packages/coq.8.7.dev/opam
+++ b/core-dev/packages/coq.8.7.dev/opam
@@ -14,7 +14,6 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-usecamlp5"
     "-camlp5dir" "%{lib}%/camlp5"
     "-coqide" "no"
   ]
@@ -50,7 +49,8 @@ remove: [
   ]
 ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "camlp5"
   "num"
 ]
+available: [ocaml-version >= "4.02.3"]

--- a/core-dev/packages/coq.8.7.dev/opam
+++ b/core-dev/packages/coq.8.7.dev/opam
@@ -5,6 +5,14 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "ocamlfind" {build}
+  "camlp5"
+  "num"
+]
+
 build: [
   [
     "./configure"
@@ -48,9 +56,3 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
 ]
-depends: [
-  "ocamlfind" {build}
-  "camlp5"
-  "num"
-]
-available: [ocaml-version >= "4.02.3"]

--- a/core-dev/packages/coq.dev/files/coq.install
+++ b/core-dev/packages/coq.dev/files/coq.install
@@ -3,7 +3,6 @@ bin: [
   "bin/coqwc"
   "bin/coqtop"
   "bin/coqtop.byte"
-  "bin/coqmktop"
   "bin/coqdoc"
   "bin/coqdep"
   "bin/coqchk"

--- a/core-dev/packages/coq.dev/opam
+++ b/core-dev/packages/coq.dev/opam
@@ -5,6 +5,14 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "ocamlfind" {build}
+  "camlp5"
+  "num"
+]
+
 build: [
   [
     "./configure"
@@ -25,8 +33,8 @@ install: [
   [make "install-byte"]
 ]
 remove: [
-  ["rm" "-R" "%{lib}%/coq" "%{share}%/coq"]
-  ["rm"
+  ["rm" "-rf" "%{lib}%/coq" "%{share}%/coq"]
+  ["rm" "-f"
   "%{man}%/man1/coqc.1"
   "%{man}%/man1/coqchk.1"
   "%{man}%/man1/coqdep.1"
@@ -47,9 +55,4 @@ remove: [
   "%{share}%/emacs/site-lisp/gallina.el"
   "%{share}%/emacs/site-lisp/gallina-syntax.el"
   ]
-]
-depends: [
-  "ocamlfind"
-  "camlp5"
-  "num"
 ]

--- a/core-dev/packages/coqide.8.7.dev/opam
+++ b/core-dev/packages/coqide.8.7.dev/opam
@@ -19,7 +19,7 @@ build: [
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
+remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
 depends: [
   "camlp5"
   "coq" {= "8.7.dev"}

--- a/core-dev/packages/coqide.8.7.dev/opam
+++ b/core-dev/packages/coqide.8.7.dev/opam
@@ -5,6 +5,15 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "camlp5"
+  "coq" {= "8.7.dev"}
+  "lablgtk"
+  "conf-gtksourceview"
+]
+
 build: [
   [
     "./configure"
@@ -19,14 +28,6 @@ build: [
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]
 ]
-remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
-depends: [
-  "camlp5"
-  "coq" {= "8.7.dev"}
-  "lablgtk"
-  "conf-gtksourceview"
-]
-available: [ocaml-version >= "4.02.3"]
 install: [
   make
   "install-ide-bin"
@@ -34,3 +35,4 @@ install: [
   "install-ide-info"
   "install-ide-devfiles"
 ]
+remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]

--- a/core-dev/packages/coqide.8.7.dev/opam
+++ b/core-dev/packages/coqide.8.7.dev/opam
@@ -14,7 +14,6 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-usecamlp5"
     "-camlp5dir" "%{lib}%/camlp5"
   ]
   [make "-j%{jobs}%" "coqide-files"]
@@ -27,6 +26,7 @@ depends: [
   "lablgtk"
   "conf-gtksourceview"
 ]
+available: [ocaml-version >= "4.02.3"]
 install: [
   make
   "install-ide-bin"

--- a/core-dev/packages/coqide.dev/opam
+++ b/core-dev/packages/coqide.dev/opam
@@ -5,6 +5,15 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "https://github.com/coq/coq.git"
 license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "camlp5"
+  "coq" {= "dev"}
+  "lablgtk"
+  "conf-gtksourceview"
+]
+
 build: [
   [
     "./configure"
@@ -19,12 +28,6 @@ build: [
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]
 ]
-depends: [
-  "camlp5"
-  "coq" {= "dev"}
-  "lablgtk"
-  "conf-gtksourceview"
-]
 install: [
   make
   "install-ide-bin"
@@ -32,3 +35,4 @@ install: [
   "install-ide-info"
   "install-ide-devfiles"
 ]
+remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]


### PR DESCRIPTION
Applying feedback I got when submitting 8.7.1 to the default repo:

* Add `{build}` tag to `ocamlfind` dependency so that Coq does not get rebuilt when `ocamlfind` does
* Remove deprecated `-usecamlp5` option
* Use `rm -f` to avoid errors when uninstalling partial/failed installs
* Reorder fields

EDIT: Now also fixes #244.