### PR TITLE
Split up coq-rewriter-perf into separate packages

### DIFF
--- a/extra-dev/packages/coq-rewriter-perf-Fast/coq-rewriter-perf-Fast.dev/opam
+++ b/extra-dev/packages/coq-rewriter-perf-Fast/coq-rewriter-perf-Fast.dev/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: [
+  "Google Inc."
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rewriter"
+bug-reports: "https://github.com/mit-plv/rewriter/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "perf-Fast" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
+]
+install: []
+depends: [
+  "coq" {>= "8.9~"}
+  "conf-time"
+  "coq-rewriter"
+]
+dev-repo: "git+https://github.com/mit-plv/rewriter.git"
+synopsis: "Performance Benchmark for Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting"
+url {
+  src: "git+https://github.com/mit-plv/rewriter.git#master"
+}

--- a/extra-dev/packages/coq-rewriter-perf-Medium/coq-rewriter-perf-Medium.dev/opam
+++ b/extra-dev/packages/coq-rewriter-perf-Medium/coq-rewriter-perf-Medium.dev/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: [
+  "Google Inc."
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rewriter"
+bug-reports: "https://github.com/mit-plv/rewriter/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "perf-Medium" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
+]
+install: []
+depends: [
+  "coq" {>= "8.9~"}
+  "conf-time"
+  "coq-rewriter"
+]
+dev-repo: "git+https://github.com/mit-plv/rewriter.git"
+synopsis: "Performance Benchmark for Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting"
+url {
+  src: "git+https://github.com/mit-plv/rewriter.git#master"
+}

--- a/extra-dev/packages/coq-rewriter-perf-Slow/coq-rewriter-perf-Slow.dev/opam
+++ b/extra-dev/packages/coq-rewriter-perf-Slow/coq-rewriter-perf-Slow.dev/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mit-plv/rewriter"
 bug-reports: "https://github.com/mit-plv/rewriter/issues"
 license: "MIT"
 build: [
-  [make "-j%{jobs}%" "perf-SuperFast" "perf-Fast" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
+  [make "-j%{jobs}%" "perf-Slow" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
 ]
 install: []
 depends: [

--- a/extra-dev/packages/coq-rewriter-perf-SuperFast/coq-rewriter-perf-SuperFast.dev/opam
+++ b/extra-dev/packages/coq-rewriter-perf-SuperFast/coq-rewriter-perf-SuperFast.dev/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mit-plv/rewriter"
 bug-reports: "https://github.com/mit-plv/rewriter/issues"
 license: "MIT"
 build: [
-  [make "-j%{jobs}%" "perf-Medium" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
+  [make "-j%{jobs}%" "perf-SuperFast" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
 ]
 install: []
 depends: [
@@ -17,7 +17,7 @@ depends: [
   "coq-rewriter"
 ]
 dev-repo: "git+https://github.com/mit-plv/rewriter.git"
-synopsis: "Extra Performance Benchmark (~ 11h) for Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting"
+synopsis: "Performance Benchmark for Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting"
 url {
   src: "git+https://github.com/mit-plv/rewriter.git#master"
 }

--- a/extra-dev/packages/coq-rewriter-perf-VerySlow/coq-rewriter-perf-VerySlow.dev/opam
+++ b/extra-dev/packages/coq-rewriter-perf-VerySlow/coq-rewriter-perf-VerySlow.dev/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors: [
+  "Google Inc."
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rewriter"
+bug-reports: "https://github.com/mit-plv/rewriter/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "perf-VerySlow" "EXTERNAL_PERF_DEPENDENCIES=1" "TIMED=1"]
+]
+install: []
+depends: [
+  "coq" {>= "8.9~"}
+  "conf-time"
+  "coq-rewriter"
+]
+dev-repo: "git+https://github.com/mit-plv/rewriter.git"
+synopsis: "Performance Benchmark for Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting"
+url {
+  src: "git+https://github.com/mit-plv/rewriter.git#master"
+}


### PR DESCRIPTION
Now we can more easily control on the bench how long we actually want
things to take.