### PR TITLE
Add coq-hott.8.8.dev package

### DIFF
--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/descr
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/descr
@@ -1,0 +1,1 @@
+The Homotopy Type Theory library.

--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD 2-clause"
+build: [
+  ["rm" ".gitmodules"]
+  ["bash" "-c" "./autogen.sh || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  ["%{make}%" "-j%{jobs}%"]
+]
+install: ["%{make}%" "install"]
+remove: ["rm" "-r" "-f" "%{share}%/hott"]
+depends: [
+  "ocamlfind" {build}
+  "coq" { >= "8.8" & < "8.9" }
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/url
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/HoTT/HoTT.git#V8.8"


### PR DESCRIPTION
Now that HoTT has a V8.8 tag, we can do this easily.