### PR TITLE
Update fiat-crypto dependency

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -16,7 +16,7 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install" "install-standalone-ocaml"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "ocaml"
-  "coq" {>= "8.8~"}
+  "coq" {>= "8.9~"}
   "coqprime"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"


### PR DESCRIPTION
For compatibility with https://github.com/mit-plv/fiat-crypto/pull/591

We could leave behind a package that works with Coq 8.8 based on the
v8.8 branch, but it's not clear to me that this would be beneficial.