### PR TITLE
Package coq-menhirlib.20180530

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20180530/descr
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20180530/descr
@@ -1,0 +1,8 @@
+A support library for verified Coq parsers produced by Menhir
+
+The Menhir parser generator, in --coq mode, can produce Coq parsers.
+These parsers must be linked against this library, which provides
+both an interpreter (which allows running the generated parser) and
+a validator (which allows verifying, at parser construction time,
+that the generated parser is correct and complete with respect to
+the grammar).

--- a/released/packages/coq-menhirlib/coq-menhirlib.20180530/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20180530/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer: "francois.pottier@inria.fr"
+authors: "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+dev-repo: "https://gitlab.inria.fr/fpottier/coq-menhirlib.git"
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "coq" {>= "8.6"}
+]
+depopts: "menhir"
+conflicts: [
+  "menhir" {< "20180530"}
+]

--- a/released/packages/coq-menhirlib/coq-menhirlib.20180530/url
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20180530/url
@@ -1,0 +1,3 @@
+http:
+  "https://gitlab.inria.fr/fpottier/coq-menhirlib/repository/20180530/archive.tar.gz"
+checksum: "1c88edd2a6650c270ebd46247179363c"


### PR DESCRIPTION
### `coq-menhirlib.20180530`

A support library for verified Coq parsers produced by Menhir

The Menhir parser generator, in --coq mode, can produce Coq parsers.
These parsers must be linked against this library, which provides
both an interpreter (which allows running the generated parser) and
a validator (which allows verifying, at parser construction time,
that the generated parser is correct and complete with respect to
the grammar).



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: https://gitlab.inria.fr/fpottier/coq-menhirlib.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---

:camel: Pull-request generated by opam-publish v0.3.5