### PR TITLE
Package coq-menhirlib.20200121

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20200121/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200121/opam
@@ -7,6 +7,7 @@ authors: [
 homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
 build: [
   [make "-C" "coq-menhirlib" "-j%{jobs}%"]
 ]

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200121/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200121/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20200121" }
+]
+tags: [
+  "date:2020-01-21"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20200121/archive.tar.gz"
+  checksum: [
+    "md5=ee92ec131eb493d55f433c37019a9e84"
+    "sha512=9aa7db5ceb00322f33cf08aff866b17352cb76011382d85e6962459abbe33d33d704c8f3918206edf622b48016cc05749b0852efd2cb42109d0216097d3d1281"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20200121`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.0