### PR TITLE
Fix libvalidsdp.0.5 dependencies

### DIFF
--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/opam
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.5/opam
@@ -18,7 +18,7 @@ build: [
 install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/libValidSDP"]
 depends: [
-  "coq" {>= "8.7" & < "8.9~"} "coq-interval" {>= "3" & < "4~"} "coq-mathcomp-field" {>= "1.7" & < "1.8~"} "ocamlfind" "camlp4" "coq-flocq" {>= "3" & < "4~"} "coq-bignums"
+  "coq" {>= "8.7" & < "8.9~"} "coq-interval" {>= "3" & < "4~"} "coq-mathcomp-field" {>= "1.7" & < "1.8~"} "ocamlfind" "camlp4" "coq-flocq" {>= "3" & < "3.1~"} "coq-bignums"
 ]
 synopsis: "LibValidSDP"
   


### PR DESCRIPTION
It appears to be incompatible with the newly released flocq.3.1.0

This also fixes https://github.com/coq/opam-coq-archive/pull/587/commits/955ef0f9bf7260d8eadf87c6717f601dcac23543
