### PR TITLE
CoqIDE OPAM file for OPAM 1.x

### DIFF
--- a/released/packages/coqide/coqide.8.8.2/descr
+++ b/released/packages/coqide/coqide.8.8.2/descr
@@ -1,0 +1,1 @@
+IDE of the Coq formal proof management system.

--- a/released/packages/coqide/coqide.8.8.2/files/coqide.install
+++ b/released/packages/coqide/coqide.8.8.2/files/coqide.install
@@ -1,0 +1,9 @@
+bin: [
+  "bin/coqide"
+]
+share_root: [
+  "ide/coq.lang" {"coq/coq.lang"}
+  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coq.png" {"coq/coq.png"}
+  "ide/coq_style.xml" {"coq/coq_style.xml"}
+]

--- a/released/packages/coqide/coqide.8.8.2/opam
+++ b/released/packages/coqide/coqide.8.8.2/opam
@@ -1,0 +1,38 @@
+opam-version: "1.2"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, University Paris Sud, University Paris 7, Ecole Polytechnique."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+
+available: [ocaml-version >= "4.02.3"]
+depends: [
+  "camlp5"
+  "coq" {= "8.8.2"}
+  "lablgtk"
+  "conf-gtksourceview"
+]
+
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-camlp5dir" "%{lib}%/camlp5"
+  ]
+  [make "-j%{jobs}%" "coqide-files"]
+  [make "-j%{jobs}%" "coqide-opt"]
+]
+install: [
+  make
+  "install-ide-bin"
+  "install-ide-files"
+  "install-ide-info"
+  "install-ide-devfiles"
+]
+remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]

--- a/released/packages/coqide/coqide.8.8.2/url
+++ b/released/packages/coqide/coqide.8.8.2/url
@@ -1,0 +1,3 @@
+http: "https://github.com/coq/coq/archive/V8.8.2.tar.gz"
+checksum: "5d693cd1953a0dd74920b43d183bc26c"
+checksum: "sha512=b0f0480fe052fced6016014cf1872d4e004b0dacb779927376d797c279aca9d5f6f4ed3d0f5ee5d42748bbd5c29b43f7a69748564a12a116bcc7ba3b052d8954"


### PR DESCRIPTION
After a colleague asked my why there is Coq 8.8.2 but no CoqIDE 8.8.2 in coq/released, I thought I might as well craft an opam packacke for that. As with #495, I simply copied and adapted the coqide opam files from the 1.x branch of OPAM. Works for me.