### PR TITLE
Update GeoCoq dependencies

### DIFF
--- a/extra-dev/packages/coq-geocoq/coq-geocoq.dev/opam
+++ b/extra-dev/packages/coq-geocoq/coq-geocoq.dev/opam
@@ -13,5 +13,6 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/GeoCoq"]
 depends: [
-  "coq" {>= "8.5pl3"}
+  "coq" {>= "8.6.2"}
+  "coq-mathcomp-field" {>= "1.6.4"}
 ]


### PR DESCRIPTION
GeoCoq is not compatible with 8.5 anymore. We also used coq-mathcomp-field library for building a model of the axioms.