### PR TITLE
Update dependencies of coq-geocoq-pof.2.4.0

### DIFF
--- a/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.4.0/opam
+++ b/released/packages/coq-geocoq-pof/coq-geocoq-pof.2.4.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/GeoCoq/GeoCoq/issues"
 dev-repo: "git+https://github.com/GeoCoq/GeoCoq.git"
 depends: [
   "coq-geocoq-main" { = "2.4.0" }
-  "coq-mathcomp-field" { >= "1.6.4" }
+  "coq-mathcomp-field" { >= "1.6.4" & < "1.10.0" }
 ]
 build: [
   ["mkdir" "-p" "Meta_theory2/Models"]


### PR DESCRIPTION
@jnarboux Due to a recent upgrade of `coq-mathcomp-field`. Install logs: https://coq-bench.github.io/clean/Linux-x86_64-4.08.1-2.0.5/released/8.7.1%2B1/geocoq-pof/2.4.0.html 