### PR TITLE
fix issue with flaky parallel builds of CompCert 3.6

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.6/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.6/opam
@@ -15,7 +15,7 @@ build: [
   "-clightgen"
   "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
   "-ignore-coq-version"]
-  [make "-j%{jobs}%"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Parallel CompCert 3.6 builds (and some earlier ones) sometimes fail, likely due to ocaml/ocaml#7472 as discussed in AbsInt/CompCert#327. This is a minimal change we came up with, which could be enacted for earlier builds as well.