### PR TITLE
Fix max menhir version for compcert.dev

### DIFF
--- a/extra-dev/packages/coq-compcert/coq-compcert.dev/opam
+++ b/extra-dev/packages/coq-compcert/coq-compcert.dev/opam
@@ -35,7 +35,7 @@ remove: [
 depends: [
   "ocaml"
   "coq" {= "dev"}
-  "menhir" {>= "20180530"}
+  "menhir" {>= "20180530" & <= "20181113"}
 ]
 synopsis: "The CompCert C compiler."
 authors: "Xavier Leroy <xavier.leroy@inria.fr>"


### PR DESCRIPTION
cf https://github.com/AbsInt/CompCert/blob/92b2d35f701ae55129fe2c34066d59d045460852/configure#L558