### PR TITLE
pi-agm compatible coq 8.10

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "coq-pi-agm"
+version: "1.2.4"
+maintainer: "yves.bertot@inria.fr"
+
+homepage: "http://www-sop.inria.fr/members/Yves.Bertot/"
+bug-reports: "yves.bertot@inria.fr"
+license: "CeCILL-B"
+build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
+       [ make "-j" "%{jobs}%" ]]
+install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
+depends: [
+  "ocaml"
+  "coq" {>= "8.10"}
+  "coq-coquelicot" {>= "3" & < "4~"}
+  "coq-interval" {>= "3.1"}
+]
+tags: [ "keyword:real analysis" "keyword:pi" "category:Mathematics/Real Calculus and Topology" ]
+authors: [ "Yves Bertot <yves.bertot@inria.fr>" ]
+synopsis:
+  "Computing thousands or millions of digits of PI with arithmetic-geometric means"
+description: """
+This is a proof of correctness for two algorithms to compute PI to high
+precision using arithmetic-geometric means.  A first file contains
+the calculus-based proofs for an abstract view of the algorithm, where all
+numbers are real numbers.  A second file describes how to approximate all
+computations using large integers.  Other files describe the second algorithm
+which is close to the one used in mpfr, for instance.
+
+The whole development can be used to produce mathematically proved and
+formally verified approximations of PI."""
+url {
+  src: "https://github.com/ybertot/pi-agm/archive/v1.2.4.zip"
+  checksum: "sha256=eed94de774db29709aa28dabb46a7205574e06aa3c977c2ce478eae89276b9f"
+}

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
@@ -31,5 +31,5 @@ The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
   src: "https://github.com/ybertot/pi-agm/archive/v1.2.4.zip"
-  checksum: "sha256=eed94de774db29709aa28dabb46a7205574e06aa3c977c2ce478eae89276b9f"
+  checksum: "sha256=f24f92b06f0afbdc56d89d5d0da10d80305298ad9470d03cf22ef882fbac0694"
 }


### PR DESCRIPTION
The previous version of the sources only works for coq 8.9 because of a slight change in the behavior of field_simplify.
On the other hand, all uses of fourier have been removed and replaced by uses of lra.