### PR TITLE
adjust coq-mathcomp-ssreflect bound of finmap-1.3.4

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.3.4/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.3.4/opam
@@ -11,7 +11,7 @@ build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
   "coq" { (>= "8.7" & < "8.11~") }
-  "coq-mathcomp-ssreflect" { (>= "1.8.0" & < "1.10~") }
+  "coq-mathcomp-ssreflect" { (>= "1.8.0" & < "1.11~") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]
 tags: [ "keyword:finmap" "keyword:finset" "keyword:multiset" "keyword:order" "date:2019-06-18" "logpath:mathcomp.finmap"]


### PR DESCRIPTION
To permit CoqEAL to work on Coq 8.10 with MathComp 1.10, as per math-comp/multinomials#29