### PR TITLE
Release 0.28 of coq-ott package

### DIFF
--- a/released/packages/coq-ott/coq-ott.0.28/descr
+++ b/released/packages/coq-ott/coq-ott.0.28/descr
@@ -1,0 +1,1 @@
+Auxiliary library for Ott, a tool for writing definitions of programming languages and calculi

--- a/released/packages/coq-ott/coq-ott.0.28/opam
+++ b/released/packages/coq-ott/coq-ott.0.28/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+authors: [ "Peter Sewell" "Francesco Zappa Nardelli" "Scott Owens" ]
+
+homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
+dev-repo: "https://github.com/ott-lang/ott.git"
+bug-reports: "https://github.com/ott-lang/ott/issues"
+license: "part BSD3, part LGPL 2.1"
+
+build: [ make "-j%{jobs}%" "-C" "coq" ]
+install: [ make "-C" "coq" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
+depends: [ "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~") | (>= "8.8" & < "8.9~")} ]
+
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:abstract syntax"
+  "date:2018-04-24"
+]

--- a/released/packages/coq-ott/coq-ott.0.28/url
+++ b/released/packages/coq-ott/coq-ott.0.28/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/ott-lang/ott/archive/0.28.tar.gz"
+checksum: "42c76a821b8ba1528f6b99025cc6f2b0"


### PR DESCRIPTION
New version of the coq-ott package to complement a new release of the Ott tool; the package now supports Coq 8.8.