### PR TITLE
Make CompCert 3.2.0 compatible with Coq 8.7.2.

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.2.0/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.2.0/opam
@@ -7,10 +7,10 @@ bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
 build: [
   ["./configure" "ia32-linux" {os = "linux"}
-		 "ia32-macosx" {os = "darwin"}
-		 "ia32-cygwin" {os = "cygwin"}
-		 "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
-		 "-clightgen"]
+  "ia32-macosx" {os = "darwin"}
+  "ia32-cygwin" {os = "cygwin"}
+  "-bindir" "%{bin}%" "-libdir" "%{lib}%/compcert"
+  "-clightgen" "-ignore-coq-version"]
   [make "-j%{jobs}%"]
 ]
 install: [
@@ -23,6 +23,6 @@ remove: [
   ["rm" "%{share}%/compcert.ini"]
 ]
 depends: [
-  "coq"  {> "8.6.0" & < "8.8~"}
-  "menhir" {>= "20160303"}
+  "coq"  {> "8.6.0" & <= "8.7.2"}
+  "menhir" {>= "20161201"}
 ]


### PR DESCRIPTION
The modification is based on the discussion on this thread: https://github.com/AbsInt/CompCert/issues/223

It tightens the OPAM dependencies. And in the meantime, it asks CompCert's `configure` checker to ignore Coq version because OPAM has done the checking already.

Note that this is the second preferred approach suggested in the thread. I choose this one because I'm not sure how to carry out the first approach.