### PR TITLE
coqide: use 'version' to automatically depend on the matching coq version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ before_script:
   - export HOME=$(pwd)
   - export EXTRA_OPAM="ocamlbuild" # some packages build extracted code this way
   - apt-get update -qy
-  - apt-get install unzip libgtksourceview2.0-dev libncurses5-dev curl jq -y
+  - apt-get install unzip libgtksourceview2.0-dev libgtksourceview-3.0-dev libncurses5-dev curl jq -y
   - test -e ${HOME}/opam-cache/cache-${COMPILER}.tgz || scripts/opam-coq-init
   - curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh > install.sh
   - echo | sh install.sh

--- a/core-dev/packages/coqide/coqide.8.9.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.9.dev/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3"}
   "camlp5"
-  "coq" {= "8.9.dev"}
+  "coq" {= version}
   "lablgtk"
   "conf-gtksourceview"
 ]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -9,7 +9,7 @@ license: "LGPL-2.1"
 depends: [
   "ocaml" {>= "4.02.3"}
   "camlp5"
-  "coq" {= "dev"}
+  "coq" {= version}
   "lablgtk"
   "conf-gtksourceview"
 ]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -22,7 +22,6 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-camlp5dir" "%{lib}%/camlp5"
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -10,8 +10,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "camlp5"
   "coq" {= version}
-  "lablgtk"
-  "conf-gtksourceview"
+  "lablgtk3-sourceview3"
 ]
 build: [
   [


### PR DESCRIPTION
This also means we can just copy-paste that part in the future.