### PR TITLE
Packaging label

### DIFF
--- a/released/packages/coq-label/coq-label.1.0.0/descr
+++ b/released/packages/coq-label/coq-label.1.0.0/descr
@@ -1,0 +1,1 @@
+'label' is a Coq plugin for referring to Propositional hypotheses by their type

--- a/released/packages/coq-label/coq-label.1.0.0/opam
+++ b/released/packages/coq-label/coq-label.1.0.0/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "pierre-evariste.dagand@lip6.fr"
+homepage: "https://github.com/pedagand/coq-label"
+dev-repo: "https://github.com/pedagand/coq-label.git"
+bug-reports: "https://github.com/pedagand/coq-label/issues"
+authors: ["Pierre-Évariste Dagand" "Théo Zimmermann" "Pierre-Marie Pédrot"]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Label"]
+depends: [
+  "coq" {>= "8.7"}
+]

--- a/released/packages/coq-label/coq-label.1.0.0/url
+++ b/released/packages/coq-label/coq-label.1.0.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/pedagand/coq-label/releases/download/v.1.0.0/coq-label-1.0.0.tar.gz"
+http: "https://github.com/pedagand/coq-label/releases/download/v1.0.0/coq-label-1.0.0.tar.gz"
 checksum: "cfb444d17f4a99a7a6cbde790c3d6fc3"

--- a/released/packages/coq-label/coq-label.1.0.0/url
+++ b/released/packages/coq-label/coq-label.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/pedagand/coq-label/releases/download/v.1.0.0/coq-label-1.0.0.tar.gz"
+checksum: "cfb444d17f4a99a7a6cbde790c3d6fc3"

--- a/released/packages/coq-label/coq-label.1.0.0/url
+++ b/released/packages/coq-label/coq-label.1.0.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/pedagand/coq-label/releases/download/v1.0.0/coq-label-1.0.0.tar.gz"
-checksum: "cfb444d17f4a99a7a6cbde790c3d6fc3"
+checksum: "3ae47300d7985cf2ddb0ba87354d061c"


### PR DESCRIPTION
As per @mattam82 [request](https://github.com/pedagand/coq-label/issues/2), this is 'label' (previously called "cortouche").