### PR TITLE
Fix Coq version for coq-menhirlib.20190613

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.8" & < "8.9" }
+  "coq" { >= "8.8.1" & < "8.9" }
 ]
 conflicts: [
   "menhir" { != "20190613" }


### PR DESCRIPTION
Bug: https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.1/released/8.8.0/menhirlib/20190613.html