### PR TITLE
[extra-dev] Use dune for coq-bignums.{dev, 8.11.dev}

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.8.11.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.11.dev/opam
@@ -11,12 +11,12 @@ description: """
 Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.6
 """
 
-build: [make "-j%{jobs}%"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
   "coq" {>= "8.11" & < "8.12~"}
+  "dune" {>= "1.9.0"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
@@ -11,12 +11,12 @@ description: """
 Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 """
 
-build: [make "-j%{jobs}%"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
   "coq" {= "dev"}
+  "dune" {>= "1.9.0"}
 ]
 
 tags: [


### PR DESCRIPTION
This PR is a follow-up of https://github.com/coq/bignums/issues/26#issuecomment-555689676

(Cc @ejgallego just FYI)

It changes the build system to `dune` for `coq-bignums.{dev,8.11.dev}` (the two versions being actively rebuilt by [Docker Hub](https://hub.docker.com/r/coqorg/coq/)) given that `make` appears to be buggy sometimes − https://github.com/coq/coq/issues/10704