### PR TITLE
Package coq-cfml.20180525

### DIFF
--- a/released/packages/coq-cfml/coq-cfml.20180525/descr
+++ b/released/packages/coq-cfml/coq-cfml.20180525/descr
@@ -1,0 +1,14 @@
+A tool for proving OCaml programs in Separation Logic
+
+CFML is a tool for carrying out proofs of correctness of OCaml programs with
+respect to specifications expressed in higher-order Separation Logic.
+
+CFML consists of two parts:
+
+- a tool, implemented in OCaml, parses OCaml source code and generates Coq
+  files that contain characteristic formulae, that is, logical descriptions
+  of the behavior of the OCaml code.
+
+- a Coq library exports definitions, lemmas, and tactics that are used
+  to reason inside Coq about the code. In short, these tactics allow
+  the reasoning rules of Separation Logic to be applied to the OCaml code.

--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "armael.gueneau@inria.fr"
+authors: "Arthur Charguéraud <arthur.chargueraud@inria.fr>"
+homepage: "https://gitlab.inria.fr/charguer/cfml"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml/issues"
+license: "CeCILL-B"
+dev-repo: "https://gitlab.inria.fr/charguer/cfml.git"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "ocamlbuild" {build}
+  "pprint"
+  "base-bytes"
+  "coq" {>= "8.6"}
+  "coq-tlc" {>= "20171206"}
+]

--- a/released/packages/coq-cfml/coq-cfml.20180525/url
+++ b/released/packages/coq-cfml/coq-cfml.20180525/url
@@ -1,0 +1,3 @@
+http:
+  "https://gitlab.inria.fr/charguer/cfml/repository/20180525/archive.tar.gz"
+checksum: "84981a5ed6dcd6d4bfc355a263fdc5bd"


### PR DESCRIPTION
### `coq-cfml.20180525`

A tool for proving OCaml programs in Separation Logic

CFML is a tool for carrying out proofs of correctness of OCaml programs with
respect to specifications expressed in higher-order Separation Logic.

CFML consists of two parts:

- a tool, implemented in OCaml, parses OCaml source code and generates Coq
  files that contain characteristic formulae, that is, logical descriptions
  of the behavior of the OCaml code.

- a Coq library exports definitions, lemmas, and tactics that are used
  to reason inside Coq about the code. In short, these tactics allow
  the reasoning rules of Separation Logic to be applied to the OCaml code.



---
* Homepage: https://gitlab.inria.fr/charguer/cfml
* Source repo: https://gitlab.inria.fr/charguer/cfml.git
* Bug tracker: https://gitlab.inria.fr/charguer/cfml/issues

---

:camel: Pull-request generated by opam-publish v0.3.5