### PR TITLE
Fix Coq version for coq-flocq-quickchick.1.0.1

### DIFF
--- a/released/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.1/opam
+++ b/released/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.1/opam
@@ -6,7 +6,7 @@ license: "MIT"
 homepage: "https://github.com/digamma-ai/flocq-quickchick"
 bug-reports: "https://github.com/digamma-ai/flocq-quickchick/issues"
 depends: [
-  "coq" {>= "8.8.2"}
+  "coq" {>= "8.9"}
   "coq-quickchick" {>= "1.0.2"}
   "coq-flocq" {>= "3.1.0"}
 ]


### PR DESCRIPTION
@p3rsik This package fails with the `8.8.2` version of Coq: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/8.8.2/flocq-quickchick/1.0.1.html It seems to me that the last change https://github.com/digamma-ai/flocq-quickchick/commit/39f92421219d5db7e02650767d5145de94101de4 actually made it incompatible with `8.8`.