### PR TITLE
Add coq-bellantonicook package

### DIFF
--- a/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/descr
+++ b/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/descr
@@ -1,0 +1,1 @@
+Deep embedding of Bellantoni and Cook's syntactic characterization of polytime functions

--- a/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/opam
+++ b/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "coq-bellantonicook"
+version: "1.0.0"
+maintainer: "David Nowak <david.nowak@univ-lille.fr>"
+authors: [
+  "Sylvain Heraud"
+  "David Nowak"
+]
+homepage: "https://github.com/davidnowak/bellantonicook"
+dev-repo: "https://github.com/davidnowak/bellantonicook.git"
+bug-reports: "https://github.com/davidnowak/bellantonicook/issues"
+license: "CeCILL-A"
+build: [make]
+build-doc: [make "html"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "coq" {>= "8.6.0" & < "8.9.0~"}
+]
+tags: [
+  "category:CS/Algo/Complexity"
+  "keyword:implicit complexity"
+  "keyword:polynomial time"
+  "logpath:BellantoniCook"
+  "date:2018-09-06"
+]

--- a/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/url
+++ b/released/packages/coq-bellantonicook/coq-bellantonicook.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/davidnowak/bellantonicook/archive/v1.0.0.tar.gz"
+checksum: "55be4b1d1eeeba344faa5212adc1dc80"


### PR DESCRIPTION
Add a new package providing a deep embedding of Bellantoni and Cook's syntactic characterization of polytime functions in Coq