### PR TITLE
Q*cert release 1.0.6 (bug fix)

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.1.0.6/descr
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/descr
@@ -1,0 +1,1 @@
+A platform for implementing and verifying query compilers

--- a/released/packages/coq-qcert/coq-qcert.1.0.6/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "coq" {>= "8.7.2"}
+]

--- a/released/packages/coq-qcert/coq-qcert.1.0.6/url
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/url
@@ -1,0 +1,2 @@
+http: "https://github.com/querycert/qcert/archive/v1.0.6.tar.gz"
+checksum: "3ae70334db76c8a994d98ee5a6970fd4"


### PR DESCRIPTION
- Fixes bug in code generation for JavaScript backend.
- New IL (NNRC imperative).
