### PR TITLE
coq-fcsl-pcm: fix dependencies and add dev version

### DIFF
--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/descr
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/descr
@@ -1,0 +1,11 @@
+Partial Commutative Monoids
+
+The PCM library provides a formalisation of Partial Commutative Monoids (PCMs),
+a common algebraic structure used in separation logic for verification of
+pointer-manipulating sequential and concurrent programs.
+The library provides lemmas for mechanised and automated reasoning about PCMs
+in the abstract, but also supports concrete common PCM instances, such as heaps,
+histories and mutexes.
+
+This library relies on extensionality axioms: propositional and
+functional extentionality.

--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "coq-fcsl-pcm"
-version: "1.0.0"
+version: "dev"
 maintainer: "FCSL <fcsl@software.imdea.org>"
 
 homepage: "http://software.imdea.org/fcsl/"
@@ -12,8 +12,8 @@ build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/fcsl'" ]
 depends: [
-  "coq" {>= "8.7" & < "8.9~"}
-  "coq-mathcomp-ssreflect" {>= "1.6.2" & <= "1.7.0"}
+  "coq" {(>= "8.7" & < "8.9~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.6.2" & < "1.8~") | (= "dev")}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/url
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/imdea-software/fcsl-pcm.git#master"


### PR DESCRIPTION
The `fcsl-pcm` library v1.0.0 is not compartible anymore with the `dev` version of mathcomp-ssreflect due to  the recent changes introduced in https://github.com/math-comp/math-comp/pull/248.

After merging this PR it should be possible to install fcsl-pcm with the dev version of mathcomp.

(CC @ilyasergey and @palmskog)
