### PR TITLE
[CoqEAL] Release 1.0.1 with support for Coq 8.10

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.0.1/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+homepage: "https://github.com/CoqEAL/CoqEAL"
+bug-reports: "https://github.com/CoqEAL/CoqEAL/issues"
+dev-repo: "git+https://github.com/CoqEAL/CoqEAL.git"
+
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {(>= "8.7" & < "8.11~")}
+  "coq-bignums" {(>= "8.7" & < "8.11~")}
+  "coq-paramcoq" {(>= "1.1.1")}
+  "coq-mathcomp-multinomials" {(>= "1.2")}
+  "coq-mathcomp-algebra" {(>= "1.8.0" & < "1.10~")}
+]
+
+tags: [
+  "keyword:effective algebra"
+  "keyword:elementary divisor rings"
+  "keyword:Smith normal form"
+  "keyword:mathematical components"
+  "keyword:Bareiss"
+  "keyword:Karatsuba"
+  "keyword:refinements"
+  "logpath:CoqEAL"
+]
+authors: [
+  "Guillaume Cano"
+  "Cyril Cohen"
+  "Maxime Dénès"
+  "Anders Mörtberg"
+  "Vincent Siles"
+]
+
+synopsis: "CoqEAL - The Coq Effective Algebra Library"
+description: """
+This libary contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
+- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
+- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof.
+"""
+url {
+  src: "https://github.com/CoqEAL/CoqEAL/archive/1.0.1.tar.gz"
+  checksum: "sha256=a289dbdfbb6dd9e8b8e95cfa202d59b82408fb921071709b45b65117c5e6feeb"
+}


### PR DESCRIPTION
Follow up on https://github.com/coq/opam-coq-archive/pull/1015 with the new release upstream