### PR TITLE
Backport dependency on conf-findutils

### DIFF
--- a/core-dev/packages/coq/coq.8.10.dev/opam
+++ b/core-dev/packages/coq/coq.8.10.dev/opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
   "num"
+  "conf-findutils" {build}
 ]
 build: [
   [


### PR DESCRIPTION
Backported from https://github.com/ocaml/opam-repository/pull/15017, following
https://github.com/coq/opam-coq-archive/issues/944.

Assigning to @clarus since he's seen the original change.