### PR TITLE
Revival of coq-math-classes.1.0.7 which compiles only with Coq 8.6

### DIFF
--- a/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
+++ b/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "b.a.w.spitters@gmail.com"
+homepage: "https://github.com/math-classes/"
+doc: "https://github.com/math-classes/"
+authors: [
+  "Eelis van der Weegen"
+  "Bas Spitters"
+  "Robbert Krebbers"
+]
+license: "Public Domain"
+build: [
+  [ "./configure.sh" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [
+  [ make "install" ]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MathClasses"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.6"}
+  "coq-bignums" {>= "8.6"}
+]
+synopsis: "A library of abstract interfaces for mathematical structures in Coq"
+flags: light-uninstall
+url {
+  src: "https://github.com/math-classes/math-classes/archive/1.0.7.zip"
+  checksum: "md5=b9b1e8f98fb9d3d197765b5366b467f1"
+}

--- a/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
+++ b/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
@@ -15,14 +15,12 @@ build: [
 install: [
   [ make "install" ]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MathClasses"]
 depends: [
   "ocaml"
   "coq" {= "8.6"}
   "coq-bignums" {>= "8.6"}
 ]
 synopsis: "A library of abstract interfaces for mathematical structures in Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/math-classes/math-classes/archive/1.0.7.zip"
   checksum: "md5=b9b1e8f98fb9d3d197765b5366b467f1"

--- a/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
+++ b/released/packages/coq-math-classes/coq-math-classes.1.0.7/opam
@@ -18,7 +18,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MathClasses"]
 depends: [
   "ocaml"
-  "coq" {>= "8.6"}
+  "coq" {= "8.6"}
   "coq-bignums" {>= "8.6"}
 ]
 synopsis: "A library of abstract interfaces for mathematical structures in Coq"


### PR DESCRIPTION
This package was removed in https://github.com/coq/opam-coq-archive/commit/37b32dcb84112c9a9bcff5a5d3f6df11d556cbab but is required by `coq-corn.1.2.0`.

* fails with Coq 8.7.2:
```
- File "./quote/classquote.v", line 22, characters 13-22:
- Error:
- Syntax error: 'Type' or 'Types' expected after 'Implicit' (in [vernac:gallina_ext]).
```
* fails with Coq 8.6.1:
```
- File "./quote/classquote.v", line 22, characters 13-22:
- Error:
- Syntax error: 'Type' or 'Types' expected after 'Implicit' (in [vernac:gallina_ext]).
```
* fails with Coq 8.5.3:
```
"coqc"  -q  -R "." MathClasses   categories/categories.v
"coqc"  -q  -R "." MathClasses   categories/product.v
"coqc"  -q  -R "." MathClasses   categories/dual.v
File "./categories/dual.v", line 42, characters 10-11:
Syntax error: [tactic:hints_path] expected after '[' (in [vernac:command]).
make: *** [categories/dual.vo] Erreur 1
```
* but works with Coq 8.6!