### PR TITLE
Make latest coq-mathcomp-ssreflect support coq.dev (unlike old versions)

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6.1/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6.1/opam
@@ -14,8 +14,7 @@ depends: [
   "ocaml"
   "coq"
     {((>= "8.4pl4" & < "8.5~") | (>= "8.5" & < "8.6~") |
-      (>= "8.6" & < "8.7~") |
-      (= "dev"))}
+      (>= "8.6" & < "8.7~"))}
 ]
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6.2/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6.2/opam
@@ -13,8 +13,7 @@ remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
 depends: [
   "ocaml"
   "coq"
-    {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~") |
-      (= "dev"))}
+    {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~"))}
 ]
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.6/opam
@@ -12,7 +12,7 @@ install: [ make "-C" "mathcomp/ssreflect" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
 depends: [
   "ocaml"
-  "coq" {((>= "8.4pl4" & < "8.5~") | (>= "8.5" & < "8.6~") | (= "dev"))}
+  "coq" {((>= "8.4pl4" & < "8.5~") | (>= "8.5" & < "8.6~"))}
 ]
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.7.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.7.0/opam
@@ -14,7 +14,7 @@ install: [ make "-C" "mathcomp/ssreflect" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
 depends: [
   "ocaml"
-  "coq" {((>= "8.6" & < "8.10~") | (= "dev"))}
+  "coq" {(>= "8.6" & < "8.10~")}
 ]
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.8.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.8.0/opam
@@ -11,7 +11,7 @@ license: "CeCILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp'" ]
-depends: [ "coq" { ((>= "8.7" & < "8.10~") | (= "dev"))} ]
+depends: [ "coq" {(>= "8.7" & < "8.10~")} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
@@ -10,7 +10,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { >= "8.7" & < "8.11~" } ]
+depends: [ "coq" { (>= "8.7" & < "8.11~") | (= "dev") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
Dear opam-coq maintainers,

This PR is a follow-up of #715, regarding compatibility of the latest released mathcomp with coq.dev.

We are aware of the discussion in https://github.com/coq/opam-coq-archive/pull/715#discussion_r287618607 (and of the ` --ignore-constraints-on` option mentioned in https://github.com/coq/opam-coq-archive/pull/715#issuecomment-496256709), so below are several observations to motivate this PR.

* The current situation seems unsatisfactory as coq-mathcomp-ssreflect.1.9.0 doesn't allow coq.dev, while all previous versions (`<= 1.8.0`) do.
* coq-mathcomp-ssreflect.1.9.0 is compatible with current coq.dev (cf. the first snippet below)
* even if the lack of this patch could to workarounded by doing:
  `opam install --ignore-constraints-on=coq coq-mathcomp-character.1.9.0`,
  this is really not practical, as all subsequent install of any other package would require the flag as well :-/ (cf. the second snippet below)

Hence this PR.

In particular, @proux01 and I stumbled on this issue when preparing a PR for coq.dev that has to be (locally) tested with stable versions of several dependencies, depending on mathcomp.

So we'd like to propose the following idea:

1. It is easy to detect when the latest mathcomp release (say, coq-mathcomp-ssreflect.1.n.0) doesn't compile with coq.dev anymore (e.g. thanks to the periodic rebuild of a Docker Hub image of coq.dev + latest mathcomp). Then, one could:
2. Remove the `mathcomp/mathcomp:1.n.0-coq-dev` Docker image
3. Release a new version of mathcomp (say, coq-mathcomp-ssreflect.1.n.1) compatible with coq.dev
4. Open a new PR targeting coq-released in this repo that simultaneously:
   * removes `"coq" {= "dev"}` in coq-mathcomp-ssreflect.1.n.0
   * adds coq-mathcomp-ssreflect.1.n.1 that allows `"coq" {= "dev"}` 
5. Create the opam-based Docker images, including `mathcomp/mathcomp:1.n.1-coq-dev`

What do you think about that suggestion for upcoming versions of mathcomp?
Cc @gares @CohenCyril

<details><summary>1st snippet: coq-mathcomp-character.1.9.0 OK with coq.dev</summary>

```
$ docker run --name=MC190 -it coqorg/coq:dev

coq@da2a805aa07b:~$ coqtop --version
The Coq Proof Assistant, version 8.10+alpha (June 2019)
compiled on Jun 4 2019 15:51:22 with OCaml 4.05.0

coq@da2a805aa07b:~$ rlwrap coqtop
Welcome to Coq bcaa5512ad49:/home/coq/.opam/4.05.0/.opam-switch/build/coq.dev/_build/default,master (589aaf4f97d5cfcdabfda285739228f5ee52261f)
Coq < 

coq@da2a805aa07b:~$ opam install -j 5 coq-mathcomp-ssreflect.1.9.0
The following dependencies couldn't be met:
  - coq-mathcomp-ssreflect -> coq < 8.11~
      not available because the package is pinned to version dev

No solution found, exiting

coq@da2a805aa07b:~$ opam install -j 5 --ignore-constraints-on=coq coq-mathcomp-character.1.9.0
The following actions will be performed:
  - install coq-mathcomp-ssreflect 1.9.0 [required by coq-mathcomp-fingroup]
  - install coq-mathcomp-fingroup  1.9.0 [required by coq-mathcomp-algebra]
  - install coq-mathcomp-algebra   1.9.0 [required by coq-mathcomp-solvable]
  - install coq-mathcomp-solvable  1.9.0 [required by coq-mathcomp-field]
  - install coq-mathcomp-field     1.9.0 [required by coq-mathcomp-character]
  - install coq-mathcomp-character 1.9.0
===== 6 to install =====
Do you want to continue? [Y/n] y

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[coq-mathcomp-algebra.1.9.0] downloaded from http://github.com/math-comp/math-comp/archive/mathcomp-1.9.0.tar.gz
[coq-mathcomp-character.1.9.0] downloaded from http://github.com/math-comp/math-comp/archive/mathcomp-1.9.0.tar.gz
[coq-mathcomp-field.1.9.0] downloaded from http://github.com/math-comp/math-comp/archive/mathcomp-1.9.0.tar.gz
[coq-mathcomp-fingroup.1.9.0] found in cache
[coq-mathcomp-solvable.1.9.0] found in cache
[coq-mathcomp-ssreflect.1.9.0] found in cache

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> installed coq-mathcomp-ssreflect.1.9.0
-> installed coq-mathcomp-fingroup.1.9.0
-> installed coq-mathcomp-algebra.1.9.0
-> installed coq-mathcomp-solvable.1.9.0
-> installed coq-mathcomp-field.1.9.0
-> installed coq-mathcomp-character.1.9.0
Done.

coq@da2a805aa07b:~$ opam pin add -k version coq-mathcomp-ssreflect 1.9.0
coq-mathcomp-ssreflect is now pinned to version 1.9.0

The following dependencies couldn't be met:
  - coq-mathcomp-ssreflect -> coq < 8.11~
      not available because the package is pinned to version dev

[NOTE] Pinning command successful, but your installed packages may be out of sync.

coq@da2a805aa07b:~$ 
```

</details>

<details><summary>2nd snippet: --ignore-constraints-on is not a proper solution</summary>

```
$ docker start -ai MC190

coq@da2a805aa07b:~$ opam list 
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-num               base        Num library distributed with the OCaml compiler
base-threads           base
base-unix              base
conf-m4                1           Virtual package relying on m4
coq                    dev         pinned to version dev at git+https://github.com/coq/coq#589aaf4f97d5cf
coq-bignums            dev         Bignums, the Coq library of arbitrary large numbers
coq-mathcomp-algebra   1.9.0       Mathematical Components Library on Algebra
coq-mathcomp-character 1.9.0       Mathematical Components Library on character theory
coq-mathcomp-field     1.9.0       Mathematical Components Library on Fields
coq-mathcomp-fingroup  1.9.0       Mathematical Components Library on finite groups
coq-mathcomp-solvable  1.9.0       Mathematical Components Library on finite groups (II)
coq-mathcomp-ssreflect 1.9.0       pinned to version 1.9.0
dune                   1.9.3       Fast, portable and opinionated build system
num                    0           The Num library for arbitrary-precision integer and rational arithmeti
ocaml                  4.05.0      The OCaml compiler (virtual package)
ocaml-base-compiler    4.05.0      Official 4.05.0 release
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.0       A library manager for OCaml
opam-depext            1.1.3       Query and install external dependencies of OPAM packages

coq@da2a805aa07b:~$ opam install ledit
The following actions will be performed:
  - install camlp5                 7.06.10-g84ce6cc4 [required by ledit]
  - remove  coq-mathcomp-character 1.9.0
  - install ledit                  2.04
  - remove  coq-mathcomp-field     1.9.0
  - remove  coq-mathcomp-solvable  1.9.0
  - remove  coq-mathcomp-algebra   1.9.0
  - remove  coq-mathcomp-fingroup  1.9.0
  - remove  coq-mathcomp-ssreflect 1.9.0*
===== 2 to install | 6 to remove =====
Do you want to continue? [Y/n] ^C

coq@da2a805aa07b:~$ opam install --ignore-constraints-on=coq ledit
The following actions will be performed:
  - install camlp5 7.06.10-g84ce6cc4 [required by ledit]
  - install ledit  2.04
===== 2 to install =====
Do you want to continue? [Y/n] 
```

</details>