### PR TITLE
Add bedrock2 as a dependency of fiat-crypto

### DIFF
--- a/extra-dev/packages/coq-bedrock2/coq-bedrock2.dev/opam
+++ b/extra-dev/packages/coq-bedrock2/coq-bedrock2.dev/opam
@@ -15,7 +15,7 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install_bedrock2"]
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/bedrock2"]
 depends: [
   "coq" {>= "8.9~"}
-  "coqutil"
+  "coq-coqutil"
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
 synopsis: "A work-in-progress language and compiler for verified low-level programming"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.9~"}
   "coq-coqprime"
+  "coq-bedrock2"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation in Fiat."


### PR DESCRIPTION
To account for https://github.com/mit-plv/fiat-crypto/pull/587