### PR TITLE
Fix the build command of math-classes.

### DIFF
--- a/extra-dev/packages/coq-math-classes/coq-math-classes.dev/opam
+++ b/extra-dev/packages/coq-math-classes/coq-math-classes.dev/opam
@@ -8,7 +8,10 @@ authors: [
   "Robbert Krebbers"
 ]
 license: "Public Domain"
-build: [make "-j%{jobs}%"]
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
 bug-reports: "https://github.com/math-classes/math-classes/issues"
 dev-repo: "https://github.com/math-classes/math-classes.git"
 install: [make "install"]


### PR DESCRIPTION
We call configure to regenerate the makefile.

See coq/coq#7550.