### PR TITLE
Fix compilation of coqide.dev package

### DIFF
--- a/core-dev/packages/coqide-server/coqide-server.dev/opam
+++ b/core-dev/packages/coqide-server/coqide-server.dev/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1"
+synopsis: "The coqidetop language server"
+description: """
+This package provides the `coqidetop` language server, an
+implementation of Coq's [XML protocol](https://github.com/coq/coq/blob/master/dev/doc/xml-protocol.md)
+which allows clients, such as CoqIDE, to interact with Coq in a
+structured way.
+"""
+
+depends: [
+  "dune"      { build & >= "1.10.0" }
+  "coq"       {          = version }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+
+url {
+  src: "git+https://github.com/coq/coq.git#master"
+}

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -6,32 +6,28 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 synopsis: "IDE of the Coq formal proof management system"
+description: """
+CoqIDE is a graphical user interface for interactive development
+of mathematical definitions, executable algorithms, and proofs of theorems
+using the Coq proof assistant.
+"""
 
 depends: [
-  "coq" {= version}
-  "lablgtk3-sourceview3"
+  "dune"                 { build & >= "1.10.0" }
+  "coqide-server"        {          = version }
+  "lablgtk3"             {         >= "3.0.beta5" }
+  "lablgtk3-sourceview3" {         >= "3.0.beta5" }
 ]
-build: [
-  [
-    "./configure"
-    "-configdir" "%{lib}%/coq/config"
-    "-prefix" prefix
-    "-mandir" man
-    "-docdir" doc
-    "-libdir" "%{lib}%/coq"
-    "-datadir" "%{share}%/coq"
-  ]
-  [make "-j%{jobs}%" "coqide-files"]
-  [make "-j%{jobs}%" "coqide-opt"]
+
+build-env: [
+  [ COQ_CONFIGURE_PREFIX = "%{prefix}" ]
 ]
-install: [
-  make
-  "install-ide-bin"
-  "install-ide-files"
-  "install-ide-info"
-  "install-ide-devfiles"
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+
+extra-files: [
+  ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
 ]
-extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
 
 url {
   src: "git+https://github.com/coq/coq.git#master"


### PR DESCRIPTION
I tried compiling `coqide.dev` and it didn't work with today's master branch. This PR seems to resolve the issue.
It looks like it's not necessary to have the installation section in an `opam` file anymore (is it because of Dune?).