### PR TITLE
Add coqutil package

### DIFF
--- a/extra-dev/packages/coq-coqutil/coq-coqutil.dev/opam
+++ b/extra-dev/packages/coq-coqutil/coq-coqutil.dev/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/coqutil"]
+depends: [
+  "coq" {>= "8.9~"}
+]
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+flags: light-uninstall
+url {
+  src: "git+https://github.com/mit-plv/coqutil.git#master"
+}


### PR DESCRIPTION
Primarily because it will be a dependency of bedrock2, which will soon
be a dependency of fiat-crypto.