### PR TITLE
Make fiat-crypto depend on bignums

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
@@ -17,5 +17,6 @@ install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "coq" {= "8.7.dev"}
+  "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -17,5 +17,6 @@ install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "coq" {= "dev"}
+  "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"


### PR DESCRIPTION
It's currently required for the coqprime-all target to work, which is
required for the install-coqprime target to work.