### PR TITLE
Fix OCaml version for coq-template-coq.2.1~beta3

### DIFF
--- a/released/packages/coq-template-coq/coq-template-coq.2.1~beta3/opam
+++ b/released/packages/coq-template-coq/coq-template-coq.2.1~beta3/opam
@@ -23,7 +23,7 @@ remove: [
   ["rm" "-R" "%{lib}%/coq/user-contrib/TemplateExtraction"]
 ]
 depends: [
-  "ocaml" {> "4.02.3"}
+  "ocaml" {>= "4.05"}
   "coq" {>= "8.8" & < "8.9~"}
 ]
 synopsis: "A quoting and unquoting library for Coq in Coq"


### PR DESCRIPTION
Here are bugs with older OCaml versions:
* OCaml 4.03: https://coq-bench.github.io/clean/Linux-x86_64-4.03.0-2.0.5/released/8.8.2/template-coq/2.1~beta3.html
* OCaml 4.04: https://coq-bench.github.io/clean/Linux-x86_64-4.04.2-2.0.5/released/8.8.0/template-coq/2.1~beta3.html