### PR TITLE
update link for coqprime-dev add thery as maintainer

### DIFF
--- a/extra-dev/packages/coq-coqprime/coq-coqprime.dev/opam
+++ b/extra-dev/packages/coq-coqprime/coq-coqprime.dev/opam
@@ -1,16 +1,17 @@
-opam-version: "1.1"
+opam-version: "1.2"
 maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
-bug-reports: "https://gforge.inria.fr/tracker/?func=add&group_id=163&atid=733"
-license: "MIT"
+bug-reports: "http://coqprime.gforge.inria.fr/"
+license: "LGPL"
 build: [
   ["./configure.sh"]
-  [make "-j%{jobs}%"]
-  [make "install"]
+  ["make" "-j%{jobs}%"]
+  ["make" "install"]
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqprime"]
 depends: [
-  "coq" {>= "8.5~"}
+  "coq" {>= "8.8~"}
+  "coq-bignums"
 ]
 
 

--- a/extra-dev/packages/coq-coqprime/coq-coqprime.dev/url
+++ b/extra-dev/packages/coq-coqprime/coq-coqprime.dev/url
@@ -1,1 +1,3 @@
-http: "https://gforge.inria.fr/frs/download.php/file/35520/coqprime_8.5b.zip"
+http: "https://github.com/thery/coqprime/archive/v8.8.zip"
+checksum: "3430856778d10abe378fbdd385ac834d"
+

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.2/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.2/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: ""
+maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
 bug-reports: "http://coqprime.gforge.inria.fr/"
 license: "LGPL"

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: ""
+maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
 bug-reports: "http://coqprime.gforge.inria.fr/"
 license: "LGPL"


### PR DESCRIPTION
@thery is the owner of the coq-prime repo, thus should be the maintainer.

`coqprime.dev` does not work if you use coq8.7+ as such, it is more interesting to put `coqprime.dev` as equal to `coqprime.1.0.3` sources.
