### PR TITLE
Set libdir for flocq.

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.2.2.0/opam
+++ b/released/packages/coq-flocq/coq-flocq.2.2.0/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]

--- a/released/packages/coq-flocq/coq-flocq.2.3.0/opam
+++ b/released/packages/coq-flocq/coq-flocq.2.3.0/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]

--- a/released/packages/coq-flocq/coq-flocq.2.4.0/opam
+++ b/released/packages/coq-flocq/coq-flocq.2.4.0/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]

--- a/released/packages/coq-flocq/coq-flocq.2.5.2/opam
+++ b/released/packages/coq-flocq/coq-flocq.2.5.2/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]

--- a/released/packages/coq-flocq/coq-flocq.2.6.1/opam
+++ b/released/packages/coq-flocq/coq-flocq.2.6.1/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]

--- a/released/packages/coq-flocq/coq-flocq.3.0.0/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.0.0/opam
@@ -5,7 +5,7 @@ dev-repo: "https://gitlab.inria.fr/flocq/flocq"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL 3"
 build: [
-  ["./configure"]
+  ["./configure" "--libdir" "%{lib}%/coq/user-contrib/Flocq"]
   ["./remake" "-j%{jobs}%"]
 ]
 install: ["./remake" "install"]


### PR DESCRIPTION
Apparently the default installation directory is not
```$(coqc -where)/user-contrib/Flocq``` as stated on the site but
/usr/local/lib. I tested the configure script of all the versions
and they all seem to default to this directory.

If the libdir is not set the uninstall also will not work correctly.