### PR TITLE
Add coq-cecoa package

### DIFF
--- a/released/packages/coq-cecoa/coq-cecoa.1.0.0/descr
+++ b/released/packages/coq-cecoa/coq-cecoa.1.0.0/descr
@@ -1,0 +1,1 @@
+Implicit-complexity Coq library to prove that some programs are computable in polynomial time

--- a/released/packages/coq-cecoa/coq-cecoa.1.0.0/opam
+++ b/released/packages/coq-cecoa/coq-cecoa.1.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "coq-cecoa"
+version: "1.0.0"
+maintainer: "David Nowak <david.nowak@univ-lille.fr>"
+authors: [
+  "Hugo Férée"
+  "Samuel Hym"
+  "Micaela Mayero"
+  "Jean-Yves Moyen"
+  "David Nowak"
+]
+homepage: "https://github.com/davidnowak/cecoa"
+dev-repo: "https://github.com/davidnowak/cecoa.git"
+bug-reports: "https://github.com/davidnowak/cecoa/issues"
+license: "CeCILL-A"
+build: [make]
+build-doc: [make "html"]
+install: [make "install"]
+remove: [make "uninstall"]
+depends: [
+  "coq" {>= "8.6.0" & < "8.9.0~"}
+  "coq-bellantonicook"
+]
+tags: [
+  "category:CS/Algo/Complexity"
+  "keyword:implicit complexity"
+  "keyword:polynomial time"
+  "keyword:rewriting"
+  "logpath:Cecoa"
+  "date:2018-09-10"
+]

--- a/released/packages/coq-cecoa/coq-cecoa.1.0.0/url
+++ b/released/packages/coq-cecoa/coq-cecoa.1.0.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/davidnowak/cecoa/archive/v1.0.0.tar.gz"
+checksum: "123728805ad3e0a91c38d61f37d0b05d"


### PR DESCRIPTION
Add a new package providing an implicit-complexity library to write programs and prove that they are computable in polynomial time