### PR TITLE
Add coq-reglang package

### DIFF
--- a/released/packages/coq-reglang/coq-reglang.1/descr
+++ b/released/packages/coq-reglang/coq-reglang.1/descr
@@ -1,0 +1,6 @@
+Regular Language Representations in the Constructive Type Theory of Coq
+
+We verify translations between different representations of regular
+languages: various forms of automata (deterministic, nondeterministic,
+one-way, two-way), regular expressions, and the logic WS1S. We also
+show various decidability results and closure properties.

--- a/released/packages/coq-reglang/coq-reglang.1/opam
+++ b/released/packages/coq-reglang/coq-reglang.1/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+name: "coq-reglang"              
+version: "1.0"
+maintainer: "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
+
+homepage: "https://github.com/chdoc/coq-reglang"
+dev-repo: "https://github.com/chdoc/coq-reglang.git"
+bug-reports: "https://github.com/chdoc/coq-reglang/issues"
+license: "CeCILL-B"
+
+build: [ make "-j%{jobs}%" "-C" "theories" ]
+install: [ make "-C" "theories" "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/RegLang'" ]
+depends: [
+  "coq" {>= "8.6" & < "8.9~"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "1.8~"}
+]
+
+tags: [
+  "keyword:regular languages"
+  "keyword:regular expressions"
+  "keyword:finite automata"
+  "keyword:two-way automata"
+  "keyword:monadic second-order logic"
+  "category:Computer Science/Formal Languages Theory and Automata"
+]
+
+authors: [
+  "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
+  "Gert Smolka <>"
+]

--- a/released/packages/coq-reglang/coq-reglang.1/url
+++ b/released/packages/coq-reglang/coq-reglang.1/url
@@ -1,0 +1,2 @@
+http: "https://github.com/chdoc/coq-reglang/archive/v1.0.tar.gz"
+checksum: "3e4be5fe3ab7bbaaa73016d5e81a8193"


### PR DESCRIPTION
This is the Coq development accompanying our paper:
Christian Doczkal and Gert Smolka, Regular Language Representations in the Constructive Type Theory of Coq, J. Autom. Reason. - Special Issue on Milestones in Interactive Theorem Proving, Springer, 2018.