### PR TITLE
Lint Compcert 2.0.0

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.2.0.0/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.0.0/opam
@@ -1,4 +1,5 @@
-opam-version: "1.1"
+opam-version: "1.2"
+author: "Xavier Leroy <xavier.leroy@inria.fr>"
 maintainer: "thomas.braibant@gmail.com"
 homepage: "http://compcert.inria.fr/"
 dev-repo: "https://github.com/AbsInt/CompCert.git"


### PR DESCRIPTION
I only lint one version of CompCert so that the integration tests have the time to run. I fill the `author` field as in CompCert 3.3.0 package.