### PR TITLE
Revert "ExtLib: don't stick to coq.dev"

### DIFF
--- a/extra-dev/packages/coq-ext-lib/coq-ext-lib.dev/opam
+++ b/extra-dev/packages/coq-ext-lib/coq-ext-lib.dev/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.8" | = "dev"}
+  "coq" {= "dev"}
 ]
 synopsis: "A library of Coq definitions, theorems, and tactics."
 flags: light-uninstall


### PR DESCRIPTION
Reverts coq/opam-coq-archive#637
Master branch of ExtLib no longer works with non-dev Coq releases, not even 8.10.