### PR TITLE
coq-cfml: add version constraints on ocaml

### DIFF
--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -1,6 +1,7 @@
 opam-version: "1.2"
 maintainer: "armael.gueneau@inria.fr"
 authors: "Arthur Charguéraud <arthur.chargueraud@inria.fr>"
+synopsis: "A tool for proving OCaml programs in Separation Logic"
 homepage: "https://gitlab.inria.fr/charguer/cfml"
 bug-reports: "https://gitlab.inria.fr/charguer/cfml/issues"
 license: "CeCILL-B"
@@ -9,6 +10,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
+  "ocaml" {>= "4.03.0" & < "4.07.0"}
   "ocamlbuild" {build}
   "pprint"
   "base-bytes"


### PR DESCRIPTION
This adds an explicit bound on the ocaml version, since this version does not build with ocaml 4.07.
(this is for the existing release, not the new one introduced by #523 )