### PR TITLE
Provide coq.8.8.2 to OPAM 1.x users via coq-released

### DIFF
--- a/released/packages/coq/coq.8.8.2/descr
+++ b/released/packages/coq/coq.8.8.2/descr
@@ -1,0 +1,1 @@
+Formal proof management system.

--- a/released/packages/coq/coq.8.8.2/files/coq.install
+++ b/released/packages/coq/coq.8.8.2/files/coq.install
@@ -1,0 +1,13 @@
+bin: [
+  "bin/gallina"
+  "bin/coqwc"
+  "bin/coqtop"
+  "bin/coqtop.byte"
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk"
+  "bin/coqc"
+  "bin/coq_makefile"
+  "bin/coq-tex"
+  "bin/coqworkmgr"
+]

--- a/released/packages/coq/coq.8.8.2/opam
+++ b/released/packages/coq/coq.8.8.2/opam
@@ -1,0 +1,58 @@
+opam-version: "1.2"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, University Paris Sud, University Paris 7, Ecole Polytechnique."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "ocamlfind" {build}
+  "camlp5"
+  "num"
+]
+
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-camlp5dir" "%{lib}%/camlp5"
+    "-coqide" "no"
+  ]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]
+remove: [
+  ["rm" "-rf" "%{lib}%/coq" "%{share}%/coq"]
+  ["rm" "-f"
+  "%{man}%/man1/coqc.1"
+  "%{man}%/man1/coqchk.1"
+  "%{man}%/man1/coqdep.1"
+  "%{man}%/man1/coqdoc.1"
+  "%{man}%/man1/coqide.1"
+  "%{man}%/man1/coq_makefile.1"
+  "%{man}%/man1/coqmktop.1"
+  "%{man}%/man1/coq-tex.1"
+  "%{man}%/man1/coqtop.1"
+  "%{man}%/man1/coqtop.byte.1"
+  "%{man}%/man1/coqtop.opt.1"
+  "%{man}%/man1/coqwc.1"
+  "%{man}%/man1/gallina.1"
+  "%{share}%/texmf/tex/latex/misc/coqdoc.sty"
+  "%{share}%/emacs/site-lisp/coq-font-lock.el"
+  "%{share}%/emacs/site-lisp/coq-inferior.el"
+  "%{share}%/emacs/site-lisp/gallina-db.el"
+  "%{share}%/emacs/site-lisp/gallina.el"
+  "%{share}%/emacs/site-lisp/gallina-syntax.el"
+  ]
+]

--- a/released/packages/coq/coq.8.8.2/url
+++ b/released/packages/coq/coq.8.8.2/url
@@ -1,0 +1,3 @@
+http: "https://github.com/coq/coq/archive/V8.8.2.tar.gz"
+checksum: "5d693cd1953a0dd74920b43d183bc26c"
+checksum: "sha512=b0f0480fe052fced6016014cf1872d4e004b0dacb779927376d797c279aca9d5f6f4ed3d0f5ee5d42748bbd5c29b43f7a69748564a12a116bcc7ba3b052d8954"


### PR DESCRIPTION
I just copied the `coq` directory from the frozen OPAM 1.x repository and updated version and URL. Works for me, and packages like coq-mathcomp-ssreflect happily install on top of it.

Also see #257 