### PR TITLE
Coq-stdpp compiles under Coq 8.8.0

### DIFF
--- a/released/packages/coq-stdpp/coq-stdpp.1.1.0/opam
+++ b/released/packages/coq-stdpp/coq-stdpp.1.1.0/opam
@@ -10,5 +10,5 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-rf" "%{lib}%/coq/user-contrib/stdpp"]
 depends: [
-  "coq" { (>= "8.6" & < "8.8~") | (= "dev") }
+  "coq" { (>= "8.6" & < "8.9~") | (= "dev") }
 ]


### PR DESCRIPTION
also the opam file from `opam source coq-stdpp` also accept coq.8.8 : `< coq.8.9~`