### PR TITLE
Add coq-ltac2.{0.1, 0.2, 0.3}

### DIFF
--- a/released/packages/coq-ltac2/coq-ltac2.0.1-8.7/opam
+++ b/released/packages/coq-ltac2/coq-ltac2.0.1-8.7/opam
@@ -2,21 +2,20 @@ opam-version: "2.0"
 name: "coq-ltac2"
 maintainer: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
 license: "LGPL 2.1"
-homepage: "https://github.com/ppedrot/ltac2"
-dev-repo: "git+https://github.com/ppedrot/ltac2.git"
-bug-reports: "https://github.com/ppedrot/ltac2/issues"
+homepage: "https://github.com/coq/ltac2"
+dev-repo: "git+https://github.com/coq/ltac2.git"
+bug-reports: "https://github.com/coq/ltac2/issues"
 build: [
   [make "COQBIN=\"\"" "-j%{jobs}%"]
 ]
 install: [make "install"]
-remove: [make "uninstall"]
 depends: [
   "ocaml"
-  "coq" {>= "8.7" & < "8.8"}
+  "coq" {>= "8.7" & < "8.8~"}
 ]
 synopsis: "A tactic language for Coq"
 authors: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
 url {
-  src: "https://github.com/ppedrot/ltac2/archive/v0.1-8.7.tar.gz"
+  src: "https://github.com/coq/ltac2/archive/v0.1-8.7.tar.gz"
   checksum: "md5=748636d22bf0319fed33be80da014d93"
 }

--- a/released/packages/coq-ltac2/coq-ltac2.0.1/opam
+++ b/released/packages/coq-ltac2/coq-ltac2.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+name: "coq-ltac2"
+maintainer: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+license: "LGPL 2.1"
+homepage: "https://github.com/coq/ltac2"
+dev-repo: "git+https://github.com/coq/ltac2.git"
+bug-reports: "https://github.com/coq/ltac2/issues"
+build: [
+  [make "COQBIN=\"\"" "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.8" & < "8.9~"}
+]
+synopsis: "A tactic language for Coq"
+authors: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+url {
+  src: "https://github.com/coq/ltac2/archive/0.1.tar.gz"
+  checksum: "sha256=f03d81d0cf9f28bfb82bbf3c371fbab5878d0923952459739282f173dea816a8"
+}

--- a/released/packages/coq-ltac2/coq-ltac2.0.2/opam
+++ b/released/packages/coq-ltac2/coq-ltac2.0.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+name: "coq-ltac2"
+maintainer: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+license: "LGPL 2.1"
+homepage: "https://github.com/coq/ltac2"
+dev-repo: "git+https://github.com/coq/ltac2.git"
+bug-reports: "https://github.com/coq/ltac2/issues"
+build: [
+  [make "COQBIN=\"\"" "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.9" & < "8.10~"}
+]
+synopsis: "A tactic language for Coq"
+authors: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+url {
+  src: "https://github.com/coq/ltac2/archive/0.2.tar.gz"
+  checksum: "sha256=20120ace91e3269294926e0ea163a3f0da6a731c327f1276ad7e55b024b8d6f6"
+}

--- a/released/packages/coq-ltac2/coq-ltac2.0.3/opam
+++ b/released/packages/coq-ltac2/coq-ltac2.0.3/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+name: "coq-ltac2"
+maintainer: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+license: "LGPL 2.1"
+homepage: "https://github.com/coq/ltac2"
+dev-repo: "git+https://github.com/coq/ltac2.git"
+bug-reports: "https://github.com/coq/ltac2/issues"
+build: [
+  [make "COQBIN=\"\"" "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10" & < "8.11~"}
+]
+synopsis: "A tactic language for Coq"
+authors: "Pierre-Marie Pédrot <pierre-marie.pedrot@irif.fr>"
+url {
+  src: "https://github.com/coq/ltac2/archive/0.3.tar.gz"
+  checksum: "sha256=e759198cd7bf1145f822bc7dfad7f47a4c682b28bdd67376026276ae88d55feb"
+}


### PR DESCRIPTION
Hello,
This PR is a follow-up of [this thread](https://github.com/coq/ltac2/issues/105).

Minor remark: for the 3 new packages, I have inserted a sha256 hashsum (instead of md5) as opam 2 seems to support them [(doc)](https://opam.ocaml.org/doc/Manual.html#Checksums).
I can revert them back to md5 if this is desired for uniformity.