### PR TITLE
add conflict with old coq-hammer versions

### DIFF
--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.9/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.9/opam
@@ -21,6 +21,10 @@ depends: [
   "coq" {>= "8.8" & < "8.10~"}
 ]
 
+conflicts: [
+  "coq-hammer" {< version}
+]
+
 tags: [  
   "keyword:automation"
   "keyword:hammer"


### PR DESCRIPTION
Should not be needed for future releases due to incompatible Coq requirements.