### PR TITLE
Fix uninstall of coq-cecoa which does not remove its folder

### DIFF
--- a/released/packages/coq-cecoa/coq-cecoa.1.0.0/opam
+++ b/released/packages/coq-cecoa/coq-cecoa.1.0.0/opam
@@ -16,7 +16,10 @@ license: "CeCILL-A"
 build: [make]
 build-doc: [make "html"]
 install: [make "install"]
-remove: [make "uninstall"]
+remove: [
+  [make "uninstall"]
+  ["rmdir" "%{lib}%/coq/user-contrib/Cecoa"]
+]
 depends: [
   "coq" {>= "8.6.0" & < "8.9.0~"}
   "coq-bellantonicook"


### PR DESCRIPTION
I do not know why but the uninstall script of `coq-cecoa` does not remove its folder in `user-contrib`, only the content of its folder: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-1.2.2/released/8.7.2/cecoa/1.0.0.html
Tested on my machine, this should fix the uninstall.