### PR TITLE
coq-vst: fix coq-compcert version to 3.5

### DIFF
--- a/extra-dev/packages/coq-vst/coq-vst.dev/opam
+++ b/extra-dev/packages/coq-vst/coq-vst.dev/opam
@@ -32,8 +32,8 @@ remove: [
 	]
 depends: [
   "ocaml"
-  "coq" {>= "8.7.0"}
-  "coq-compcert" {>= "3.3.0"}
+  "coq" {>= "8.10.0"}
+  "coq-compcert" {= "3.5"}
 ]
 synopsis: "Verified Software Toolchain"
 description:


### PR DESCRIPTION
Because this is what Makefile checks as of commit
https://github.com/PrincetonUniversity/VST/blob/a04b451b3ef9fd99007115f7745713f6fc84d1dc/compcert/VERSION#L1