### PR TITLE
Try using --strict when building to catch failures

### DIFF
--- a/released/packages/coq-scev/coq-scev.1.0.1/opam
+++ b/released/packages/coq-scev/coq-scev.1.0.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SCEV"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SCEV-incorrect-dir"]
 depends: [
   "coq" {>= "8.5" & < "8.6~"}
 ]

--- a/scripts/opam-coq-install-remove
+++ b/scripts/opam-coq-install-remove
@@ -50,11 +50,11 @@ while [ ! -z "$1" ]; do
     ;;
     esac
     echo Check if $PKG_NAME_VERSION is compatible with the current environment
-    if opam install "$PKG_NAME_VERSION" -y --show-action; then
+    if opam install "$PKG_NAME_VERSION" -y --strict --show-action; then
       echo Installing $PKG_NAME_VERSION
-      opam install "$PKG_NAME_VERSION" -y -v -v >> $LOG
+      opam install "$PKG_NAME_VERSION" -y -v -v --strict >> $LOG
       echo Removing $PKG_NAME
-      opam remove "$PKG_NAME" -y >> $LOG
+      opam remove "$PKG_NAME" -y --strict >> $LOG
     else
       echo Skipping $PKG_NAME_VERSION
     fi


### PR DESCRIPTION
As referenced  at https://github.com/coq/opam-coq-archive/pull/513, I had messed up when 
setting up the install files, and `opam` therefore tried to remove a package that was incorrectly named
in the `uninstall` rule.

However, this did not break CI. I was expecting it to.

So, try passing `--strict` to make the check stricter and not fail immediately?