### PR TITLE
Fix Coq version for coq-geocoq-axioms.2.4.0

### DIFF
--- a/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.4.0/opam
+++ b/released/packages/coq-geocoq-axioms/coq-geocoq-axioms.2.4.0/opam
@@ -12,7 +12,10 @@ license: "LGPL 3"
 homepage: "http://geocoq.github.io/GeoCoq/"
 bug-reports: "https://github.com/GeoCoq/GeoCoq/issues"
 dev-repo: "git+https://github.com/GeoCoq/GeoCoq.git"
-depends: [ "coq-geocoq-coinc" { = "2.4.0" } ]
+depends: [
+  "coq" {>= "8.7"}
+  "coq-geocoq-coinc" { = "2.4.0" }
+]
 build: [
   ["./configure-axioms.sh"]
   [make "-j%{jobs}%"]


### PR DESCRIPTION
@jnarboux I got this bug with `coq.8.6.1`:
```
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-geocoq-axioms: ./configure-axioms.sh]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure-axioms.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-geocoq-axioms.2.4.0)
- Fatal error: exception Invalid_argument("index out of bounds")
[ERROR] The compilation of coq-geocoq-axioms failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build ./configure-axioms.sh".
#=== ERROR while compiling coq-geocoq-axioms.2.4.0 ============================#
# context              2.0.1 | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-geocoq-axioms.2.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure-axioms.sh
# exit-code            2
# env-file             ~/.opam/log/coq-geocoq-axioms-12409-e7966f.env
# output-file          ~/.opam/log/coq-geocoq-axioms-12409-e7966f.out
### output ###
# Fatal error: exception Invalid_argument("index out of bounds")
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-geocoq-axioms 2.4.0
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-geocoq-axioms.2.4.0 coq.8.6.1' failed.
```