### PR TITLE
[extra-dev] Add coq-{libvalidsdp,validsdp}.dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ before_script:
   - export OPAM_ROOT_CACHE=${HOME}/opam-cache/cache-${COMPILER}-${OPAM_VERSION}-${OPAM_VARIANT}.tgz
   - export EXTRA_OPAM="ocamlbuild" # some packages build extracted code this way
   - apt-get update -qy
-  - apt-get install unzip libgtksourceview2.0-dev libgtksourceview-3.0-dev libncurses5-dev curl jq ruby bubblewrap time libgmp-dev -y
+  - apt-get install unzip libgtksourceview2.0-dev libgtksourceview-3.0-dev libncurses5-dev curl jq ruby bubblewrap time libgmp-dev coinor-csdp -y
   - test -e $OPAM_ROOT_CACHE || scripts/opam-coq-init
   - curl -L https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux >/usr/local/bin/opam
   - chmod +x /usr/local/bin/opam

--- a/extra-dev/packages/coq-libvalidsdp/coq-libvalidsdp.dev/opam
+++ b/extra-dev/packages/coq-libvalidsdp/coq-libvalidsdp.dev/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]
+
+homepage: "https://sourcesup.renater.fr/validsdp/"
+dev-repo: "git+https://github.com/validsdp/validsdp.git"
+bug-reports: "https://github.com/validsdp/validsdp/issues"
+license: "LGPL-2.1-or-later"
+
+build: [
+  ["sh" "-c" "cd libvalidsdp && ./autogen.sh && ./configure"]
+  [make "-C" "libvalidsdp" "-j%{jobs}%"]
+]
+install: [make "-C" "libvalidsdp" "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7" & < "8.11~"}
+  "coq-bignums"
+  "coq-flocq" {>= "3.1.0"}
+  "coq-coquelicot" {>= "3.0"}
+  "coq-interval" {>= "3.4.0" & < "4~"}
+  "coq-mathcomp-field" {>= "1.8" & < "1.10~"}
+  "ocamlfind" {build}
+  "conf-autoconf" {build}
+]
+synopsis: "LibValidSDP"
+description: """
+LibValidSDP is a library for the Coq formal proof assistant. It provides
+results mostly about rounding errors in the Cholesky decomposition algorithm
+used in the ValidSDP library which itself implements Coq tactics to prove
+multivariate inequalities using SDP solvers.
+
+Once installed, the following modules can be imported :
+From libValidSDP Require Import Rstruct.v misc.v real_matrix.v bounded.v float_spec.v fsum.v fcmsum.v binary64.v cholesky.v float_infnan_spec.v binary64_infnan.v cholesky_infnan.v flx64.v zulp.v coqinterval_infnan.v.
+"""
+
+tags: [
+  "keyword:libValidSDP"
+  "keyword:ValidSDP"
+  "keyword:floating-point arithmetic"
+  "keyword:Cholesky decomposition"
+  "category:libValidSDP"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:libValidSDP"
+]
+authors: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]
+url {
+  src: "git+https://github.com/validsdp/validsdp.git#master"
+}

--- a/extra-dev/packages/coq-validsdp/coq-validsdp.dev/opam
+++ b/extra-dev/packages/coq-validsdp/coq-validsdp.dev/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Pierre Roux <pierre.roux@onera.fr>"
+]
+
+homepage: "https://sourcesup.renater.fr/validsdp/"
+dev-repo: "git+https://github.com/validsdp/validsdp.git"
+bug-reports: "https://github.com/validsdp/validsdp/issues"
+license: "LGPL-2.1-or-later"
+
+build: [
+  ["sh" "-c" "./autogen.sh && ./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+
+depends: [
+  "ocaml"
+  "coq" {>= "8.7" & < "8.11~"}
+  "coq-bignums"
+  "coq-flocq" {>= "3.1.0"}
+  "coq-interval" {>= "3.4.0" & < "4~"}
+  "coq-mathcomp-field" {>= "1.8" & < "1.10~"}
+  "coq-libvalidsdp" {= "dev"}
+  "coq-mathcomp-multinomials" {>= "1.2"}
+  "coq-coqeal" {>= "1.0.0"}
+  "coq-paramcoq" {>= "1.1.0"}
+  "osdp" {>= "1.0"}
+  "ocamlfind" {build}
+  "conf-autoconf" {build}
+]
+synopsis: "ValidSDP"
+description: """
+ValidSDP is a library for the Coq formal proof assistant. It provides
+reflexive tactics to prove multivariate inequalities involving
+real-valued variables and rational constants, using SDP solvers as
+untrusted back-ends and verified checkers based on libValidSDP.
+
+Once installed, you can import the following modules:
+From Coq Require Import Reals.
+From ValidSDP Require Import validsdp.
+"""
+
+tags: [
+  "keyword:libValidSDP"
+  "keyword:ValidSDP"
+  "keyword:floating-point arithmetic"
+  "keyword:Cholesky decomposition"
+  "category:ValidSDP"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:ValidSDP"
+]
+authors: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Pierre Roux <pierre.roux@onera.fr>"
+]
+url {
+  src: "git+https://github.com/validsdp/validsdp.git#master"
+}


### PR DESCRIPTION
This adds the dev version of two opam packages developed with @proux01 in the [ValidSDP](https://github.com/validsdp/validsdp) repository.

The latest master has been tested with MathComp 1.8.0, 1.9.0, and Coq 8.7, 8.8, 8.9, 8.10 [(CI link)](https://travis-ci.com/validsdp/validsdp/builds/137372914)

We're going to prepare a release very soon but it sounded more standard to submit a separate PR for the extra-dev and released packages(?)