### PR TITLE
Add fiat-crypto-legacy

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat (legacy pipeline).

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/opam
@@ -9,14 +9,10 @@ maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
-build: [
-  ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "coqprime-all"]
-]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.8.dev"}
-  "coq-bignums"
+  "coq" {= "8.6.dev"}
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.6.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#v8.6"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat (legacy pipeline).

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/opam
@@ -11,12 +11,12 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.8.dev"}
+  "coq" {= "8.7.dev"}
   "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.7.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#sp2019latest"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat (legacy pipeline).

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.8.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#sp2019latest"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat (legacy pipeline).

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/opam
@@ -11,12 +11,12 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.8.dev"}
+  "coq" {= "8.9.dev"}
   "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.8.9.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#sp2019latest"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat (legacy pipeline).

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/opam
@@ -11,12 +11,12 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.8.dev"}
+  "coq" {= "dev"}
   "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto-legacy/coq-fiat-crypto-legacy.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#sp2019latest"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.6.dev/opam
@@ -5,7 +5,7 @@ authors: [
   "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
   "Massachusetts Institute of Technology"
 ]
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.7.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat.

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.7.dev"}
+  "coq" {= "8.8.dev"}
   "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.8.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#master"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/descr
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/descr
@@ -1,0 +1,1 @@
+Cryptographic Primitive Code Generation in Fiat.

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
-  "coq" {= "8.7.dev"}
+  "coq" {= "8.9.dev"}
   "coq-bignums"
 ]
 dev-repo: "https://github.com/mit-plv/fiat-crypto.git"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/url
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.8.9.dev/url
@@ -1,0 +1,1 @@
+git: "https://github.com/mit-plv/fiat-crypto.git#master"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
   ["git" "submodule" "update" "--init" "--recursive"]
-  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
+  [make "-j%{jobs}%" "coq" "coqprime-all"]
 ]
 install: [make "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -5,7 +5,7 @@ authors: [
   "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
   "Massachusetts Institute of Technology"
 ]
-maintainer: "Matej Košík <matej.kosik@inria.fr>"
+maintainer: "Jason Gross <jgross@mit.edu>"
 homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"


### PR DESCRIPTION
On top of #540

Once mit-plv/fiat-crypto#477 is merged, the legacy pipeline targets will go away, so we make these alternatives for the bench.

What's required to get this added to the standard bench?