### PR TITLE
Fix Coq version of coq-menhirlib.20190620

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.8" & < "8.9" }
+  "coq" { >= "8.8.1" & < "8.9" }
 ]
 conflicts: [
   "menhir" { != "20190620" }


### PR DESCRIPTION
Error: https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.1/released/8.8.0/menhirlib/20190620.html