### PR TITLE
Fix coq-io-system for OPAM 2

### DIFF
--- a/released/packages/coq-io-system/coq-io-system.2.0.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.0.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
 depends: [
   "ocaml"
   "coq" {>= "8.4pl4" & < "8.5~"}
@@ -21,8 +20,13 @@ depends: [
   "coq-io" {< "2.1.0"}
   "coq-io-system-ocaml"
 ]
+tags: [
+  "date:2015-03-03"
+  "keyword:effects"
+  "keyword:extraction"
+  "logpath:Io/System"
+]
 synopsis: "System effects for Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/coq-io/system/archive/2.0.0.tar.gz"
   checksum: "md5=9cc821d7fb35a0b20ce55642dae034cb"

--- a/released/packages/coq-io-system/coq-io-system.2.1.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/clarus/io-system"
+dev-repo: "git+https://github.com/clarus/io-system.git"
+bug-reports: "https://github.com/clarus/io-system/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.4pl4"}
+  "coq-function-ninjas"
+  "coq-list-string" {>= "2.0.0"}
+  "coq-io" {>= "2.1.0" & < "3.0.0"}
+  "coq-io-system-ocaml" {>= "2.1.0"}
+]
+synopsis: "System effects for Coq"
+flags: light-uninstall
+url {
+  src: "https://github.com/coq-io/system/archive/2.1.0.tar.gz"
+  checksum: "md5=9272c56ba0a3af923fe804da45c7bafe"
+}

--- a/released/packages/coq-io-system/coq-io-system.2.1.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.1.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
 depends: [
   "ocaml"
   "coq" {>= "8.4pl4"}
@@ -22,7 +21,6 @@ depends: [
   "coq-io-system-ocaml" {>= "2.1.0"}
 ]
 synopsis: "System effects for Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/coq-io/system/archive/2.1.0.tar.gz"
   checksum: "md5=9272c56ba0a3af923fe804da45c7bafe"

--- a/released/packages/coq-io-system/coq-io-system.2.1.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.1.0/opam
@@ -20,6 +20,12 @@ depends: [
   "coq-io" {>= "2.1.0" & < "3.0.0"}
   "coq-io-system-ocaml" {>= "2.1.0"}
 ]
+tags: [
+  "date:2015-03-11"
+  "keyword:effects"
+  "keyword:extraction"
+  "logpath:Io/System"
+]
 synopsis: "System effects for Coq"
 url {
   src: "https://github.com/coq-io/system/archive/2.1.0.tar.gz"

--- a/released/packages/coq-io-system/coq-io-system.2.2.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.2.0/opam
@@ -20,6 +20,12 @@ depends: [
   "coq-io" {= "3.0.0"}
   "coq-io-system-ocaml" {>= "2.2.0" & < "2.3.0"}
 ]
+tags: [
+  "date:2015-03-23"
+  "keyword:effects"
+  "keyword:extraction"
+  "logpath:Io/System"
+]
 synopsis: "System effects for Coq"
 url {
   src: "https://github.com/coq-io/system/archive/2.2.0.tar.gz"

--- a/released/packages/coq-io-system/coq-io-system.2.2.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.2.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
 depends: [
   "ocaml"
   "coq" {>= "8.4pl4"}
@@ -22,7 +21,6 @@ depends: [
   "coq-io-system-ocaml" {>= "2.2.0" & < "2.3.0"}
 ]
 synopsis: "System effects for Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/coq-io/system/archive/2.2.0.tar.gz"
   checksum: "md5=ca83d1060db9e8365b00ea71f1391592"

--- a/released/packages/coq-io-system/coq-io-system.2.2.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/clarus/io-system"
+dev-repo: "git+https://github.com/clarus/io-system.git"
+bug-reports: "https://github.com/clarus/io-system/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.4pl4"}
+  "coq-function-ninjas"
+  "coq-list-string" {>= "2.0.0"}
+  "coq-io" {= "3.0.0"}
+  "coq-io-system-ocaml" {>= "2.2.0" & < "2.3.0"}
+]
+synopsis: "System effects for Coq"
+flags: light-uninstall
+url {
+  src: "https://github.com/coq-io/system/archive/2.2.0.tar.gz"
+  checksum: "md5=ca83d1060db9e8365b00ea71f1391592"
+}

--- a/released/packages/coq-io-system/coq-io-system.2.3.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.3.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/clarus/io-system"
+dev-repo: "git+https://github.com/clarus/io-system.git"
+bug-reports: "https://github.com/clarus/io-system/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.4pl4"}
+  "coq-function-ninjas"
+  "coq-list-string" {>= "2.0.0"}
+  "coq-io" {= "3.1.0"}
+  "coq-io-system-ocaml" {>= "2.2.0"}
+]
+synopsis: "System effects for Coq"
+flags: light-uninstall
+url {
+  src: "https://github.com/coq-io/system/archive/2.3.0.tar.gz"
+  checksum: "md5=fdf48fba559ba76bf20ca8b351104c37"
+}

--- a/released/packages/coq-io-system/coq-io-system.2.3.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.3.0/opam
@@ -20,6 +20,12 @@ depends: [
   "coq-io" {= "3.1.0"}
   "coq-io-system-ocaml" {>= "2.2.0"}
 ]
+tags: [
+  "date:2015-05-10"
+  "keyword:effects"
+  "keyword:extraction"
+  "logpath:Io/System"
+]
 synopsis: "System effects for Coq"
 url {
   src: "https://github.com/coq-io/system/archive/2.3.0.tar.gz"

--- a/released/packages/coq-io-system/coq-io-system.2.3.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.3.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
 depends: [
   "ocaml"
   "coq" {>= "8.4pl4"}
@@ -22,7 +21,6 @@ depends: [
   "coq-io-system-ocaml" {>= "2.2.0"}
 ]
 synopsis: "System effects for Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/coq-io/system/archive/2.3.0.tar.gz"
   checksum: "md5=fdf48fba559ba76bf20ca8b351104c37"

--- a/released/packages/coq-io-system/coq-io-system.2.4.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.4.0/opam
@@ -12,7 +12,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/System"]
 depends: [
   "ocaml"
   "coq" {>= "8.4pl4"}
@@ -21,8 +20,13 @@ depends: [
   "coq-io" {>= "3.2.0"}
   "coq-io-system-ocaml" {>= "2.2.0"}
 ]
+tags: [
+  "date:2015-07-04"
+  "keyword:effects"
+  "keyword:extraction"
+  "logpath:Io/System"
+]
 synopsis: "System effects for Coq"
-flags: light-uninstall
 url {
   src: "https://github.com/coq-io/system/archive/2.4.0.tar.gz"
   checksum: "md5=750547991abee194c99bd32ea93e46b2"


### PR DESCRIPTION
Fixing packages which were broken (and removed) during the move to OPAM 2