### PR TITLE
fcsl-pcm: coq >= 8.10

### DIFF
--- a/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
+++ b/extra-dev/packages/coq-fcsl-pcm/coq-fcsl-pcm.dev/opam
@@ -12,7 +12,7 @@ build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
 depends: [
   "ocaml"
-  "coq" {(>= "8.9" & < "8.11~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.11~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(= "dev")}
 ]
 tags: [


### PR DESCRIPTION
After this is merged, I'll introduce backwards incompatible changes to fcsl-pcm's master