### PR TITLE
Fix the Coq version for coq-metacoq-translations.1.0~alpha+8.8

### DIFF
--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~alpha+8.8/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~alpha+8.8/opam
@@ -19,7 +19,7 @@ install: [
 ]
 depends: [
   "ocaml" {> "4.02.3"}
-  "coq" {>= "8.8" & < "8.9~"}
+  "coq" {>= "8.8.1" & < "8.9~"}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}
 ]


### PR DESCRIPTION
@mattam82 The issue concerns only the `8.8.0` version of Coq (`8.8.1` is fine): https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.1/released/8.8.0/metacoq-translations/1.0~alpha%2B8.8.html

The gist:
```
- File "./param_original.v", line 226, characters 2-101:
- Error:
- The term
-  "fun f : forall (A : Type) (x y : A), x = y -> x = y =>
-   forall (A : Type) (Aᵗ : A -> Type) (x : A) (xᵗ : Aᵗ x) 
-     (y : A) (yᵗ : Aᵗ y) (p : x = y),
-   eqᵗ A Aᵗ x xᵗ y yᵗ p -> eqᵗ A Aᵗ x xᵗ y yᵗ (f A x y p)" has type
-  "(forall (A : Type) (x y : A), x = y -> x = y) -> Type"
- while it is expected to have type
-  "(forall (A : Type) (x y : A), x = y -> x = y) -> Prop".
```
and:
```
- File "./times_bool_fun.v", line 229, characters 0-163:
- Error:
- The term
-  "((forall A : Set,
-     (forall B : Set,
-      (forall f : (A -> B) × bool,
-       (forall g : (A -> B) × bool,
-        ((forall x : A, π1 (π1 (π1 pathsᵗ B) (π1 f x)) (π1 g x)) × bool ->
-         π1 (π1 (π1 pathsᵗ ((A -> B) × bool)) f) g) × bool) × bool) × bool)
-     × bool) × bool -> Falseᵗ) × bool" has type "Type"
- while it is expected to have type "Set".
```