### PR TITLE
coq-intuitionistic-nuprl: fix download link

### DIFF
--- a/released/packages/coq-intuitionistic-nuprl/coq-intuitionistic-nuprl.8.5.0/url
+++ b/released/packages/coq-intuitionistic-nuprl/coq-intuitionistic-nuprl.8.5.0/url
@@ -1,2 +1,2 @@
-http: "https://github.com/coq-contribs/abp/archive/v8.5.0.tar.gz"
-checksum: "9df2a01467f74d04c7eaeec6ebf6d2d9"
+http: "https://github.com/coq-contribs/intuitionistic-nuprl/archive/v8.5.0.tar.gz"
+checksum: "beb2615ee0374f25190ca18c19bc95c8"


### PR DESCRIPTION
The Ruby script to find all the contribs with such a broken link:
```ruby
Dir.glob("released/packages/*/*/url") do |url|
  url_content = File.read(url)
  contrib_name_match = /coq-contribs\/([^\/]+)\//.match(url_content)
  if contrib_name_match
    contrib_name_url = contrib_name_match[1]
    contrib_name_package = /packages\/coq-([^\/]+)\//.match(url)[1]
    if contrib_name_url != contrib_name_package
      p contrib_name_package
    end
  end
end
```