### PR TITLE
fcsl-pcm is compartible with mathcomp-ssreflect.dev

### DIFF
--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.0.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.0.0/opam
@@ -12,7 +12,7 @@ install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/fcsl'" ]
 depends: [
   "coq" {>= "8.7" & < "8.9~"}
-  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.8~"}
+  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.8~" | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
We expect this to hold in the future. If ssreflect.dev breaks fcsl-pcm
then we will release another (compatible) version of fcsl-pcm