### PR TITLE
coq-reglang supports Coq 8.9

### DIFF
--- a/released/packages/coq-reglang/coq-reglang.1/opam
+++ b/released/packages/coq-reglang/coq-reglang.1/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "coq-reglang"              
-version: "1.0"
+version: "1"
 maintainer: "Christian Doczkal <christian.doczkal@ens-lyon.fr>"
 
 homepage: "https://github.com/chdoc/coq-reglang"
@@ -12,7 +12,7 @@ build: [ make "-j%{jobs}%" "-C" "theories" ]
 install: [ make "-C" "theories" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/RegLang'" ]
 depends: [
-  "coq" {>= "8.6" & < "8.9~"}
+  "coq" {>= "8.6" & < "8.10~"}
   "coq-mathcomp-ssreflect" {>= "1.6" & < "1.8~"}
 ]
 
@@ -23,6 +23,7 @@ tags: [
   "keyword:two-way automata"
   "keyword:monadic second-order logic"
   "category:Computer Science/Formal Languages Theory and Automata"
+  "logpath:RegLang"
 ]
 
 authors: [


### PR DESCRIPTION
Adjust supported Coq version and add one piece of missing metadata.