### PR TITLE
Fix urls and checksums of template-coq packages

### DIFF
--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta3/url
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta3/url
@@ -1,2 +1,2 @@
-http: "https://github.com/Template-Coq/template-coq/archive/v2.1-beta3.tar.gz"
-checksum: "9c988cd7cd7df9017b5c244ab00d1b8e"
+http: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+checksum: "e81b8ecabef788a10337a39b095d54f3"


### PR DESCRIPTION
The change of name from template-coq to meta-coq made github rebuild packages, which hence have a different checksum.