### PR TITLE
It turns out that these coq-menhirlib versions are only compatible with Coq 8.8.

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.6" }
+  "coq" { >= "8.8" & < "8.9" }
 ]
 conflicts: [
   "menhir" { != "20190613" }

--- a/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.6" }
+  "coq" { >= "8.8" & < "8.9" }
 ]
 conflicts: [
   "menhir" { != "20190620" }


### PR DESCRIPTION
A fix is coming in a future release.