### PR TITLE
This fixes installation directory for contribution lesniewski-mereology in 8.6

### DIFF
--- a/released/packages/coq-lesniewski-mereology/coq-lesniewski-mereology.8.6.0/descr
+++ b/released/packages/coq-lesniewski-mereology/coq-lesniewski-mereology.8.6.0/descr
@@ -1,4 +1,4 @@
-KDTL.
+Knowledge-based Dependently Typed Language (KDTL).
 
 http://www.polytech.univ-savoie.fr/index.php?id=listic-logiciels-coq&L=1
 

--- a/released/packages/coq-lesniewski-mereology/coq-lesniewski-mereology.8.6.0/url
+++ b/released/packages/coq-lesniewski-mereology/coq-lesniewski-mereology.8.6.0/url
@@ -1,2 +1,2 @@
 http: "https://github.com/coq-contribs/lesniewski-mereology/archive/v8.6.0.tar.gz"
-checksum: "93cbe08b734b338e2cff3ba1617c872d"
+checksum: "18d6e4a6bcc010074333c0824ece34d0"


### PR DESCRIPTION
This fixes the checksum of the url of the 8.6.0 version of lesniewski-mereology. (I made the assumption that noone was expecting the 8.6.0.tar.gz broken package to be unchanged. I hope this is reasonable.)

I also made the title of the contribution in the description file a little bit more explicit.