### PR TITLE
Update to CompCert 3.2

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.2.0/descr
+++ b/released/packages/coq-compcert/coq-compcert.3.2.0/descr
@@ -1,0 +1,1 @@
+The CompCert C compiler.

--- a/released/packages/coq-compcert/coq-compcert.3.2.0/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Matej Košík <matej.kosik@inria.fr>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+		 "ia32-macosx" {os = "darwin"}
+		 "ia32-cygwin" {os = "cygwin"}
+		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+		 "-clightgen"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["rm" "%{bin}%/ccomp"]
+  ["rm" "%{bin}%/clightgen"]
+  ["rm" "-R" "%{lib}%/compcert"]
+  ["rm" "%{share}%/compcert.ini"]
+]
+depends: [
+  "coq"  {> "8.6.0" & < "8.8"~}
+  "menhir" {>= "20160303"}
+]

--- a/released/packages/coq-compcert/coq-compcert.3.2.0/url
+++ b/released/packages/coq-compcert/coq-compcert.3.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/AbsInt/CompCert/archive/v3.2.tar.gz"
+checksum: "f503af99aa0c6c8919b7e3f1a98ec64d"


### PR DESCRIPTION
See https://github.com/AbsInt/CompCert/blob/v3.2/Changelog
for info about changes.

CompCert 3.2 doesn't support Coq 8.6.0.