### PR TITLE
Workaround coq/bignums#26

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
@@ -11,11 +11,12 @@ description: """
 Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 """
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+
 depends: [
   "ocaml"
   "coq" {= "dev"}
-  "dune" {>= "1.9.0"}
 ]
 
 tags: [


### PR DESCRIPTION
Close coq/bignums#26

This tiny PR is a clone of https://github.com/coq/bignums/pull/27, albeit necessary for building `coqorg/coq:dev`, relying on the `extra-dev` opam coq repo

Cc @vbgl @palmskog FYI