### PR TITLE
LibValidSDP

### DIFF
--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/descr
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/descr
@@ -1,0 +1,9 @@
+LibValidSDP
+
+LibValidSDP is a library for the Coq formal proof assistant. It provides
+results mostly about rounding errors in the Cholesky decomposition algorithm
+used in the ValidSDP library which itself implements Coq tactics to prove
+multivariate inequalities using SDP solvers.
+
+Once installed, the following modules can be imported :
+From libValidSDP Require Import Rstruct.v misc.v real_matrix.v bounded.v float_spec.v fsum.v fcmsum.v binary64.v cholesky.v float_infnan_spec.v binary64_infnan.v cholesky_infnan.v flx64.v zulp.v coqinterval_infnan.v.

--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/opam
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+name: "coq-libvalidsdp"
+version: "0.5"
+maintainer: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]
+
+homepage: "https://sourcesup.renater.fr/validsdp/"
+dev-repo: "https://github.com/validsdp/validsdp.git"
+bug-reports: "https://github.com/validsdp/validsdp/issues"
+license: "LGPL"
+
+build: [
+  ["./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/libValidSDP"]
+depends: [
+  "coq" {>= "8.7" & < "8.9~"} "coq-interval" {>= "3" & < "4~"} "coq-mathcomp-field" {>= "1.7" & < "1.8~"} "ocamlfind" "camlp4" "coq-flocq" {>= "3" & < "4~"} "coq-bignums"
+]
+synopsis: "LibValidSDP"
+  
+tags: [
+  "keyword:libValidSDP"
+  "keyword:ValidSDP"
+  "keyword:floating-point arithmetic"
+  "keyword:Cholesky decomposition"
+  "category:libValidSDP"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:libValidSDP"
+]
+authors: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]

--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/url
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/validsdp/validsdp/releases/download/v0.5/libvalidsdp.0.5.tgz"
+checksum: "8804c308899b85fccb54ec6a6b9fc57c"


### PR DESCRIPTION
Mathematical results used for the validSDP tactic.

This doesn't include the tactic itself and OCaml module, having further dependencies
(not yet available in Opam).
