### PR TITLE
Fix OCaml version of coq-firing-squad.8.10.0

### DIFF
--- a/released/packages/coq-firing-squad/coq-firing-squad.8.10.0/opam
+++ b/released/packages/coq-firing-squad/coq-firing-squad.8.10.0/opam
@@ -6,7 +6,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/FiringSquad"]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.09"}
   "coq" {>= "8.10" & < "8.11~"}
 ]
 tags: [


### PR DESCRIPTION
Error logs with OCaml 4.09:
```
# make -f Makefile.coq fire
# ocamlopt -o fire unix.cmxa graphics.cmxa extracted.mli extracted.ml fire.ml
# File "fire.ml", line 65, characters 5-13:
# 65 | open Graphics
#           ^^^^^^^^
# Error: Unbound module Graphics
```
This does not compile even if I add the `graphics` package which is supposed to provide the `Graphics` module in opam.