### PR TITLE
CompCert: darwin -> macos

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.5/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.5/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
 build: [
   ["./configure" "ia32-linux" {os = "linux"}
-  "ia32-macosx" {os = "darwin"}
+  "ia32-macosx" {os = "macos"}
   "ia32-cygwin" {os = "cygwin"}
   "-bindir" "%{bin}%"
   "-libdir" "%{lib}%/compcert"

--- a/released/packages/coq-compcert/coq-compcert.3.6/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.6/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
 build: [
   ["./configure" "ia32-linux" {os = "linux"}
-  "ia32-macosx" {os = "darwin"}
+  "ia32-macosx" {os = "macos"}
   "ia32-cygwin" {os = "cygwin"}
   "-bindir" "%{bin}%"
   "-libdir" "%{lib}%/compcert"


### PR DESCRIPTION
Otherwise there is an installation error:
```
Error: no target architecture specified.
Usage: ./configure [options] target
```

My setup:
- macOS 10.14.6 (Mojave)
- opam 2.0.5