### PR TITLE
Increase the required Coq version for failing Paco pakages

### DIFF
--- a/released/packages/coq-paco/coq-paco.1.2.9/opam
+++ b/released/packages/coq-paco/coq-paco.1.2.9/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.2.0.0/opam
+++ b/released/packages/coq-paco/coq-paco.2.0.0/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.2.0.1/opam
+++ b/released/packages/coq-paco/coq-paco.2.0.1/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.2.0.2/opam
+++ b/released/packages/coq-paco/coq-paco.2.0.2/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.2.0.3/opam
+++ b/released/packages/coq-paco/coq-paco.2.0.3/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.2.1.0/opam
+++ b/released/packages/coq-paco/coq-paco.2.1.0/opam
@@ -20,7 +20,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.3.0.0/opam
+++ b/released/packages/coq-paco/coq-paco.3.0.0/opam
@@ -18,7 +18,7 @@ build: [make "-C" "src" "all" "-j%{jobs}%"]
 install: [make "-C" "src" "-f" "Makefile.coq" "install"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
-  "coq" {>= "8.5" & < "8.10"}
+  "coq" {>= "8.6" & < "8.10"}
 ]
 tags: [
   "date:2019-03-25"


### PR DESCRIPTION
All `coq-paco` versions but one fail with Coq 8.5.3 according to the bench: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/