### PR TITLE
(release) Q*cert 1.2.0 with Coq 8.8.1 and improved JavaScript backend

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.1.2.0/descr
+++ b/released/packages/coq-qcert/coq-qcert.1.2.0/descr
@@ -1,0 +1,1 @@
+Verified compiler for data-centric languages

--- a/released/packages/coq-qcert/coq-qcert.1.2.0/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.2.0/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "coq" {>= "8.8.1"}
+  "coq-flocq" {>= "2.6.1" & < "3.0~"}
+  "coq-jsast" {>= "1.0.8"}
+]

--- a/released/packages/coq-qcert/coq-qcert.1.2.0/url
+++ b/released/packages/coq-qcert/coq-qcert.1.2.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/querycert/qcert/archive/v1.2.0.tar.gz"
+checksum: "2908bc90f9f175da3a7f5bcce26e0f0e"


### PR DESCRIPTION
- Support for Coq 8.8.1
- New JavaScript backend: more of the compilation pipeline is proven correct using imperative intermediate representations ; Lower level optimizations
- Bug fixes (Wrong type for float comparisons in infer with sub typing; Wrong error message when creating brand model)
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>