### PR TITLE
Packaging MathComp Real-closed 1.0.4

### DIFF
--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.0.4/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+name: "coq-mathcomp-real-closed"
+maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+
+homepage: "https://github.com/math-comp/real-closed"
+bug-reports: "https://github.com/math-comp/real-closed/issues"
+dev-repo: "git+https://github.com/math-comp/real-closed.git"
+license: "CeCILL-B"
+
+build: [ make "-j" "%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "coq" { (>= "8.7" & < "8.11~") }
+  "coq-mathcomp-field"       {(>= "1.8.0" & <= "1.10.0")}
+  "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1~")}
+]
+
+tags: [ "keyword:real closed field" "keyword:small scale reflection" "keyword:mathematical components" "date:2019-05-23" "logpath:mathcomp"]
+authors: [ "Cyril Cohen <>" "Assia Mahboubi <>" ]
+synopsis: "Mathematical Components Library on real closed fields"
+description: """
+This library contains definitions and theorems about real closed
+fields, with a construction of the real closure and the algebraic
+closure (including a proof of the fundamental theorem of algebra). It
+also contains a proof of decidability of the first order theory of
+real closed field, through quantifier elimination.
+"""
+url {
+  http: "https://github.com/math-comp/real-closed/archive/1.0.4.tar.gz"
+  checksum: "sha512=3e3b265d3a13581294541bc2e4a110c534663f55689712003c7493262f45c53d2928e02d852700060055fb7024c8f40b600be0556cd56671eee58d51e8f7eec8"
+}


### PR DESCRIPTION
This is a release for compatibility with MathComp 1.10.0.
