### PR TITLE
[paramcoq] 1.0.9 release fixing 1.0.8 release

### DIFF
--- a/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/descr
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/descr
@@ -1,0 +1,5 @@
+Keller, Chantal, and Marc Lasson. “Parametricity in an Impredicative Sort.” Computer Science Logic, September 27, 2012. https://doi.org/10.4230/LIPIcs.CSL.2012.399.
+
+Originally implemented by the above authors.
+
+

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "abhishek.anand.iitg@gmail.com"
+homepage: "https://github.com/aa755/paramcoq"
+dev-repo: "https://github.com/aa755/paramcoq"
+authors: ["Chantal Keller" "Marc Lasson"]
+bug-reports: "https://github.com/aa755/paramcoq/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Param"]
+depends: [
+  "coq" {>= "8.8" & < "8.9~"}
+]

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/url
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.0.9/url
@@ -1,0 +1,2 @@
+http: "https://github.com/aa755/paramcoq/archive/v1.0.9.tar.gz"
+checksum: "7c46df48ebf0bda825ebf369dc960445"


### PR DESCRIPTION
This one does compile with coq 8.8 and includes the qualified option