### PR TITLE
Fix fiat crypto install

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [make "-j%{jobs}%"]
 install: [make "install"]
-remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Fiat"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "coq" {= "8.6.dev"}
 ]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
@@ -9,9 +9,12 @@ maintainer: "Matej Košík <matej.kosik@inria.fr>"
 homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
-build: [make "-j%{jobs}%"]
+build: [
+  ["git" "submodule" "update" "--init" "--recursive"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display"]
+]
 install: [make "install"]
-remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Fiat"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "coq" {= "8.7.dev"}
 ]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "selected-specific-display"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "selected-specific-display"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]


### PR DESCRIPTION
This is on top of #318 and will not build until we merge https://github.com/mit-plv/fiat-crypto/pull/360.  However, once these three PRs are merged, fiat-crypto should build again on opam.