### PR TITLE
Initial JsAst release

### DIFF
--- a/released/packages/coq-jsast/coq-jsast.1.0.7/descr
+++ b/released/packages/coq-jsast/coq-jsast.1.0.7/descr
@@ -1,0 +1,1 @@
+A minimal JavaScript syntax tree carved out of the JsCert project.

--- a/released/packages/coq-jsast/coq-jsast.1.0.7/opam
+++ b/released/packages/coq-jsast/coq-jsast.1.0.7/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://github.com/querycert/jsast/tree/JsAst"
+dev-repo: "https://github.com/querycert/jsast/tree/JsAst"
+bug-reports: "https://github.com/querycert/jsast/issues"
+authors: [ "Jerome Simeon" ]
+license: "BSD-2-Clause"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/JsAst"]
+depends: [
+  "coq" {> "8.7.1" & <= "8.7.2"}
+  "coq-flocq" {>= "2.6.0"}
+]

--- a/released/packages/coq-jsast/coq-jsast.1.0.7/url
+++ b/released/packages/coq-jsast/coq-jsast.1.0.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/querycert/jsast/archive/v1.0.7.tar.gz"
+checksum: "cae64f4a5cdc9b8f39f772376179b6e3"


### PR DESCRIPTION
This contains a minimalistic JavaScript AST in Coq, based on JsCert, but which works for recent Coq versions. Contains some additional fixes to Floating point numbers in JsNumber module compared to the initial JsCert implementation.