### PR TITLE
Add OCamlBuild dependency to coq-semantics.8.9.0

### DIFF
--- a/released/packages/coq-semantics/coq-semantics.8.9.0/opam
+++ b/released/packages/coq-semantics/coq-semantics.8.9.0/opam
@@ -7,6 +7,7 @@ install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Semantics"]
 depends: [
   "ocaml"
+  "ocamlbuild" {build}
   "coq" {>= "8.9" & < "8.10~"}
 ]
 tags: [


### PR DESCRIPTION
Error: https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.1/released/8.9.1/semantics/8.9.0.html