### PR TITLE
add Coq and CoqIDE 8.10+beta1 packages in core-dev

### DIFF
--- a/core-dev/packages/coq/coq.8.10+beta1/files/coq.install
+++ b/core-dev/packages/coq/coq.8.10+beta1/files/coq.install
@@ -1,0 +1,12 @@
+bin: [
+  "bin/coqwc"
+  "bin/coqtop"
+  "bin/coqtop.byte"
+  "bin/coqdoc"
+  "bin/coqdep"
+  "bin/coqchk"
+  "bin/coqc"
+  "bin/coq_makefile"
+  "bin/coq-tex"
+  "bin/coqworkmgr"
+]

--- a/core-dev/packages/coq/coq.8.10+beta1/opam
+++ b/core-dev/packages/coq/coq.8.10+beta1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "Formal proof management system"
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "num"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-coqide" "no"
+  ]
+  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" "byte"]
+]
+install: [
+  [make "install"]
+  [make "install-byte"]
+]
+extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.10+beta1.tar.gz"
+  checksum: "md5=ef38adef06580d047ec13cedb5c71013"
+}

--- a/core-dev/packages/coqide/coqide.8.10+beta1/files/coqide.install
+++ b/core-dev/packages/coqide/coqide.8.10+beta1/files/coqide.install
@@ -1,0 +1,9 @@
+bin: [
+  "bin/coqide"
+]
+share_root: [
+  "ide/coq.lang" {"coq/coq.lang"}
+  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coq.png" {"coq/coq.png"}
+  "ide/coq_style.xml" {"coq/coq_style.xml"}
+]

--- a/core-dev/packages/coqide/coqide.8.10+beta1/opam
+++ b/core-dev/packages/coqide/coqide.8.10+beta1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "IDE of the Coq formal proof management system"
+
+depends: [
+  "coq" {= version}
+  "lablgtk3-sourceview3"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+  ]
+  [make "-j%{jobs}%" "coqide-files"]
+  [make "-j%{jobs}%" "coqide-opt"]
+]
+install: [
+  make
+  "install-ide-bin"
+  "install-ide-files"
+  "install-ide-info"
+  "install-ide-devfiles"
+]
+extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
+
+url {
+  src: "https://github.com/coq/coq/archive/V8.10+beta1.tar.gz"
+  checksum: "md5=ef38adef06580d047ec13cedb5c71013"
+}


### PR DESCRIPTION
Note that these are based on the current 8.10/dev packages in `core-dev`. However, as has been pointed out by @ejgallego, there are now different OPAM package definitions that use dune available as well (with CoqIDE split up into `coqide` and `coqide-server`). 

I think it's in everyone's interest for there to be harmony among packages in `core-dev` and what ends up in the official OPAM repo. Hence, could you make the call @vbgl whether 8.10.0 will use dune in the official OPAM repo or not? If we aim to use dune, I can adjust the packages in this PR accordingly.

cc: @RalfJung