### PR TITLE
coq-label 1.0.0 is only compatible with Coq 8.7.

### DIFF
--- a/released/packages/coq-label/coq-label.1.0.0/opam
+++ b/released/packages/coq-label/coq-label.1.0.0/opam
@@ -13,5 +13,5 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Label"]
 depends: [
-  "coq" {>= "8.7"}
+  "coq" {>= "8.7" & < "8.8~"}
 ]


### PR DESCRIPTION
According to Guillaume's bench (https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/)