### PR TITLE
disel is compatible with MathComp 1.9

### DIFF
--- a/released/packages/coq-disel-examples/coq-disel-examples.2.1/opam
+++ b/released/packages/coq-disel-examples/coq-disel-examples.2.1/opam
@@ -12,7 +12,7 @@ install: [make "-C" "Examples" "install"]
 depends: [
   "ocaml"
   "coq" {>= "8.7" & < "8.10~"}
-  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.9~"}
+  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.10~"}
   "coq-fcsl-pcm"
   "coq-disel" {= version}
 ]

--- a/released/packages/coq-disel/coq-disel.2.1/opam
+++ b/released/packages/coq-disel/coq-disel.2.1/opam
@@ -21,7 +21,7 @@ install: [make "-C" "Core" "install"]
 depends: [
   "ocaml"
   "coq" {>= "8.7" & < "8.10~"}
-  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.9~"}
+  "coq-mathcomp-ssreflect" {>= "1.6.2" & < "1.10~"}
   "coq-fcsl-pcm"
 ]
 tags: [


### PR DESCRIPTION
This also serves as a small test of index generation as in #730.