### PR TITLE
CoqEAL doesn't compile with mathcomp-multinomials.1.4

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.0.1/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "coq" {(>= "8.7" & < "8.11~")}
   "coq-bignums" {(>= "8.7" & < "8.11~")}
   "coq-paramcoq" {(>= "1.1.1")}
-  "coq-mathcomp-multinomials" {(>= "1.2")}
+  "coq-mathcomp-multinomials" {(>= "1.2" & < "1.4~")}
   "coq-mathcomp-algebra" {(>= "1.8.0" & < "1.10~")}
 ]
 


### PR DESCRIPTION
CoqEAL doesn't compile with recently released multinomials 1.4 : https://github.com/coq/opam-coq-archive/pull/1034

Adding a constraint to CoqEAL 1.0.1 while maybe preparing a compatible 1.0.2 (may take more time).
