### PR TITLE
Add opam 2 repo files for core-dev and extra-dev

### DIFF
--- a/core-dev/repo
+++ b/core-dev/repo
@@ -1,1 +1,2 @@
+opam-version: "1.2"
 upstream: "https://github.com/coq/opam-coq-archive/tree/master"

--- a/core-dev/repo
+++ b/core-dev/repo
@@ -1,0 +1,1 @@
+upstream: "https://github.com/coq/opam-coq-archive/tree/master"

--- a/extra-dev/repo
+++ b/extra-dev/repo
@@ -1,2 +1,3 @@
+opam-version: "1.2"
 upstream: "https://github.com/coq/opam-coq-archive/tree/master"
 browse: "https://coq.inria.fr/opam/www/"

--- a/extra-dev/repo
+++ b/extra-dev/repo
@@ -1,0 +1,2 @@
+upstream: "https://github.com/coq/opam-coq-archive/tree/master"
+browse: "https://coq.inria.fr/opam/www/"

--- a/released/repo
+++ b/released/repo
@@ -1,2 +1,3 @@
+opam-version: "1.2"
 upstream: "https://github.com/coq/opam-coq-archive/tree/master"
 browse: "https://coq.inria.fr/opam/www/"


### PR DESCRIPTION
https://github.com/coq/opam-coq-archive/pull/254 only added this to `released`.

Is there a web UI for `core-dev`? https://coq.inria.fr/opam/www/ seems to not contain that repo.

Also, I think `opam-version: "1.2"` should be added to all three files. However, I'd first like to learn why @tchajed did not add that in #254.