### PR TITLE
Fix uninstallation of coq-min-imports.1.0.0

### DIFF
--- a/released/packages/coq-min-imports/coq-min-imports.1.0.0/opam
+++ b/released/packages/coq-min-imports/coq-min-imports.1.0.0/opam
@@ -11,11 +11,6 @@ build: [
 install: [
   ["install" "coq_min_imports" "%{bin}%"]
 ]
-
-remove: [
-  ["rm" "%{bin}%/coq_min_imports"]
-]
-
 depends: [
   "ocaml"
   "coq" {>= "8.5"}
@@ -33,7 +28,6 @@ description: """
 sources. It examines modules listed in "Require Import" statements one
 by one and tries to recompile to see if their removal would cause
 compilation errors."""
-flags: light-uninstall
 url {
   src: "https://github.com/vzaliva/coq-min-imports/archive/v1.0.0.tar.gz"
   checksum: "md5=5d66474c9d71dbc46b44c786fb6fef00"


### PR DESCRIPTION
It seems this is the only package left with some uninstallation errors: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/8.9.0/min-imports/1.0.0.html