### PR TITLE
coq-quickchick.dev: track master branch explicitly

### DIFF
--- a/extra-dev/packages/coq-quickchick/coq-quickchick.dev/url
+++ b/extra-dev/packages/coq-quickchick/coq-quickchick.dev/url
@@ -1,1 +1,1 @@
-git: "https://github.com/QuickChick/QuickChick"
+git: "https://github.com/QuickChick/QuickChick#master"


### PR DESCRIPTION
So we can change the default branch of QuickChick.