### PR TITLE
Extend the compatible Coq versions for coq-rsa

### DIFF
--- a/released/packages/coq-rsa/coq-rsa.8.8.0/opam
+++ b/released/packages/coq-rsa/coq-rsa.8.8.0/opam
@@ -7,7 +7,7 @@ install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/RSA"]
 depends: [
   "ocaml"
-  "coq" {>= "8.8" & < "8.9~"}
+  "coq" {>= "8.8"}
 ]
 tags: [ "keyword: RSA" "keyword: Chinese remainder" "keyword: Fermat's little theorem" "category: Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms" "date: 1999" ]
 authors: [ "Jose C. Almeida" "Laurent Théry" ]


### PR DESCRIPTION
@herbelin I do not know what you think about saying that a contrib can be installed with Coq 8.9, even if there was no new tag `v8.9`.
Related to https://github.com/coq/opam-coq-archive/issues/936