### PR TITLE
Fix Menhir version for CompCert 2.7.1

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.2.7.1/opam
+++ b/released/packages/coq-compcert/coq-compcert.2.7.1/opam
@@ -24,6 +24,6 @@ remove: [
 ]
 depends: [
   "coq" {>= "8.5.2" & < "8.6~"}
-  "menhir" {>= "20160303"}
+  "menhir" {>= "20160303" & < "20180530"}
 ]
 patches: "fix-coq-version.patch"


### PR DESCRIPTION
An output of the bug: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-1.2.2/released/8.5.3/compcert/2.7.1.html
Related to https://github.com/AbsInt/CompCert/issues/234