### PR TITLE
coq-qcert v1.0.4 publication

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.1.0.4/descr
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/descr
@@ -1,0 +1,1 @@
+A platform for implementing and verifying query compilers

--- a/released/packages/coq-qcert/coq-qcert.1.0.4/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: ["Josh Auerbach","Martin Hirzel","Louis Mandel","Avi Shinnar","Jerome Simeon"]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}% qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "coq" {>= "8.7.1"}
+]

--- a/released/packages/coq-qcert/coq-qcert.1.0.4/url
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/url
@@ -1,0 +1,2 @@
+http: "https://github.com/querycert/qcert/archive/v1.0.4.tar.gz"
+checksum: "f14bff99263f5025acc6b92afed1e434"


### PR DESCRIPTION
coq-qcert package including all the Coq formalization part of the Q*cert query compiler (https://querycert.github.io).