### PR TITLE
Remove "git+" from "dev-repo" fields

### DIFF
--- a/extra-dev/packages/coq-coqprime/coq-coqprime.dev/opam
+++ b/extra-dev/packages/coq-coqprime/coq-coqprime.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
 bug-reports: "http://coqprime.gforge.inria.fr/"
-dev-repo: "git+https://github.com/thery/coqprime.git"
+dev-repo: "https://github.com/thery/coqprime.git"
 license: "LGPL"
 authors: ["Laurent Théry"]
 build: [

--- a/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/analysis"
 bug-reports: "https://github.com/math-comp/analysis/issues"
-dev-repo: "git+https://github.com/math-comp/analysis.git"
+dev-repo: "https://github.com/math-comp/analysis.git"
 license: "CeCILL-C"
 authors: [
   "Reynald Affeldt"

--- a/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "http://www.cyrilcohen.fr"
 bug-reports: "Cyril Cohen <cyril.cohen@inria.fr>"
-dev-repo: "git+https://github.com/math-comp/finmap.git"
+dev-repo: "https://github.com/math-comp/finmap.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.x.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.x.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/multinomials-ssr"
 bug-reports: "https://github.com/math-comp/multinomials-ssr/issues"
-dev-repo: "git+https://github.com/math-comp/multinomials.git"
+dev-repo: "https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [

--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/multinomials-ssr"
 bug-reports: "https://github.com/math-comp/multinomials-ssr/issues"
-dev-repo: "git+https://github.com/math-comp/multinomials.git"
+dev-repo: "https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [

--- a/extra-dev/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-odd-order/coq-mathcomp-odd-order.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/odd-order.git"
+dev-repo: "https://github.com/math-comp/odd-order.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/real-closed.git"
+dev-repo: "https://github.com/math-comp/real-closed.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -5,7 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "https://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
-dev-repo: "git+https://github.com/math-comp/math-comp.git"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]

--- a/extra-dev/packages/coq-ssr-elliptic-curves/coq-ssr-elliptic-curves.1.6.dev/opam
+++ b/extra-dev/packages/coq-ssr-elliptic-curves/coq-ssr-elliptic-curves.1.6.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/strub/elliptic-curves-ssr"
 bug-reports: "https://github.com/strub/elliptic-curves-ssr/issues"
-dev-repo: "git+https://github.com/strub/elliptic-curves-ssr.git"
+dev-repo: "https://github.com/strub/elliptic-curves-ssr.git"
 license: "CeCILL-B"
 authors: [
   "Evmorfia-Iro Bartzia"

--- a/extra-dev/packages/coq-ssr-elliptic-curves/coq-ssr-elliptic-curves.dev/opam
+++ b/extra-dev/packages/coq-ssr-elliptic-curves/coq-ssr-elliptic-curves.dev/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/strub/elliptic-curves-ssr"
 bug-reports: "https://github.com/strub/elliptic-curves-ssr/issues"
-dev-repo: "git+https://github.com/strub/elliptic-curves-ssr.git"
+dev-repo: "https://github.com/strub/elliptic-curves-ssr.git"
 license: "CeCILL-B"
 authors: [
   "Evmorfia-Iro Bartzia"

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.2/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.2/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
 bug-reports: "http://coqprime.gforge.inria.fr/"
-dev-repo: "git+https://github.com/thery/coqprime.git"
+dev-repo: "https://github.com/thery/coqprime.git"
 license: "LGPL"
 authors: ["Laurent Théry"]
 build: [

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "thery@sophia.inria.fr"
 homepage: "http://coqprime.gforge.inria.fr/"
 bug-reports: "http://coqprime.gforge.inria.fr/"
-dev-repo: "git+https://github.com/thery/coqprime.git"
+dev-repo: "https://github.com/thery/coqprime.git"
 license: "LGPL"
 authors: ["Laurent Théry"]
 build: [

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.0/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.0/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/multinomials-ssr"
 bug-reports: "https://github.com/math-comp/multinomials-ssr/issues"
-dev-repo: "git+https://github.com/math-comp/multinomials.git"
+dev-repo: "https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.1/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.1/opam
@@ -2,7 +2,7 @@ opam-version: "1.2"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/multinomials-ssr"
 bug-reports: "https://github.com/math-comp/multinomials-ssr/issues"
-dev-repo: "git+https://github.com/math-comp/multinomials.git"
+dev-repo: "https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [


### PR DESCRIPTION
It turns out "git+https" is not a valid scheme -- see here for
discussion : https://github.com/math-comp/analysis/pull/113

This commit fixes all the packages in this archive.

This fixes some errors that were here before PR #456 and the ones I introduced in that PR. I'm sorry for the noise.