### PR TITLE
Release Procrastination v1.1

### DIFF
--- a/released/packages/coq-procrastination/coq-procrastination.1.1/descr
+++ b/released/packages/coq-procrastination/coq-procrastination.1.1/descr
@@ -1,0 +1,1 @@
+A small library for collecting side conditions and deferring their proof

--- a/released/packages/coq-procrastination/coq-procrastination.1.1/opam
+++ b/released/packages/coq-procrastination/coq-procrastination.1.1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "armael.gueneau@inria.fr"
+authors: [
+  "Armaël Guéneau <armael.gueneau@inria.fr>"
+]
+homepage: "https://github.com/Armael/coq-procrastination"
+dev-repo: "https://github.com/Armael/coq-procrastination.git"
+bug-reports: "https://github.com/Armael/coq-procrastination/issues"
+license: "LGPL"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Procrastination"]
+depends: [
+  "coq" {>= "8.5"}
+]

--- a/released/packages/coq-procrastination/coq-procrastination.1.1/url
+++ b/released/packages/coq-procrastination/coq-procrastination.1.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Armael/coq-procrastination/archive/v1.1.zip"
+checksum: "3fe0fd825ff25d3c33e0f8cf9853c05e"


### PR DESCRIPTION
This is a bugfix release.

### Changes:

- Fix a bug where `end defer` would not work when deferring in Type
- Make `Group` opaque to avoid having its contents being instantiated by e.g.
  `eauto`.
