### PR TITLE
fcsl-pcm works with 8.9

### DIFF
--- a/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.0.0/opam
+++ b/released/packages/coq-fcsl-pcm/coq-fcsl-pcm.1.0.0/opam
@@ -12,7 +12,7 @@ build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/fcsl'" ]
 depends: [
-  "coq" {>= "8.7" & < "8.9~"}
+  "coq" {>= "8.7" & < "8.10~"}
   "coq-mathcomp-ssreflect" {>= "1.6.2" & <= "1.7.0"}
 ]
 


### PR DESCRIPTION
To make package work with Coq 8.9.0.