### PR TITLE
[mathcomp]: add dev-repo to current SSReflect's opam

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.7.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.7.0/opam
@@ -5,6 +5,7 @@ maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 
 homepage: "http://math-comp.github.io/math-comp/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+dev-repo: "https://github.com/math-comp/math-comp.git"
 license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]


### PR DESCRIPTION
I'm starting to lint the released mathcomp packages one by one so not to overwhelm CI.