### PR TITLE
Fix Coq version of coq-equations.1.2+8.8

### DIFF
--- a/released/packages/coq-equations/coq-equations.1.2+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.2+8.8/opam
@@ -27,7 +27,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.8" & < "8.9~"}
+  "coq" {>= "8.8.1" & < "8.9~"}
 ]
 url {
   src:


### PR DESCRIPTION
Bug: https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.1/released/8.8.0/equations/1.2%2B8.8.html