### PR TITLE
coqide: Depend on conf-findutils and conf-gnome-icon-theme3

### DIFF
--- a/core-dev/packages/coqide/coqide.8.10.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.10.dev/opam
@@ -10,6 +10,8 @@ synopsis: "IDE of the Coq formal proof management system"
 depends: [
   "coq" {= version}
   "lablgtk3-sourceview3"
+  "conf-findutils" {build}
+  "conf-gnome-icon-theme3"
 ]
 build: [
   [


### PR DESCRIPTION
Fix #944.
- Backport ocaml/opam-repository#15050.
- Let coqide depend on findutils as well (backport from
https://github.com/ocaml/opam-repository/pull/15017/commits/e78ef91b57664065b802e18bdac7013eca784dc4,
forgot in #946).