### PR TITLE
sync coq.dev packages with 8.11.dev

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -6,11 +6,22 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 synopsis: "Formal proof management system"
+description: """
+The Coq proof assistant provides a formal language to write
+mathematical definitions, executable algorithms, and theorems, together
+with an environment for semi-interactive development of machine-checked
+proofs. Typical applications include the certification of properties of programming
+languages (e.g., the CompCert compiler certification project and the
+Bedrock verified low-level programming library), the formalization of
+mathematics (e.g., the full formalization of the Feit-Thompson theorem
+and homotopy type theory) and teaching.
+"""
 
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
   "num"
+  "conf-findutils" {build}
 ]
 build: [
   [
@@ -30,7 +41,10 @@ install: [
   [make "install"]
   [make "install-byte"]
 ]
-extra-files: ["coq.install" "md5=a5d0f9a35ef24aa3948a6960e657b206"]
+
+extra-files: [
+   ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+]
 
 url {
   src: "git+https://github.com/coq/coq.git#master"

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -6,10 +6,17 @@ bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1"
 synopsis: "IDE of the Coq formal proof management system"
+description: """
+CoqIDE is a graphical user interface for interactive development
+of mathematical definitions, executable algorithms, and proofs of theorems
+using the Coq proof assistant.
+"""
 
 depends: [
   "coq" {= version}
   "lablgtk3-sourceview3"
+  "conf-findutils" {build}
+  "conf-gnome-icon-theme3"
 ]
 build: [
   [
@@ -31,7 +38,10 @@ install: [
   "install-ide-info"
   "install-ide-devfiles"
 ]
-extra-files: ["coqide.install" "md5=d005cda8cb7888fbea94c5416dcb31bc"]
+
+extra-files: [
+  ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
+]
 
 url {
   src: "git+https://github.com/coq/coq.git#master"


### PR DESCRIPTION
The package added in https://github.com/coq/opam-coq-archive/pull/1006 slightly deviated from the one for master. Also bring those improvements to the master packages.

Cc @palmskog @Blaisorblade 