### PR TITLE
some more debug output from the CI

### DIFF
--- a/scripts/opam-coq-install-remove
+++ b/scripts/opam-coq-install-remove
@@ -27,8 +27,7 @@ while [ ! -z "$1" ]; do
     PKG_VERSION_DIR=`dirname "$1"`
     PKG_NAME_VERSION=`basename "$PKG_VERSION_DIR"`
     PKG_VERSION=`echo $PKG_NAME_VERSION | cut -d . -f 2-`
-    PKG_DIR=`dirname "$PKG_VERSION_DIR"`
-    PKG=`basename "$PKG_DIR"`
+    PKG_NAME=`echo $PKG_NAME_VERSION | cut -d . -f 1`
     case "$PKG_VERSION" in
     *dev)
       echo Add dev repos
@@ -40,8 +39,8 @@ while [ ! -z "$1" ]; do
     esac
     echo Installing $PKG_NAME_VERSION
     opam install "$PKG_NAME_VERSION" -y -v -v
-    echo Removing $PKG
-    opam remove "$PKG" -y
+    echo Removing $PKG_NAME
+    opam remove "$PKG_NAME" -y
     echo -en "travis_fold:end:$1\\\\r"
   ;;
   *)

--- a/scripts/opam-coq-install-remove
+++ b/scripts/opam-coq-install-remove
@@ -13,6 +13,8 @@ function setup_root() {
   eval $(opam config --root=${HOME}/opam-root env)
   echo .Add released repo
   opam repo add released file://$PWD/released
+  opam repository
+  opam pin list
 }
 
 while [ ! -z "$1" ]; do


### PR DESCRIPTION
We see strange CI failure e.g. in <https://github.com/coq/opam-coq-archive/pull/243>. Maybe this helps finding out what is going on.

Also, this fixes a problem that came up in #242: The scripts relied on the `package/package.version` folder structure; now they only assume `package.version` and make no assumption about the next-higher directory.