### PR TITLE
Packaging mathcomp-analysis version 0.2.2 (fix)

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.2.2/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.2.2/opam
@@ -20,7 +20,7 @@ install: [
 ]
 depends: [
   "coq" { (>= "8.8" | = "dev") }
-  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.9.0~")}
+  "coq-mathcomp-field"       {(>= "1.8.0" & < "1.10.0~")}
   "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1.0~")}
   "coq-mathcomp-finmap"      {(>= "1.2.0" & < "1.3.0~")}
 ]


### PR DESCRIPTION
Previous PR was too restrictive w.r.t. mathcomp's version.
