### PR TITLE
Fix Coq version for coq-pi-agm.1.2.3

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.3/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.3/opam
@@ -12,7 +12,7 @@ install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {>= "8.9"}
+  "coq" {>= "8.9" & < "8.10~"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "3.1"}
 ]


### PR DESCRIPTION
@ybertot The latest version of `coq-pi-agm` does not seem to compile with Coq 8.10:
```
# [...]
# File "./filter_Rlt.v", line 645, characters 30-37:
# Warning: Tactic fourier is deprecated since 8.9.0. Use lra instead.
# [deprecated-tactic,deprecated]
# COQC generalities.v
# COQC elliptic_integral.v
# File "./elliptic_integral.v", line 641, characters 4-45:
# Error: Rdiv does not occur.
# 
# Makefile:658: recipe for target 'elliptic_integral.vo' failed
# make[1]: *** [elliptic_integral.vo] Error 1
# Makefile:320: recipe for target 'all' failed
# make: *** [all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-pi-agm 1.2.3
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-pi-agm.1.2.3 coq.8.10.0' failed.
```