### PR TITLE
Do not install the ocaml-secondary-compiler dependency for my packages

### DIFF
--- a/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
+++ b/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
@@ -21,6 +21,9 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2019-11-26"
   "keyword:blog"

--- a/released/packages/coq-concurrency-proxy/coq-concurrency-proxy.1.0.0/opam
+++ b/released/packages/coq-concurrency-proxy/coq-concurrency-proxy.1.0.0/opam
@@ -15,6 +15,9 @@ depends: [
   "num"
   "base64" {>= "1.0.0" & < "2"}
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2015-01-28"
   "keyword:effects"

--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.0.0/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.0.0/opam
@@ -16,6 +16,9 @@ depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2015-03-03"
   "keyword:effects"

--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.1.0/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.1.0/opam
@@ -17,6 +17,9 @@ depends: [
   "ocamlfind"
   "num"
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2015-03-11"
   "keyword:effects"

--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.2.0/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.2.0/opam
@@ -17,6 +17,9 @@ depends: [
   "ocamlfind"
   "num"
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2015-03-19"
   "keyword:effects"

--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.0/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.0/opam
@@ -17,6 +17,9 @@ depends: [
   "ocamlfind"
   "num"
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2015-04-28"
   "keyword:effects"

--- a/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.1/opam
+++ b/released/packages/coq-io-system-ocaml/coq-io-system-ocaml.2.3.1/opam
@@ -18,6 +18,9 @@ depends: [
   "ocamlfind" {build}
   "num"
 ]
+conflicts: [
+  "ocaml-secondary-compiler"
+]
 tags: [
   "date:2019-07-25"
   "keyword:effects"


### PR DESCRIPTION
I prefer these packages to depend on the version 1 of Dune to install their dependencies, or to ask the user to upgrade OCaml once the version 1 of Dune is not enough anymore.