### PR TITLE
coq-relation-algebra release v1.7

### DIFF
--- a/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/descr
+++ b/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/descr
@@ -1,0 +1,3 @@
+Relation Algebra and KAT.
+
+A modular library about relation algebra, from idempotent semirings to residuated Kleene allegories, including a decision tactic for Kleene algebra with Tests (KAT).

--- a/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/opam
+++ b/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "coq-relation-algebra"
+maintainer: "Damien Pous <Damien.Pous@ens-lyon.fr>"
+homepage: "http://perso.ens-lyon.fr/damien.pous/ra/"
+license: "LGPL"
+depends: [ "coq" {>= "8.8" & < "8.9~"} ]
+depopts: [ "coq-mathcomp-ssreflect" ]
+build: [
+  ["sh" "-exc" "./configure --%{coq-mathcomp-ssreflect:enable}%-ssr"]
+  [make "-j%{jobs}%"]
+  [make "install"]
+]
+logpath: "RelationAlgebra"
+remove: [ "sh" "-exc" "rm -r '%{lib}%/coq/user-contrib/RelationAlgebra'" ]
+tags: [
+  "keyword:relation algebra"
+  "keyword:kleene algebra with tests"
+  "keyword:kat"
+  "keyword:allegories"
+  "keyword:residuated structures"
+  "keyword:automata"
+  "keyword:regular expressions"
+  "keyword:matrices"
+  "category:Mathematics/Algebra" ]
+authors: [
+  "Damien Pous <Damien.Pous@ens-lyon.fr>"
+  "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
+]

--- a/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/url
+++ b/released/packages/coq-relation-algebra/coq-relation-algebra.1.7/url
@@ -1,0 +1,5 @@
+http: "https://github.com/damien-pous/relation-algebra/archive/v1.7.tar.gz"
+checksum: "5cb2d207797949dd688f5c6c3499ad55"
+checksum: "sha256=76dc99d1c69373057ffbdc835653451d5613de99f68b2069caf53023ae16c992"
+
+


### PR DESCRIPTION
This is a new release of the relation-algebra library. See [here](https://github.com/damien-pous/relation-algebra/releases/tag/v1.7) for detail.