### PR TITLE
Chapar 8.9.0 release and dev package

### DIFF
--- a/extra-dev/packages/coq-chapar/coq-chapar.dev/opam
+++ b/extra-dev/packages/coq-chapar/coq-chapar.dev/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/chapar"
+dev-repo: "git+https://github.com/coq-community/chapar.git"
+bug-reports: "https://github.com/coq-community/chapar/issues"
+license: "MIT"
+
+synopsis: "A framework for verification of causal consistency for distributed key-value stores and their clients in Coq"
+description: """
+A framework for modular verification of causal consistency for replicated key-value
+store implementations and their client programs in Coq. Includes proofs of the causal consistency
+of two key-value store implementations and a simple automatic model checker for the correctness
+of client programs.
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
+]
+
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:causal consistency"
+  "keyword:key-value stores"
+  "keyword:distributed algorithms"
+  "keyword:program verification"
+  "logpath:Chapar"
+]
+authors: [
+  "Mohsen Lesani"
+  "Christian J. Bell"
+  "Adam Chlipala"
+]
+
+url {
+  src: "git+https://github.com/coq-community/chapar.git#master"
+}

--- a/released/packages/coq-chapar/coq-chapar.8.9.0/opam
+++ b/released/packages/coq-chapar/coq-chapar.8.9.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/chapar"
+dev-repo: "git+https://github.com/coq-community/chapar.git"
+bug-reports: "https://github.com/coq-community/chapar/issues"
+license: "MIT"
+
+synopsis: "A framework for verification of causal consistency for distributed key-value stores and their clients in Coq"
+description: """
+A framework for modular verification of causal consistency for replicated key-value
+store implementations and their client programs in Coq. Includes proofs of the causal consistency
+of two key-value store implementations and a simple automatic model checker for the correctness
+of client programs.
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.9" & < "8.10~"}
+]
+
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:causal consistency"
+  "keyword:key-value stores"
+  "keyword:distributed algorithms"
+  "keyword:program verification"
+  "logpath:Chapar"
+  "date:2019-05-15"
+]
+authors: [
+  "Mohsen Lesani"
+  "Christian J. Bell"
+  "Adam Chlipala"
+]
+
+url {
+  src: "https://github.com/coq-community/chapar/archive/v8.9.0.tar.gz"
+  checksum: "sha256=a4b76cb183a159a98ec50327d8bf7285055a6fdd0617385b465e97277dfa17da"
+}


### PR DESCRIPTION
This project currently uses an axiom to define the maximum number of distributed nodes in a system (filled in after extraction to OCaml code). In future releases, I hope to make this a simple parameter. Since there is no soundness issue with the axiom, I believe these packages should be allowed under current guidelines.