### PR TITLE
Dpdgraph.0.6.5

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.5/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "yves.bertot@inria.fr"
+license: "LGPL 2.1"
+
+homepage: "https://github.com/karmaki/coq-dpdgraph"
+
+build: [
+  ["./configure"]
+  ["echo" "%{jobs}%" "jobs for the linter"]
+  [make]
+ ]
+
+bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
+
+dev-repo: "git+https://github.com/karmaki/coq-dpdgraph.git"
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+
+remove: [
+  ["rm" "%{bin}%/dpd2dot" "%{bin}%/dpdusage"]
+  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
+]
+
+depends: [
+  "ocaml" {< "4.10.0"}
+  "coq" {>= "8.9" & < "8.10~"}
+  "ocamlgraph"
+]
+authors: [ "Anne Pacalet" "Yves Bertot"]
+synopsis: "Compute dependencies between Coq objects (definitions, theorems)"
+description: "and produce graphs"
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/Karmaki/coq-dpdgraph/releases/download/v0.6.5/coq-dpdgraph-0.6.5.tgz"
+  checksum: "sha256=539d49b739a4f173e03a3194453f8367051e808c8e329773648ba1c0a495a07f"
+}

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.5/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.5/opam
@@ -1,13 +1,13 @@
 opam-version: "2.0"
 maintainer: "yves.bertot@inria.fr"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 
 homepage: "https://github.com/karmaki/coq-dpdgraph"
 
 build: [
   ["./configure"]
   ["echo" "%{jobs}%" "jobs for the linter"]
-  [make]
+  [make "-j%{jobs}%"]
  ]
 
 bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
@@ -15,11 +15,6 @@ bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
 dev-repo: "git+https://github.com/karmaki/coq-dpdgraph.git"
 install: [
   [make "install" "BINDIR=%{bin}%"]
-]
-
-remove: [
-  ["rm" "%{bin}%/dpd2dot" "%{bin}%/dpdusage"]
-  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
 ]
 
 depends: [
@@ -30,7 +25,7 @@ depends: [
 authors: [ "Anne Pacalet" "Yves Bertot"]
 synopsis: "Compute dependencies between Coq objects (definitions, theorems)"
 description: "and produce graphs"
-flags: light-uninstall
+
 url {
   src:
     "https://github.com/Karmaki/coq-dpdgraph/releases/download/v0.6.5/coq-dpdgraph-0.6.5.tgz"

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.6/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "yves.bertot@inria.fr"
+license: "LGPL 2.1"
+
+homepage: "https://github.com/karmaki/coq-dpdgraph"
+
+build: [
+  ["./configure"]
+  ["echo" "%{jobs}%" "jobs for the linter"]
+  [make "WARN_ERR="]
+ ]
+
+bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
+
+dev-repo: "git+https://github.com/karmaki/coq-dpdgraph.git"
+install: [
+  [make "install" "BINDIR=%{bin}%"]
+]
+
+remove: [
+  ["rm" "%{bin}%/dpd2dot" "%{bin}%/dpdusage"]
+  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
+]
+
+depends: [
+  "ocaml" {}
+  "coq" {>= "8.10" & < "8.11~"}
+  "ocamlgraph"
+]
+authors: [ "Anne Pacalet" "Yves Bertot"]
+synopsis: "Compute dependencies between Coq objects (definitions, theorems)"
+description: "and produce graphs"
+flags: light-uninstall
+url {
+  src:
+    "https://github.com/Karmaki/coq-dpdgraph/releases/download/v0.6.6/coq-dpdgraph-0.6.6.tgz"
+  checksum: "sha256=1bc2715bdc412b9413f1a9348d6598a7a722c3b68c087c0294d1d58cdf2d2c7f"
+}

--- a/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.6/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.0.6.6/opam
@@ -1,13 +1,13 @@
 opam-version: "2.0"
 maintainer: "yves.bertot@inria.fr"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 
 homepage: "https://github.com/karmaki/coq-dpdgraph"
 
 build: [
   ["./configure"]
   ["echo" "%{jobs}%" "jobs for the linter"]
-  [make "WARN_ERR="]
+  [make "-j%{jobs}%" "WARN_ERR="]
  ]
 
 bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
@@ -15,11 +15,6 @@ bug-reports: "https://github.com/karmaki/coq-dpdgraph/issues"
 dev-repo: "git+https://github.com/karmaki/coq-dpdgraph.git"
 install: [
   [make "install" "BINDIR=%{bin}%"]
-]
-
-remove: [
-  ["rm" "%{bin}%/dpd2dot" "%{bin}%/dpdusage"]
-  ["rm" "-R" "%{lib}%/coq/user-contrib/dpdgraph"]
 ]
 
 depends: [
@@ -30,7 +25,7 @@ depends: [
 authors: [ "Anne Pacalet" "Yves Bertot"]
 synopsis: "Compute dependencies between Coq objects (definitions, theorems)"
 description: "and produce graphs"
-flags: light-uninstall
+
 url {
   src:
     "https://github.com/Karmaki/coq-dpdgraph/releases/download/v0.6.6/coq-dpdgraph-0.6.6.tgz"


### PR DESCRIPTION
This pull requests contains updates to make coq-dpdgraph available for coq-8.9 with ocaml-4.09 and for coq-8.10 with a wider range of versions of ocaml.