### PR TITLE
Fix QCert for OPAM 2

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.1.0.4/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.1"}
+  "coq" {>= "8.7.1" & < "8.8"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
 url {

--- a/released/packages/coq-qcert/coq-qcert.1.0.4/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/opam
@@ -11,13 +11,11 @@ build: [
 install: [
   [make "install-coq"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
   "ocaml"
   "coq" {>= "8.7.1"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
-flags: light-uninstall
 url {
   src: "https://github.com/querycert/qcert/archive/v1.0.4.tar.gz"
   checksum: "md5=f14bff99263f5025acc6b92afed1e434"

--- a/released/packages/coq-qcert/coq-qcert.1.0.4/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.4/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "git+https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7.1"}
+]
+synopsis: "A platform for implementing and verifying query compilers"
+flags: light-uninstall
+url {
+  src: "https://github.com/querycert/qcert/archive/v1.0.4.tar.gz"
+  checksum: "md5=f14bff99263f5025acc6b92afed1e434"
+}

--- a/released/packages/coq-qcert/coq-qcert.1.0.5/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.5/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.2"}
+  "coq" {>= "8.7.2" & < "8.8"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
 url {

--- a/released/packages/coq-qcert/coq-qcert.1.0.5/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.5/opam
@@ -11,13 +11,11 @@ build: [
 install: [
   [make "install-coq"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
   "ocaml"
   "coq" {>= "8.7.2"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
-flags: light-uninstall
 url {
   src: "https://github.com/querycert/qcert/archive/v1.0.5.tar.gz"
   checksum: "md5=3904c818b69823498769cacc1774c5d6"

--- a/released/packages/coq-qcert/coq-qcert.1.0.5/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.5/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "git+https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7.2"}
+]
+synopsis: "A platform for implementing and verifying query compilers"
+flags: light-uninstall
+url {
+  src: "https://github.com/querycert/qcert/archive/v1.0.5.tar.gz"
+  checksum: "md5=3904c818b69823498769cacc1774c5d6"
+}

--- a/released/packages/coq-qcert/coq-qcert.1.0.6/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.2"}
+  "coq" {>= "8.7.2" & < "8.8"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
 url {

--- a/released/packages/coq-qcert/coq-qcert.1.0.6/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/opam
@@ -11,13 +11,11 @@ build: [
 install: [
   [make "install-coq"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
   "ocaml"
   "coq" {>= "8.7.2"}
 ]
 synopsis: "A platform for implementing and verifying query compilers"
-flags: light-uninstall
 url {
   src: "https://github.com/querycert/qcert/archive/v1.0.6.tar.gz"
   checksum: "md5=3ae70334db76c8a994d98ee5a6970fd4"

--- a/released/packages/coq-qcert/coq-qcert.1.0.6/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.6/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "git+https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7.2"}
+]
+synopsis: "A platform for implementing and verifying query compilers"
+flags: light-uninstall
+url {
+  src: "https://github.com/querycert/qcert/archive/v1.0.6.tar.gz"
+  checksum: "md5=3ae70334db76c8a994d98ee5a6970fd4"
+}

--- a/released/packages/coq-qcert/coq-qcert.1.0.7/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.2"}
+  "coq" {>= "8.7.2" & < "8.8"}
   "coq-flocq" {>= "2.6.0" & < "3.0~"}
   "coq-jsast" {>= "1.0.7"}
 ]

--- a/released/packages/coq-qcert/coq-qcert.1.0.7/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/opam
@@ -11,7 +11,6 @@ build: [
 install: [
   [make "install-coq"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
   "ocaml"
   "coq" {>= "8.7.2"}
@@ -19,7 +18,6 @@ depends: [
   "coq-jsast" {>= "1.0.7"}
 ]
 synopsis: "Verified compiler for data-centric languages"
-flags: light-uninstall
 url {
   src: "https://github.com/querycert/qcert/archive/v1.0.7.tar.gz"
   checksum: "md5=36fd7cda0fae7887d8c17bb4822e599b"

--- a/released/packages/coq-qcert/coq-qcert.1.0.7/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "git+https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7.2"}
+  "coq-flocq" {>= "2.6.0" & < "3.0~"}
+  "coq-jsast" {>= "1.0.7"}
+]
+synopsis: "Verified compiler for data-centric languages"
+flags: light-uninstall
+url {
+  src: "https://github.com/querycert/qcert/archive/v1.0.7.tar.gz"
+  checksum: "md5=36fd7cda0fae7887d8c17bb4822e599b"
+}

--- a/released/packages/coq-qcert/coq-qcert.1.0.9/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.9/opam
@@ -11,7 +11,6 @@ build: [
 install: [
   [make "install-coq"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
 depends: [
   "ocaml"
   "coq" {>= "8.7.2"}
@@ -19,7 +18,6 @@ depends: [
   "coq-jsast" {>= "1.0.7"}
 ]
 synopsis: "Verified compiler for data-centric languages"
-flags: light-uninstall
 url {
   src: "https://github.com/querycert/qcert/archive/v1.0.9.tar.gz"
   checksum: "md5=f04c8466cc2310baec0bc277fced0911"

--- a/released/packages/coq-qcert/coq-qcert.1.0.9/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.9/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "jeromesimeon@me.com"
+homepage: "https://querycert.github.io"
+dev-repo: "git+https://github.com/querycert/qcert"
+bug-reports: "https://github.com/querycert/qcert/issues"
+authors: [ "Josh Auerbach" "Martin Hirzel" "Louis Mandel" "Avi Shinnar" "Jerome Simeon" ]
+license: "Apache-2.0"
+build: [
+  [make "-j%{jobs}%" "qcert-coq"]
+]
+install: [
+  [make "install-coq"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Qcert"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7.2"}
+  "coq-flocq" {>= "2.6.0"}
+  "coq-jsast" {>= "1.0.7"}
+]
+synopsis: "Verified compiler for data-centric languages"
+flags: light-uninstall
+url {
+  src: "https://github.com/querycert/qcert/archive/v1.0.9.tar.gz"
+  checksum: "md5=f04c8466cc2310baec0bc277fced0911"
+}

--- a/released/packages/coq-qcert/coq-qcert.1.0.9/opam
+++ b/released/packages/coq-qcert/coq-qcert.1.0.9/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.2"}
+  "coq" {>= "8.7.2" & < "8.8"}
   "coq-flocq" {>= "2.6.0"}
   "coq-jsast" {>= "1.0.7"}
 ]


### PR DESCRIPTION
Fixing packages which were broken (and removed) during the move to OPAM 2