### PR TITLE
Packaging first version (1.0.0) of LibHyps.

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.1.0.0/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "coq-libhyps"
+version: "1.0.0"
+maintainer: "Pierre.Courtieu@lecnam.net"
+synopsis: "Hypotheses manipulation library"
+
+homepage: "https://github.com/Matafou/LibHyps"
+dev-repo: "git+https://github.com/Matafou/LibHyps.git"
+bug-reports: "https://github.com/Matafou/LibHyps/issues"
+doc: "https://github.com/Matafou/LibHyps"
+license: "GPL3"
+
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+
+install: [make "install"]
+
+depends: [
+  "coq" {(>= "8.9" & < "8.10~") | (= "dev")}
+]
+
+tags: [
+  "keyword:proof environment manipulation"
+  "keyword:forward reasoning"
+  "keyword:hypothesis naming"
+]
+
+authors: [
+ "Pierre Courtieu"
+]
+
+description: "
+This library defines a set of tactics to manipulate hypothesis
+indivually or by group. In particular it allows to apply a tactic on
+each hypothesis of a goal, or only *new* hypothesis after some tactic.
+Manipulations include: automatic renaming, decomposition, extracting
+premisses, but define your own manipulation on (groups of) hypothesis.
+"
+
+url {
+    http: "https://github.com/Matafou/LibHyps/archive/libhyps-1.0.0.tar.gz"
+    checksum: "07830a474ce69f1040677141880995c2"
+}


### PR DESCRIPTION
LibHyps

This library defines a set of tactics to manipulate hypothesis
indivually or by group. In particular it allows to apply a tactic on
each hypothesis of a goal, or only *new* hypothesis after some tactic.
Manipulations include: automatic renaming, decomposition, extracting
premisses, but define your own manipulation on (groups of) hypothesis.