### PR TITLE
Fix OCaml version for coq-dpdgraph.0.6.4

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.4/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.4/opam
@@ -23,7 +23,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "4.08.0"}
   "coq" {>= "8.9" & < "8.10~"}
   "ocamlgraph"
 ]


### PR DESCRIPTION
@ybertot The latest version of `coq-dpdgraph` does not work with OCaml 4.08:
```
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
camlp5              7.10        Preprocessor-pretty-printer of OCaml
conf-m4             1           Virtual package relying on m4
coq                 8.9.1       Formal proof management system
num                 1.2         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.08.1      The OCaml compiler (virtual package)
ocaml-base-compiler 4.08.1      Official release 4.08.1
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
ocamlgraph          1.8.8       A generic graph library for OCaml
[NOTE] Package coq is already installed (current version is 8.9.1).
The following actions will be performed:
  - install coq-dpdgraph 0.6.4
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-dpdgraph.0.6.4: http]
[coq-dpdgraph.0.6.4] downloaded from https://github.com/Karmaki/coq-dpdgraph/releases/download/v0.6.4/coq-dpdgraph-0.6.4.tgz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-dpdgraph: ./configure]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4)
- configure: coq-dpdgraph version 0.6.4
- configure: ~~~~~~~~~~~~~~~~~~~~
- configure: ~~ OCaml compilers  
- configure: ~~~~~~~~~~~~~~~~~~~~
- checking for ocamlc... ocamlc
- checking ocamlc version... 4.08.1
- checking ocamlc -safe-string option... yes
- checking ocaml library path... /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/ocaml
- checking for ocamlopt... ocamlopt
- checking ocamlopt version... ok
- checking for ocamlc.opt... ocamlc.opt
- checking ocamlc.opt version... ok
- checking for ocamlopt.opt... ocamlopt.opt
- checking ocamlc.opt version... ok
- checking for ocamldep... ocamldep
- checking for ocamllex... ocamllex
- checking for ocamllex.opt... ocamllex.opt
- checking for ocamlyacc... ocamlyacc
- checking for ocamldoc... ocamldoc
- checking for ocamldoc.opt... ocamldoc.opt
- configure: ~~~~~~~~~~~~~~~
- configure: ~~ ocamlgraph  
- configure: ~~~~~~~~~~~~~~~
- checking for ocamlfind... ocamlfind
- checking ocamlfind compatibility... yes
- checking ocamlgraph package... /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/ocamlgraph
- configure: ~~~~~~~~
- configure: ~~ Coq  
- configure: ~~~~~~~~
- checking for coqc... coqc
- checking coq version... 8.9.1 (October 2019)
- checking for coq_makefile... coq_makefile
- configure: ~~~~~~~~~~~~~~~~~~~~~~
- configure: ~~ creating Makefile  
- configure: ~~~~~~~~~~~~~~~~~~~~~~
- configure: creating ./config.status
- config.status: creating Makefile
Processing  1/2: [coq-dpdgraph: echo 4]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "echo" "4" "jobs for the linter" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4)
- 4 jobs for the linter
Processing  1/2: [coq-dpdgraph: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4)
- Makefile:125: .depend: No such file or directory
-    * build version.ml
-    * build dpd_parse.ml
- ocamlyacc dpd_parse.mly
-    * build dpd_lex.ml
- ocamllex.opt dpd_lex.mll
- 29 states, 495 transitions, table size 2154 bytes
-    * build .depend
- ocamldep version.ml dpd_compute.ml dpd_dot.ml dpd_parse.ml  dpd_lex.ml dpd2dot.ml dpdusage.ml *.mli > .depend
-    * build Make_coq
- coq_makefile -f Make -o Make_coq
-    * build dpdgraph.vo
- make -f Make_coq dpdgraph.vo
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4'
- COQDEP VFILES
- *** Warning: dpdgraph.mllib already found in . (discarding ./dpdgraph.mllib)
- 
- *** Warning: graphdepend.ml4 already found in . (discarding ./graphdepend.ml4)
- 
- *** Warning: searchdepend.ml4 already found in . (discarding ./searchdepend.ml4)
- 
- COQDEP dpdgraph.mllib
- *** Warning: dpdgraph.mllib already found in . (discarding ./dpdgraph.mllib)
- 
- CAMLDEP -pp graphdepend.ml4
- CAMLDEP -pp searchdepend.ml4
- CAMLOPT -pp -c  searchdepend.ml4
- CAMLOPT -pp -c  graphdepend.ml4
- File "graphdepend.ml4", line 54, characters 24-42:
- 54 |     let compare n1 n2 = Pervasives.compare (id n1) (id n2)
-                              ^^^^^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- CAMLOPT -a -o dpdgraph.cmxa
- CAMLOPT -shared -o dpdgraph.cmxs
- COQC dpdgraph.v
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4'
-    * build version.cmo
- ocamlc.opt -w +a -warn-error +a -g -dtypes -I /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/ocamlgraph -c  version.ml
-    * build dpd_compute.cmo
- ocamlc.opt -w +a -warn-error +a -g -dtypes -I /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/ocamlgraph -c  dpd_compute.ml
- File "dpd_compute.ml", line 91, characters 22-40:
- 91 |   let compare n1 n2 = Pervasives.compare (id n1) (id n2)
-                            ^^^^^^^^^^^^^^^^^^
- Error (alert deprecated): module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "dpd_compute.ml", line 99, characters 22-40:
- 99 |   let compare e1 e2 = Pervasives.compare e1 e2
-                            ^^^^^^^^^^^^^^^^^^
- Error (alert deprecated): module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- Makefile:96: recipe for target 'dpd_compute.cmo' failed
- make: *** [dpd_compute.cmo] Error 2
[ERROR] The compilation of coq-dpdgraph failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make".
#=== ERROR while compiling coq-dpdgraph.0.6.4 =================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-dpdgraph.0.6.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/coq-dpdgraph-1296-0a5907.env
# output-file          ~/.opam/log/coq-dpdgraph-1296-0a5907.out
### output ###
# [...]
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# File "dpd_compute.ml", line 99, characters 22-40:
# 99 |   let compare e1 e2 = Pervasives.compare e1 e2
#                            ^^^^^^^^^^^^^^^^^^
# Error (alert deprecated): module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# Makefile:96: recipe for target 'dpd_compute.cmo' failed
# make: *** [dpd_compute.cmo] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-dpdgraph 0.6.4
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-dpdgraph.0.6.4 coq.8.9.1' failed.
```