### PR TITLE
Paramcoq versioning policy.

### DIFF
--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/descr
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/descr
@@ -1,0 +1,5 @@
+Paramcoq
+
+The plugin is still in an experimental state. It is not very user
+friendly (lack of good error messages) and still contains bugs. But is
+useable enough to "translate" a large chunk of standard library.

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+synopsis: "Paramcoq"
+name: "coq-paramcoq"
+version: "1.1.1+coq8.7"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Param"]
+depends: [
+  "coq" {>= "8.7" & < "8.8~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:ocaml module"
+  "category:paramcoq"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/url
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.7/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/coq-community/paramcoq/releases/download/v1.1.1+coq8.7/coq-paramcoq.1.1.1+coq8.7.tgz"
+checksum: "3eb94ccdb53e6dfc7f0d74b3cd1a5db5"

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/descr
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/descr
@@ -1,0 +1,5 @@
+Paramcoq
+
+The plugin is still in an experimental state. It is not very user
+friendly (lack of good error messages) and still contains bugs. But is
+useable enough to "translate" a large chunk of standard library.

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+synopsis: "Paramcoq"
+name: "coq-paramcoq"
+version: "1.1.1+coq8.8"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Param"]
+depends: [
+  "coq" {>= "8.8" & < "8.9~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:ocaml module"
+  "category:paramcoq"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/url
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.8/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/coq-community/paramcoq/releases/download/v1.1.1/coq-paramcoq.1.1.1+coq8.8.tgz"
+checksum: "d7445ae507bdfa92c8d7e5b0ed5cac08"


### PR DESCRIPTION
Number versions according to https://github.com/coq-community/paramcoq/issues/9

Will do the same for 8.9 when it'll be released.
