### PR TITLE
[mathcomp]: add dev-repo links

### DIFF
--- a/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-algebra"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
@@ -2,6 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/analysis"
 bug-reports: "https://github.com/math-comp/analysis/issues"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
 license: "CeCILL-C"
 authors: [
   "Reynald Affeldt"

--- a/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-character"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-field"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-fingroup"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -5,6 +5,7 @@ maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "http://www.cyrilcohen.fr"
 bug-reports: "Cyril Cohen <cyril.cohen@inria.fr>"
+dev-repo: "git+https://github.com/math-comp/finmap.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-odd-order"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/odd-order.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-real-closed"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/real-closed.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-solvable"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -3,8 +3,9 @@ name: "coq-mathcomp-ssreflect"
 version: "dev"
 maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
-homepage: "http://math-comp.github.io/math-comp/"
+homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]


### PR DESCRIPTION
This commit fixes the following issue:
```shell
$ opam pin add --dev-repo coq-mathcomp-ssreflect
[ERROR] "dev-repo" field missing in coq-mathcomp-ssreflect metadata, you'll need to specify the pinning location
```
for the mathcomp family of packages. At least for those that have clear
dev version. E.g. coq-mathcomp-grobner.dev is pinned to a Git tag, not a branch.
The commit also changes http to https for the homepage links.

If this is accepted I can also prepare PRs for the math-comp libraries' `opam` files.