### PR TITLE
Fix Coq version for coq-infotheo.0.0.6

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.0.6/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.0.6/opam
@@ -25,6 +25,7 @@ install: [
   [make "install"]
 ]
 depends: [
+  "coq" {>= "8.10~"}
   "coq-mathcomp-field" {>= "1.9.0" & <= "1.10.0"}
   "coq-mathcomp-analysis"   {(>= "0.2.0" & <= "0.2.3")}
 ]


### PR DESCRIPTION
@affeldt-aist Here is an example of bug with Coq 8.9.1: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/8.9.1/infotheo/0.0.6.html