### PR TITLE
Add opam package coq-bignums.8.10+beta1

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.8.10+beta1/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.10+beta1/opam
@@ -17,7 +17,6 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bignums"]
 depends: [
   "ocaml"
   "coq" {>= "8.10" & < "8.11~"}
@@ -35,7 +34,6 @@ tags: [
 synopsis: "Bignums, the Coq library of arbitrary large numbers"
 description:
   "Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.7."
-flags: light-uninstall
 url {
   src: "https://github.com/coq/bignums/archive/V8.10+beta1.tar.gz"
   checksum: "md5=7389fc52776af64717fc6b4550066aa8"

--- a/extra-dev/packages/coq-bignums/coq-bignums.8.10+beta1/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.10+beta1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Laurent.Thery@inria.fr"
+homepage: "https://github.com/coq/bignums"
+dev-repo: "git+https://github.com/coq/bignums.git"
+bug-reports: "https://github.com/coq/bignums/issues"
+authors: [
+  "Laurent Théry"
+  "Benjamin Grégoire"
+  "Arnaud Spiwack"
+  "Evgeny Makarov"
+  "Pierre Letouzey"
+]
+license: "LGPL 2"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Bignums"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10" & < "8.11~"}
+]
+tags: [
+  "keyword:integer numbers"
+  "keyword:rational numbers"
+  "keyword:arithmetic"
+  "keyword:arbitrary-precision"
+  "category:Miscellaneous/Coq Extensions"
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "category:Mathematics/Arithmetic and Number Theory/Rational numbers"
+  "logpath:Bignums"
+]
+synopsis: "Bignums, the Coq library of arbitrary large numbers"
+description:
+  "Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.7."
+flags: light-uninstall
+url {
+  src: "https://github.com/coq/bignums/archive/V8.10+beta1.tar.gz"
+  checksum: "md5=7389fc52776af64717fc6b4550066aa8"
+}


### PR DESCRIPTION
(see also https://github.com/coq/coq/issues/8446#issuecomment-495956288)

Side question: is the version constraint `"coq" {>= "8.10~" & < "8.11~"}` OK or should it be stricter?