### PR TITLE
Fix Coq version for coq-mathcomp-finmap.1.0.0

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.0.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.0.0/opam
@@ -5,12 +5,14 @@ maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "http://www.cyrilcohen.fr"
 bug-reports: "Cyril Cohen <cyril.cohen@inria.fr>"
+dev-repo: "git+https://github.com/math-comp/finmap.git"
 license: "CeCILL-B"
 
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
   "ocaml"
+  "coq" {>= "8.6"}
   "coq-mathcomp-ssreflect" {>= "1.6.1" & < "1.8~"}
 ]
 tags: [


### PR DESCRIPTION
https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.1/released/8.5.3/mathcomp-finmap/1.0.0.html

This error went undetected before because opam was upgrading Coq while installing this package (behaviour now fixed).