### PR TITLE
Q*cert release 1.0.7

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.1.0.7/descr
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/descr
@@ -1,0 +1,1 @@
+Verified compiler for data-centric languages

--- a/released/packages/coq-qcert/coq-qcert.1.0.7/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "coq" {>= "8.7.2"}
+  "coq-flocq" {>= "2.6.0"}
+  "coq-jsast" {>= "1.0.7"}
+]

--- a/released/packages/coq-qcert/coq-qcert.1.0.7/url
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/querycert/qcert/archive/v1.0.7.tar.gz"
+checksum: "36fd7cda0fae7887d8c17bb4822e599b"


### PR DESCRIPTION
- Add native support for floating points in data model, using flocq
- Add JavaScript AST support
- Add imperative intermediate representation (NNRCimp)
- Bug fixes to runtime and query runners
