### PR TITLE
add latest coq-hammer releases for 8.7 and 8.8

### DIFF
--- a/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/descr
+++ b/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/descr
@@ -1,0 +1,1 @@
+Automation for Dependent Type Theory

--- a/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL 2.1"
+
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+remove: [
+  ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
+  ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
+]
+depends: [ "coq" {>= "8.7" & < "8.8~"} ]
+
+tags: [ "keyword:automation"
+	"category:Misc/Coq Extensions"
+	"date:2018-04-09" ]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]

--- a/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/url
+++ b/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/url
@@ -1,0 +1,2 @@
+http: "https://github.com/lukaszcz/coqhammer/archive/v1.0.8-coq8.7.tar.gz"
+checksum: "01267d1ade74dd431ba15cee21c87217"

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/descr
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/descr
@@ -1,0 +1,1 @@
+Automation for Dependent Type Theory

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL 2.1"
+
+build: [ make "-j%{jobs}%" ]
+build-test: [ make "tests" ]
+install: [ make "install" ]
+remove: [
+  ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
+  ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
+]
+depends: [ "coq" {= "8.8.0"} ]
+
+tags: [ "keyword:automation"
+	"category:Misc/Coq Extensions"
+	"date:2018-08-22" ]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/url
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/lukaszcz/coqhammer/archive/v1.0.9-coq8.8.0.tar.gz"
+checksum: "b39e959d96bf366773424e71f21b69e1"

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/descr
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/descr
@@ -1,0 +1,1 @@
+Automation for Dependent Type Theory

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL 2.1"
+
+build: [ make "-j%{jobs}%" ]
+build-test: [ make "tests" ]
+install: [ make "install" ]
+remove: [
+  ["sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Hammer'"]
+  ["sh" "-c" "rm -f '%{bin}%/predict' '%{bin}%/htimeout'"]
+]
+depends: [ "coq" {>= "8.8.1" & < "8.9~"} ]
+
+tags: [ "keyword:automation"
+	"category:Misc/Coq Extensions"
+	"date:2018-08-22" ]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/url
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/lukaszcz/coqhammer/archive/v1.0.9-coq8.8.1.tar.gz"
+checksum: "525fffc2e9e07ec87e12ced8104c33b1"


### PR DESCRIPTION
CoqHammer now has regular GitHub releases. Due to plugin dependencies, releases are typically tied to a specific version of Coq. Here are packages for the latest releases for 8.7, 8.8.0, and 8.8.1.