### PR TITLE
Fix install of some dev packages

### DIFF
--- a/extra-dev/packages/coq-checker/coq-checker.dev/opam
+++ b/extra-dev/packages/coq-checker/coq-checker.dev/opam
@@ -5,8 +5,8 @@ license: "LGPL 2"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Checker"]
 depends: [
   "ocaml"

--- a/extra-dev/packages/coq-chinese/coq-chinese.dev/opam
+++ b/extra-dev/packages/coq-chinese/coq-chinese.dev/opam
@@ -5,8 +5,8 @@ license: "Proprietary"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Chinese"]
 depends: [
   "ocaml"

--- a/extra-dev/packages/coq-circuits/coq-circuits.dev/opam
+++ b/extra-dev/packages/coq-circuits/coq-circuits.dev/opam
@@ -5,8 +5,8 @@ license: "LGPL 2"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Circuits"]
 depends: [
   "ocaml"

--- a/extra-dev/packages/coq-concat/coq-concat.dev/opam
+++ b/extra-dev/packages/coq-concat/coq-concat.dev/opam
@@ -5,8 +5,8 @@ license: "LGPL 2"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ConCaT"]
 depends: [
   "ocaml"

--- a/extra-dev/packages/coq-constructive-geometry/coq-constructive-geometry.dev/opam
+++ b/extra-dev/packages/coq-constructive-geometry/coq-constructive-geometry.dev/opam
@@ -5,8 +5,8 @@ license: "Proprietary"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/ConstructiveGeometry"]
 depends: [
   "ocaml"

--- a/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
+++ b/extra-dev/packages/coq-coqoban/coq-coqoban.dev/opam
@@ -5,8 +5,8 @@ license: "LGPL 2"
 build: [
   ["coq_makefile" "-f" "Make" "-o" "Makefile"]
   [make "-j%{jobs}%"]
-  [make "install"]
 ]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqoban"]
 depends: [
   "ocaml"


### PR DESCRIPTION
To prevent generating the following kind of error:
```
install: cannot change permissions of '/home/bench/.opam/ocaml-base-compiler.4.05.0/lib/coq//user-contrib/Exceptions/': No such file or directory
```