### PR TITLE
add CoqHammer packages in extra-dev

### DIFF
--- a/extra-dev/packages/coq-hammer-tactics/coq-hammer-tactics.8.10.dev/opam
+++ b/extra-dev/packages/coq-hammer-tactics/coq-hammer-tactics.8.10.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Reconstruction tactics for the hammer for Coq"
+description: """
+Collection of tactics that are used by the hammer for Coq
+to reconstruct proofs found by automated theorem provers. When the hammer
+has been successfully applied to a project, only this package needs
+to be installed; the hammer plugin is not required.
+"""
+
+build: [make "-j%{jobs}%" "tactics"]
+install: [make "install-tactics"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10" & < "8.11~"}
+]
+
+tags: [  
+  "keyword:automation"
+  "keyword:hammer"
+  "keyword:tactics"
+  "logpath:Hammer"
+]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]
+
+url {
+  src: "git+https://github.com/lukaszcz/coqhammer.git#coq8.10"
+}

--- a/extra-dev/packages/coq-hammer-tactics/coq-hammer-tactics.dev/opam
+++ b/extra-dev/packages/coq-hammer-tactics/coq-hammer-tactics.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Reconstruction tactics for the hammer for Coq"
+description: """
+Collection of tactics that are used by the hammer for Coq
+to reconstruct proofs found by automated theorem provers. When the hammer
+has been successfully applied to a project, only this package needs
+to be installed; the hammer plugin is not required.
+"""
+
+build: [make "-j%{jobs}%" "tactics"]
+install: [make "install-tactics"]
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+]
+
+tags: [  
+  "keyword:automation"
+  "keyword:hammer"
+  "keyword:tactics"
+  "logpath:Hammer"
+]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]
+
+url {
+  src: "git+https://github.com/lukaszcz/coqhammer.git#master"
+}

--- a/extra-dev/packages/coq-hammer/coq-hammer.8.10.dev/opam
+++ b/extra-dev/packages/coq-hammer/coq-hammer.8.10.dev/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "General-purpose automated reasoning hammer tool for Coq"
+description: """
+A general-purpose automated reasoning hammer tool for Coq that combines
+learning from previous proofs with the translation of problems to the
+logics of automated systems and the reconstruction of successfully found proofs.
+"""
+
+build: [make "-j%{jobs}%" "plugin"]
+install: [make "install-plugin"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10" & < "8.11~"}
+  "conf-g++" {build}
+  "coq-hammer-tactics" {= version}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:hammer"
+  "logpath:Hammer"
+]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]
+
+url {
+  src: "git+https://github.com/lukaszcz/coqhammer.git#coq8.10"
+}

--- a/extra-dev/packages/coq-hammer/coq-hammer.dev/opam
+++ b/extra-dev/packages/coq-hammer/coq-hammer.dev/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/lukaszcz/coqhammer"
+dev-repo: "git+https://github.com/lukaszcz/coqhammer.git"
+bug-reports: "https://github.com/lukaszcz/coqhammer/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "General-purpose automated reasoning hammer tool for Coq"
+description: """
+A general-purpose automated reasoning hammer tool for Coq that combines
+learning from previous proofs with the translation of problems to the
+logics of automated systems and the reconstruction of successfully found proofs.
+"""
+
+build: [make "-j%{jobs}%" "plugin"]
+install: [make "install-plugin"]
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+  "conf-g++" {build}
+  "coq-hammer-tactics" {= version}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:automation"
+  "keyword:hammer"
+  "logpath:Hammer"
+]
+
+authors: [
+  "Lukasz Czajka <lukaszcz@mimuw.edu.pl>"
+  "Cezary Kaliszyk <cezary.kaliszyk@uibk.ac.at>"
+  "Burak Ekici <burak.ekici@uibk.ac.at>"
+]
+
+url {
+  src: "git+https://github.com/lukaszcz/coqhammer.git#master"
+}


### PR DESCRIPTION
To my knowledge, Sledgehammer in Isabelle generates only built-in tactics for proof reconstruction, which is user friendly - there is no need to add extra dependencies to a project after applying Sledgehammer.

Thanks to recent changes in CoqHammer, a project need no longer depend on the whole hammer plugin after the hammer has been applied - only the reconstruction tactics, which are now bundled a separate package (`coq-hammer-tactics`) and useful in isolation. In particular, this elides the need for `gcc` and `g++`. Here are the corresponding extra-dev package definitions.