### PR TITLE
Paramcoq for Coq 8.9

### DIFF
--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/descr
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/descr
@@ -1,0 +1,5 @@
+Paramcoq
+
+The plugin is still in an experimental state. It is not very user
+friendly (lack of good error messages) and still contains bugs. But is
+useable enough to "translate" a large chunk of standard library.

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/opam
@@ -1,0 +1,35 @@
+opam-version: "1.2"
+synopsis: "Paramcoq"
+name: "coq-paramcoq"
+version: "1.1.1+coq8.9"
+maintainer: "Pierre Roux <pierre.roux@onera.fr>"
+
+homepage: "https://github.com/coq-community/paramcoq"
+dev-repo: "https://github.com/coq-community/paramcoq.git"
+bug-reports: "https://github.com/coq-community/paramcoq/issues"
+license: "MIT"
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Param"]
+depends: [
+  "coq" {>= "8.9" & < "8.10~"}
+]
+
+tags: [
+  "keyword:paramcoq"
+  "keyword:parametricity"
+  "keyword:ocaml module"
+  "category:paramcoq"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Param"
+]
+authors: [
+  "Chantal Keller (Inria, École polytechnique)"
+  "Marc Lasson (ÉNS de Lyon)"
+  "Abhishek Anand"
+  "Pierre Roux"
+  "Emilio Jesús Gallego Arias"
+  "Cyril Cohen"
+  "Matthieu Sozeau"
+]

--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/url
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.1+coq8.9/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/coq-community/paramcoq/archive/v1.1.1+coq8.9.tar.gz"
+checksum: "e0ca9436a81fd47e676541254d28e8bb"


### PR DESCRIPTION
Publish the opam package now that Coq 8.9 is out.