### PR TITLE
add package for lemma-overloading 8.8.0

### DIFF
--- a/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/descr
+++ b/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/descr
@@ -1,0 +1,1 @@
+Hoare Type Theory libraries showcasing design patterns for programming with canonical structures

--- a/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/opam
+++ b/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/opam
@@ -1,0 +1,31 @@
+opam-version: "1.2"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/lemma-overloading"
+dev-repo: "https://github.com/coq-community/lemma-overloading.git"
+bug-reports: "https://github.com/coq-community/lemma-overloading/issues"
+license: "GPL 3"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/LemmaOverloading"]
+depends: [
+  "coq" {>= "8.8" & < "8.9~"}
+  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.8~"}
+]
+
+tags: [
+  "keyword:canonical structures"
+  "keyword:proof automation"
+  "keyword:hoare type theory"
+  "keyword:lemma overloading"
+  "category:Computer Science/Data Types and Data Structures"
+  "date:2018-07-24"
+  "logpath:LemmaOverloading"
+]
+authors: [
+  "Georges Gonthier"
+  "Beta Ziliani"
+  "Aleksandar Nanevski"
+  "Derek Dreyer"
+]

--- a/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/url
+++ b/released/packages/coq-lemma-overloading/coq-lemma-overloading.8.8.0/url
@@ -1,0 +1,2 @@
+http: "https://github.com/coq-community/lemma-overloading/archive/v8.8.0.tar.gz"
+checksum: "a7056f6477fc274d2c0ef30dab492bde"


### PR DESCRIPTION
This is a former coq-contrib, now maintained in coq-community, that has releases but no OPAM package until now.