### PR TITLE
Fix the name of the fiat-crypto dependency

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -17,7 +17,7 @@ remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Crypto"]
 depends: [
   "ocaml"
   "coq" {>= "8.9~"}
-  "coqprime"
+  "coq-coqprime"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation in Fiat."


### PR DESCRIPTION
Closes coq/coq-bench#73