### PR TITLE
Update URL for people relying on Equations's 8.6 dev package

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.8.6.dev/url
+++ b/extra-dev/packages/coq-equations/coq-equations.8.6.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/mattam82/Coq-Equations#master"
+git: "https://github.com/mattam82/Coq-Equations#8.6"


### PR DESCRIPTION
Master is now for the current Coq