### PR TITLE
Template Coq release for Coq 8.8

### DIFF
--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/descr
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/descr
@@ -1,0 +1,17 @@
+A quoting and unquoting library for Coq in Coq.
+
+Template Coq is a quoting library for Coq. It takes Coq terms and
+constructs a representation of their syntax tree as a Coq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Coq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaCoq/MTac.
+- A partial type-checker for the Calculus of Inductive Constructions,
+  runable as a plugin.
+- Example plugins built on top of this.

--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/descr
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/descr
@@ -13,5 +13,5 @@ Template Coq includes:
   checker, and inserting them in the global environment, in the style of
   MetaCoq/MTac.
 - A partial type-checker for the Calculus of Inductive Constructions,
-  runable as a plugin.
+  runnable as a plugin.
 - Example plugins built on top of this.

--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/opam
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2" 
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://template-coq.github.io/template-coq"
+dev-repo: "https://github.com/Template-Coq/template-coq.git#coq-8.8"
+bug-reports: "https://github.com/Template-Coq/template-coq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Template"]
+depends: [
+  "coq" {>= "8.8" & < "8.9~"}
+]

--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/opam
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/opam
@@ -1,4 +1,5 @@
-opam-version: "1.2" 
+opam-version: "1.2"
+version: "2.1~beta"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://template-coq.github.io/template-coq"
 dev-repo: "https://github.com/Template-Coq/template-coq.git#coq-8.8"

--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/url
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Template-Coq/template-coq/archive/v2.0-beta.tar.gz"
+checksum: "a65347f987fca3d21011a02aff0ee179"

--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta/url
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta/url
@@ -1,2 +1,2 @@
-http: "https://github.com/Template-Coq/template-coq/archive/v2.0-beta.tar.gz"
-checksum: "a65347f987fca3d21011a02aff0ee179"
+http: "https://github.com/Template-Coq/template-coq/archive/v2.1-beta.tar.gz"
+checksum: "b17f40953793fb53ac81f85bc8ec054d"


### PR DESCRIPTION
Initial release of [Template Coq](https://template-coq.github.io/template-coq/) for Coq 8.8 reflecting the current status of the 8.8 branch