### PR TITLE
Use coq_makefile to build flocq.dev

### DIFF
--- a/extra-dev/packages/coq-flocq/coq-flocq.dev/opam
+++ b/extra-dev/packages/coq-flocq/coq-flocq.dev/opam
@@ -6,7 +6,10 @@ license: "LGPL 3"
 build: [
   ["./autogen.sh"]
   ["./configure"]
-  ["./remake" "-j%{jobs}%"]
+  ["find" "src" "-name" "*.v" "-fprint" "vfiles"]
+  ["sh" "-c" "cat _CoqProject vfiles > _CoqProject.full"] # how else to add to a file in opam?
+  ["coq_makefile" "-f" "_CoqProject.full" "-o" "Makefile"]
+  ["%{make}%" "-j" "%{jobs}%"]
 ]
 install: ["./remake" "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Flocq"]

--- a/extra-dev/packages/coq-flocq/coq-flocq.dev/opam
+++ b/extra-dev/packages/coq-flocq/coq-flocq.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "guillaume.melquiond@inria.fr"
+maintainer: "everybody"
 homepage: "http://flocq.gforge.inria.fr/"
 dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/flocq/flocq.git"
 license: "LGPL 3"


### PR DESCRIPTION
This makes it possible to get per file timings in Coq's bench (which sets the environment variable TIMING=1)
I think this works OK but I'm not 100% sure we want to merge this, what do other people think?

cc @silene as maintainer according to the opam file