### PR TITLE
coq-fcsl-pcm dev depends on mathcomp dev

### DIFF
--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
@@ -13,7 +13,7 @@ install: [ make "install" ]
 depends: [
   "ocaml"
   "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.9.0" & < "1.10~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(= "dev")}
 ]
 tags: [
   "keyword:separation logic"


### PR DESCRIPTION
To use latest mathcomp features