### PR TITLE
Package coq-cfml.20180523d

### DIFF
--- a/packages/coq-cfml/coq-cfml.20180523d/descr
+++ b/packages/coq-cfml/coq-cfml.20180523d/descr
@@ -1,0 +1,14 @@
+A tool for proving OCaml programs in Separation Logic
+
+CFML is a tool for carrying out proofs of correctness of OCaml programs with
+respect to specifications expressed in higher-order Separation Logic.
+
+CFML consists of two parts:
+
+- a tool, implemented in OCaml, parses OCaml source code and generates Coq
+  files that contain characteristic formulae, that is, logical descriptions
+  of the behavior of the OCaml code.
+
+- a Coq library exports definitions, lemmas, and tactics that are used
+  to reason inside Coq about the code. In short, these tactics allow
+  the reasoning rules of Separation Logic to be applied to the OCaml code.

--- a/packages/coq-cfml/coq-cfml.20180523d/opam
+++ b/packages/coq-cfml/coq-cfml.20180523d/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "armael.gueneau@inria.fr"
+authors: "Arthur Charguéraud <arthur.chargueraud@inria.fr>"
+homepage: "https://gitlab.inria.fr/charguer/cfml"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml/issues"
+license: "CeCILL-B"
+dev-repo: "https://gitlab.inria.fr/charguer/cfml.git"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlbuild" {build}
+  "pprint"
+  "coq" {= "8.6"}
+  "coq-tlc" {>= "20161010"}
+]

--- a/packages/coq-cfml/coq-cfml.20180523d/url
+++ b/packages/coq-cfml/coq-cfml.20180523d/url
@@ -1,0 +1,3 @@
+http:
+  "https://gitlab.inria.fr/charguer/cfml/repository/20180523d/archive.tar.gz"
+checksum: "34f8e891717df8188a105d3d3e482400"


### PR DESCRIPTION
### `coq-cfml.20180523d`

A tool for proving OCaml programs in Separation Logic

CFML is a tool for carrying out proofs of correctness of OCaml programs with
respect to specifications expressed in higher-order Separation Logic.

CFML consists of two parts:

- a tool, implemented in OCaml, parses OCaml source code and generates Coq
  files that contain characteristic formulae, that is, logical descriptions
  of the behavior of the OCaml code.

- a Coq library exports definitions, lemmas, and tactics that are used
  to reason inside Coq about the code. In short, these tactics allow
  the reasoning rules of Separation Logic to be applied to the OCaml code.



---
* Homepage: https://gitlab.inria.fr/charguer/cfml
* Source repo: https://gitlab.inria.fr/charguer/cfml.git
* Bug tracker: https://gitlab.inria.fr/charguer/cfml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5