### PR TITLE
[extra-dev] Add coq-bignums.8.8.dev & Fix coq-bignums.8.7.dev

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/descr
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/descr
@@ -1,0 +1,2 @@
+Bignums, the Coq library of arbitrary large numbers
+Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.7.

--- a/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/opam
@@ -19,7 +19,7 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bignums"]
 depends: [
-  "coq" {>= "8.7" & < "8.8~"}
+  "coq" {>= "8.8" & < "8.10~"}
 ]
 tags: [
   "keyword:integer numbers"

--- a/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/url
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.8.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/coq/bignums.git#v8.8"


### PR DESCRIPTION
The Docker-Coq images I have prepared in https://github.com/coq-community/docker-coq rely on the `coq-bignums` package, and @Zimmi48 suggested me to provide a Docker image for Coq 8.9+beta1 as well, cf. coq-community/paramcoq#8.

However the current version of `coq-bignums.8.7.dev` happens to be incompatible with the newest Coq 8.9. Hence this PR (see commit message for details).