### PR TITLE
Package coq-simple-io.0.2

### DIFF
--- a/released/packages/coq-simple-io/coq-simple-io.0.2/descr
+++ b/released/packages/coq-simple-io/coq-simple-io.0.2/descr
@@ -1,0 +1,10 @@
+IO monad for Coq
+
+This library provides tools to implement IO programs directly in Coq, in a
+similar style to Haskell. Facilities for formal verification are not included.
+
+IO is defined as a parameter with a purely functional interface in Coq,
+to be extracted to OCaml.
+
+Some wrappers for the basic types and functions in the OCaml Pervasives module
+are provided. Users are free to define their own APIs on top of this IO type.

--- a/released/packages/coq-simple-io/coq-simple-io.0.2/opam
+++ b/released/packages/coq-simple-io/coq-simple-io.0.2/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+maintainer: "Li-yao Xia <lysxia@gmail.com>"
+authors: "Li-yao Xia"
+homepage: "https://github.com/Lysxia/coq-simple-io"
+bug-reports: "https://github.com/Lysxia/coq-simple-io/issues"
+license: "MIT"
+dev-repo: "https://github.com/Lysxia/coq-simple-io.git"
+build: [make "build"]
+install: [make "install"]
+build-test: [make "test"]
+remove: [make "uninstall"]
+depends: "coq"
+tags: [
+  "date:2018-07-28"
+  "logpath:SimpleIO"
+  "keyword:extraction"
+  "keyword:effects"
+]

--- a/released/packages/coq-simple-io/coq-simple-io.0.2/url
+++ b/released/packages/coq-simple-io/coq-simple-io.0.2/url
@@ -1,0 +1,2 @@
+http: "https://github.com/Lysxia/coq-simple-io/archive/0.2.tar.gz"
+checksum: "3198cd391703efcd51f225ec2beb7426"


### PR DESCRIPTION
### `coq-simple-io.0.2`

IO monad for Coq



---
* Homepage: https://github.com/Lysxia/coq-simple-io
* Source repo: https://github.com/Lysxia/coq-simple-io.git
* Bug tracker: https://github.com/Lysxia/coq-simple-io/issues

---
### opam-lint failures
- **WARNING** 97 long description unspecified

---

:camel: Pull-request generated by opam-publish v0.3.5