### PR TITLE
Update the various versions of HoTT for a bit more consistency

### DIFF
--- a/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
@@ -3,7 +3,7 @@ authors: ["The Coq-HoTT Development Team"]
 dev-repo: "https://github.com/HoTT/HoTT.git"
 maintainer: "Matej Košík <matej.kosik@inria.fr>"
 homepage: "http://homotopytypetheory.org/"
-bug-reports: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"
 build: [
   ["./autogen.sh"]

--- a/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.6.dev/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "https://github.com/HoTT/HoTT.git"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "Matej Košík <matej.kosik@inria.fr>"
 homepage: "http://homotopytypetheory.org/"
-bug-reports: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"
 build: [
   ["rm" ".gitmodules"]
@@ -13,7 +13,7 @@ install: ["%{make}%" "install"]
 remove: ["rm" "-r" "-f" "%{share}%/hott"]
 depends: [
   "ocamlfind" {build}
-  "coq" {= "8.7.dev"}
+  "coq" { >= "8.7" & < "8.8" }
 ]
-authors: ["The UniMath Development Team"]
-dev-repo: "https://github.com/ejgallego/HoTT.git"
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/url
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/ejgallego/HoTT.git#ocaml.4.02.3"
+git: "https://github.com/HoTT/HoTT.git#V8.7"

--- a/extra-dev/packages/coq-hott/coq-hott.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"

--- a/extra-dev/packages/coq-hott/coq-hott.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.dev/opam
@@ -1,7 +1,7 @@
 opam-version: "1.2"
 maintainer: "Matej Košík <matej.kosik@inria.fr>"
 homepage: "http://homotopytypetheory.org/"
-bug-reports: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD 2-clause"
 build: [
   ["rm" ".gitmodules"]
@@ -15,5 +15,5 @@ depends: [
   "ocamlfind" {build}
   "coq" {= "dev"}
 ]
-authors: ["The UniMath Development Team"]
-dev-repo: "https://github.com/ejgallego/HoTT.git"
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "https://github.com/HoTT/HoTT.git"


### PR DESCRIPTION
I'm not sure why 8.7.dev was pointing at @ejgallego's repo.

I've copied the author name from the 8.6.dev file; I'm not sure it's
right, but UniMath is definitely wrong.

I've updated the issue tracker.

I'm not sure why the build script is different for the .dev version than
for the other versions, so I haven't touched it.

I'll create a v8.8 version once we make a V8.8 tag.