### PR TITLE
make coq package consistent with ocaml repository

### DIFF
--- a/core-dev/packages/coq/coq.8.9.dev/opam
+++ b/core-dev/packages/coq/coq.8.9.dev/opam
@@ -49,7 +49,7 @@ remove: [
   "%{share}%/texmf/tex/latex/misc/coqdoc.sty"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
 url {

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -47,7 +47,7 @@ remove: [
   "%{share}%/texmf/tex/latex/misc/coqdoc.sty"
   ]
 ]
-synopsis: "Formal proof management system."
+synopsis: "Formal proof management system"
 flags: light-uninstall
 extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
 url {

--- a/core-dev/packages/coqide/coqide.8.9.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.9.dev/opam
@@ -35,7 +35,7 @@ install: [
   "install-ide-devfiles"
 ]
 remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
-synopsis: "IDE of the Coq formal proof management system."
+synopsis: "IDE of the Coq formal proof management system"
 flags: light-uninstall
 extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
 url {

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -35,7 +35,7 @@ install: [
   "install-ide-devfiles"
 ]
 remove: ["rm" "-rf" "%{lib}%/coq/ide" "%{doc}%/FAQ-CoqIde"]
-synopsis: "IDE of the Coq formal proof management system."
+synopsis: "IDE of the Coq formal proof management system"
 flags: light-uninstall
 extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
 url {


### PR DESCRIPTION
@mattam82 removed the final `.` for https://github.com/ocaml/opam-repository/pull/13326, let's do the same here.