### PR TITLE
ITree: update dependency

### DIFF
--- a/extra-dev/packages/coq-itree/coq-itree.dev/opam
+++ b/extra-dev/packages/coq-itree/coq-itree.dev/opam
@@ -11,12 +11,11 @@ license: "MIT"
 
 build: [ make "-j%{jobs}%" ]
 install: [ make "install" ]
-remove: [ make "uninstall" ]
 run-test: [ make "-j%{jobs}%" "all" ]
 
 depends: [
-  "coq" {>= "8.8" & < "8.10~"}
-  "coq-ext-lib" {= "0.10.2"}
+  "coq" {>= "8.8"}
+  "coq-ext-lib" {>= "0.10.3"}
   "coq-paco" {>= "4.0.0"}
   "ocamlbuild" {with-test}
 ]
@@ -31,7 +30,6 @@ authors: [
 ]
 
 tags: "org:deepspec"
-flags: light-uninstall
 url {
   src: "git+https://github.com/DeepSpec/InteractionTrees"
 }


### PR DESCRIPTION
per DeepSpec/InteractionTrees#153

@Lysxia I've removed upper bounds so that ExtLib CI can test `coq-itree.dev` as a dependent of `coq-ext-lib.dev`.