### PR TITLE
Fix upper Coq version constraint for high school geometry and tree automata

### DIFF
--- a/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
+++ b/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/HighSchoolGeometry"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.5" & < "8.6~"}
 ]
 tags: [ "keyword:geometry" "keyword:teaching" "keyword:high school" "category:Mathematics/Geometry/General" "date:2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr>" ]

--- a/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
+++ b/released/packages/coq-tree-automata/coq-tree-automata.8.5.0/opam
@@ -6,7 +6,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/TreeAutomata"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.5" & < "8.6~"}
   "coq-int-map"
 ]
 tags: [ "keyword:tree automatas" "keyword:bottom up reflexion terms" "category:Computer Science/Formal Languages Theory and Automata" "date:1999-09" ]


### PR DESCRIPTION
Hi, this fixes two failures of packages in coq-contribs which fails in coq-bench.github.io (8.6) due to missing upper Coq version constraint.