### PR TITLE
Package coq-menhirlib.20190613

### DIFF
--- a/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -15,7 +15,9 @@ install: [
 ]
 depends: [
   "coq" { >= "8.6" }
-  "menhir" { = "20190613" }
+]
+conflicts: [
+  "menhir" { != "20190613" }
 ]
 url {
   src:

--- a/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -13,9 +13,6 @@ build: [
 install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
-remove: [
-  [make "-C" "coq-menhirlib" "uninstall"]
-]
 depends: [
   "coq" { >= "8.6" }
   "menhir" { = "20190613" }

--- a/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -19,6 +19,10 @@ depends: [
 conflicts: [
   "menhir" { != "20190613" }
 ]
+tags: [
+  "date:2019-06-13"
+  "logpath:MenhirLib"
+]
 url {
   src:
     "https://gitlab.inria.fr/fpottier/menhir/repository/20190613/archive.tar.gz"

--- a/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/packages/released/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+remove: [
+  [make "-C" "coq-menhirlib" "uninstall"]
+]
+depends: [
+  "coq" { >= "8.6" }
+  "menhir" { = "20190613" }
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20190613/archive.tar.gz"
+  checksum: [
+    "md5=23c380e23903e1974c923f3a6ff25ad4"
+    "sha512=0a929803068771bcc785abd94d37966fdb84f515f7f82393e685d44cc6e18144f62f2e00e0a7bf9b69f87c2c4bb9e33435878322d26b8fc37f7756fd84bc6f46"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20190613`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.0