### PR TITLE
Packaging infotheo version 0.0.4

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.0.4/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.0.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "reynald.affeldt@aist.go.jp"
+homepage: "https://github.com/affeldt-aist/infotheo"
+bug-reports: "https://github.com/affeldt-aist/infotheo/issues"
+dev-repo: "git+https://github.com/affeldt-aist/infotheo.git"
+license: "GPLv3"
+authors: [
+  "Reynald Affeldt"
+  "Manabu Hagiwara"
+  "Jonas Senizergues"
+  "Jacques Garrigue"
+  "Kazuhiko Sakaguchi"
+  "Taku Asai"
+  "Takafumi Saikawa"
+  "Naruomi Obata"
+  "Erik Martin-Dorel"
+  "Ryosuke Obi"
+  "Mitsuharu Yamamoto"
+]
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make]
+  [make "-C" "extraction" "tests"] {with-test}
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.1" & < "8.10~"}
+  "coq-mathcomp-field" {>= "1.9.0" & < "1.10~"}
+  "coq-mathcomp-analysis"   {>= "0.2.0" & <= "0.2.2"}
+]
+synopsis: "Infotheo"
+description: """
+a Coq formalization of information theory and linear error-correcting codes
+"""
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword: information theory"
+  "keyword: probability"
+  "keyword: error-correcting codes"
+  "logpath:infotheo"
+  "date:2019-09-17"
+]
+url {
+  http: "https://github.com/affeldt-aist/infotheo/archive/0.0.4.tar.gz"
+  checksum: "bd4b64fa26c55400f056aebdfda7c820"
+}


### PR DESCRIPTION
This is an update of infotheo necessary to package another development (coq-monae).