### PR TITLE
Re-add unicoq release for 8.9 to opam 2.0

### DIFF
--- a/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
@@ -18,7 +18,7 @@ depends: [
 ]
 synopsis: "An enhanced unification algorithm for Coq"
 flags: light-uninstall
-url: {
+url {
   src: "https://github.com/unicoq/unicoq/archive/v1.3-8.10.tar.gz"
   checksum: "md5=06f7a0abf3ba2de4467160d5872bb7b6"
 }

--- a/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
@@ -1,0 +1,24 @@
+opam-version: "1.2"
+maintainer: "matthieu.sozeau@inria.fr"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Beta Ziliani <beta@mpi-sws.org>" ]
+dev-repo: "git+https://github.com/unicoq/unicoq.git"
+homepage: "https://github.com/unicoq/unicoq"
+bug-reports: "https://github.com/unicoq/unicoq/issues"
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "Make" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Unicoq"]
+depends: [
+  "coq" {>= "8.9.0" & < "8.10~"}
+]
+synopsis: "An enhanced unification algorithm for Coq"
+flags: light-uninstall
+url: {
+  src: "https://github.com/unicoq/unicoq/archive/v1.3-8.10.tar.gz"
+  checksum: "md5=06f7a0abf3ba2de4467160d5872bb7b6"
+}

--- a/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.3+8.9/opam
@@ -19,6 +19,6 @@ depends: [
 synopsis: "An enhanced unification algorithm for Coq"
 flags: light-uninstall
 url {
-  src: "https://github.com/unicoq/unicoq/archive/v1.3-8.10.tar.gz"
+  src: "https://github.com/unicoq/unicoq/archive/v1.3-8.9.tar.gz"
   checksum: "md5=06f7a0abf3ba2de4467160d5872bb7b6"
 }


### PR DESCRIPTION
I'm creating this PR to re-add the latest Unicoq release to the archive, based off this comment: https://gitter.im/coq/coq?at=5cb4b3e6a84e0c501a377274

cc @beta-ziliani 