### PR TITLE
Fix the dependencies of coq-compcert.3.6

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.6/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.6/opam
@@ -23,7 +23,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.7.0"}
-  "menhir" {>= "20190626"}
+  "menhir" {>= "20190626" & < "20200123"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "The CompCert C compiler"


### PR DESCRIPTION
It seems that CompCert is not compatible with the latest version of (OCaml) Menhir. This PR fixes it. @jhjourdan 

Temporary error link: https://coq-bench.github.io/clean/Linux-x86_64-4.08.1-2.0.5/released/8.10.1/compcert/3.6.html
Full logs:
```
## Command
# opam list; echo; ulimit -Sv 4000000; timeout 2h opam install -y -v coq-compcert.3.6 coq.8.10.1
## Return code
# 7936
## Duration
# 20 m 7 s
## Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.10.1      Formal proof management system
dune                2.1.3       Fast, portable, and opinionated build system
menhir              20200123    An LR(1) parser generator
menhirLib           20200123    Runtime support library for parsers generated by Menhir
menhirSdk           20200123    Compile-time library for auxiliary tools related to Menhir
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.08.1      The OCaml compiler (virtual package)
ocaml-base-compiler 4.08.1      Official release 4.08.1
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.10.1).
The following actions will be performed:
  - install coq-compcert 3.6
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-compcert.3.6: http]
[coq-compcert.3.6] downloaded from https://github.com/AbsInt/CompCert/archive/v3.6.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-compcert: ./configure ia32-linux]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure" "ia32-linux" "-bindir" "/home/bench/.opam/ocaml-base-compiler.4.08.1/bin" "-libdir" "/home/bench/.opam/ocaml-base-compiler.4.08.1/lib/compcert" "-install-coqdev" "-clightgen" "-coqdevdir" "/home/bench/.opam/ocaml-base-compiler.4.08.1/lib/coq/user-contrib/compcert" "-ignore-coq-version" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6)
- Testing assembler support for CFI directives... yes
- Testing linker support for '-no-pie' / '-nopie' option... no
- Testing Coq... version 8.10.1 -- UNSUPPORTED
- Warning: this version of Coq is unsupported, proceed at your own risks.
- Testing OCaml... version 4.08.1 -- good!
- Testing OCaml .opt compilers... yes
- Testing Menhir... version 20200123 -- good!
- Testing GNU make... version 4.2.1 (command 'make') -- good!
- 
- CompCert configuration:
-     Target architecture........... x86
-     Hardware model................ 32sse2
-     Application binary interface.. standard
-     Endianness.................... little
-     OS and development env........ linux
-     C compiler.................... gcc -m32
-     C preprocessor................ gcc
-     Assembler..................... gcc
-     Assembler supports CFI........ true
-     Assembler for runtime lib..... gcc -m32 -c
-     Linker........................ gcc
-     Linker needs '-no-pie'........ false
-     Math library.................. -lm
-     Build command to use.......... make
-     Binaries installed in......... /home/bench/.opam/ocaml-base-compiler.4.08.1/bin
-     Runtime library provided...... true
-     Library files installed in.... /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/compcert
-     Standard headers provided..... true
-     Standard headers installed in. /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/compcert/include
-     Coq development installed in.. /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/coq/user-contrib/compcert
Processing  1/2: [coq-compcert: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6)
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- ocamlopt -o tools/ndfun str.cmxa tools/ndfun.ml
- menhir --coq --coq-lib-path compcert.MenhirLib --coq-no-version-check cparser/Parser.vy
- Preprocessing x86/ConstpropOp.vp
- Preprocessing x86/SelectOp.vp
- Preprocessing x86/SelectLong.vp
- Preprocessing backend/SelectDiv.vp
- Preprocessing backend/SplitLong.vp
- Analyzing Coq dependencies
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make proof
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- COQC lib/Axioms.v
- COQC lib/Coqlib.v
- COQC flocq/Core/Zaux.v
- COQC driver/Compopts.v
- COQC MenhirLib/Alphabet.v
- COQC cparser/Cabs.v
- COQC lib/Wfsimpl.v
- COQC MenhirLib/Grammar.v
- COQC MenhirLib/Validator_classes.v
- COQC flocq/Core/Raux.v
- COQC flocq/Core/Digits.v
- COQC lib/Iteration.v
- COQC lib/Parmov.v
- COQC lib/UnionFind.v
- COQC lib/FSetAVLplus.v
- COQC lib/IntvSets.v
- COQC lib/Decidableplus.v
- COQC lib/BoolEqual.v
- COQC common/Errors.v
- COQC MenhirLib/Automaton.v
- COQC lib/Intv.v
- COQC lib/Maps.v
- COQC lib/Zbits.v
- COQC flocq/Core/Defs.v
- COQC MenhirLib/Validator_safe.v
- COQC MenhirLib/Validator_complete.v
- COQC flocq/Core/Float_prop.v
- COQC flocq/Core/Round_pred.v
- COQC lib/Lattice.v
- COQC lib/Postorder.v
- COQC common/Unityping.v
- COQC MenhirLib/Interpreter.v
- COQC flocq/Core/Generic_fmt.v
- COQC flocq/Calc/Bracket.v
- COQC flocq/Calc/Operations.v
- COQC MenhirLib/Interpreter_complete.v
- COQC MenhirLib/Interpreter_correct.v
- COQC flocq/Core/Ulp.v
- COQC flocq/Calc/Div.v
- COQC flocq/Calc/Sqrt.v
- COQC flocq/Prop/Sterbenz.v
- COQC flocq/Core/Round_NE.v
- COQC MenhirLib/Main.v
- COQC cparser/Parser.v
- COQC flocq/Core/FIX.v
- COQC flocq/Core/FLX.v
- COQC flocq/Core/FLT.v
- COQC flocq/Core/FTZ.v
- COQC flocq/Core/Core.v
- COQC flocq/Prop/Double_rounding.v
- COQC flocq/Calc/Round.v
- COQC flocq/Prop/Relative.v
- COQC flocq/Prop/Round_odd.v
- COQC flocq/IEEE754/Binary.v
- COQC flocq/Prop/Plus_error.v
- COQC flocq/Prop/Mult_error.v
- COQC flocq/Prop/Div_sqrt_error.v
- COQC flocq/IEEE754/Bits.v
- COQC lib/IEEE754_extra.v
- COQC x86_32/Archi.v
- COQC lib/Integers.v
- COQC lib/Ordered.v
- COQC lib/Floats.v
- COQC lib/Heaps.v
- COQC common/AST.v
- COQC common/Linking.v
- COQC common/Values.v
- COQC cfrontend/Ctypes.v
- COQC common/Memdata.v
- COQC common/Switch.v
- COQC backend/Registers.v
- COQC common/Memtype.v
- COQC common/Builtins0.v
- COQC common/Memory.v
- COQC x86/Builtins1.v
- COQC common/Builtins.v
- COQC common/Globalenvs.v
- COQC cfrontend/Cop.v
- COQC common/Events.v
- COQC cfrontend/Csyntax.v
- COQC cfrontend/Initializers.v
- COQC common/Smallstep.v
- COQC common/Separation.v
- COQC x86/Op.v
- COQC backend/Kildall.v
- COQC common/Behaviors.v
- COQC backend/Cminor.v
- COQC cfrontend/Csem.v
- COQC cfrontend/Clight.v
- COQC common/Determinism.v
- COQC backend/Cminortyping.v
- COQC cfrontend/Ctyping.v
- COQC cfrontend/Cstrategy.v
- COQC cfrontend/Initializersproof.v
- COQC cfrontend/SimplExpr.v
- COQC cfrontend/ClightBigstep.v
- COQC cfrontend/SimplLocals.v
- COQC cfrontend/Csharpminor.v
- COQC cfrontend/SimplExprspec.v
- COQC cfrontend/SimplLocalsproof.v
- COQC cfrontend/Cshmgen.v
- COQC cfrontend/Cminorgen.v
- COQC cfrontend/Cexec.v
- COQC cfrontend/Cshmgenproof.v
- COQC cfrontend/Cminorgenproof.v
- COQC cfrontend/SimplExprproof.v
- COQC backend/CminorSel.v
- COQC x86/Machregs.v
- COQC backend/RTL.v
- COQC x86/SelectOp.v
- COQC backend/Locations.v
- COQC backend/RTLgen.v
- COQC backend/Inlining.v
- COQC backend/Renumber.v
- COQC backend/Liveness.v
- COQC backend/ValueDomain.v
- COQC backend/CSEdomain.v
- COQC backend/Unusedglob.v
- COQC backend/RTLgenspec.v
- COQC x86/Conventions1.v
- COQC backend/Inliningspec.v
- COQC backend/Renumberproof.v
- COQC x86/CombineOp.v
- COQC backend/Unusedglobproof.v
- COQC backend/SplitLong.v
- COQC x86/SelectOpproof.v
- COQC backend/RTLgenproof.v
- COQC backend/Conventions.v
- COQC backend/Inliningproof.v
- COQC backend/RTLtyping.v
- COQC x86/CombineOpproof.v
- COQC backend/LTL.v
- COQC x86/SelectLong.v
- COQC backend/SplitLongproof.v
- COQC backend/Tailcall.v
- COQC x86/ValueAOp.v
- COQC backend/NeedDomain.v
- COQC backend/Allocation.v
- COQC backend/Tunneling.v
- COQC backend/Linear.v
- COQC backend/SelectDiv.v
- COQC backend/Tailcallproof.v
- COQC backend/ValueAnalysis.v
- COQC x86/ConstpropOp.v
- COQC x86/NeedOp.v
- COQC backend/Tunnelingproof.v
- COQC backend/Lineartyping.v
- COQC backend/Linearize.v
- COQC backend/CleanupLabels.v
- COQC backend/Debugvar.v
- COQC backend/Bounds.v
- COQC backend/Selection.v
- COQC x86/SelectLongproof.v
- COQC backend/Constprop.v
- COQC x86/ConstpropOpproof.v
- COQC backend/CSE.v
- COQC backend/Deadcode.v
- COQC backend/Allocproof.v
- COQC backend/Linearizeproof.v
- COQC backend/CleanupLabelsproof.v
- COQC backend/Debugvarproof.v
- COQC x86/Stacklayout.v
- COQC backend/SelectDivproof.v
- COQC backend/Constpropproof.v
- COQC backend/CSEproof.v
- COQC backend/Deadcodeproof.v
- COQC backend/Mach.v
- COQC x86/Asm.v
- COQC backend/Selectionproof.v
- COQC backend/Stacking.v
- COQC x86/Asmgen.v
- COQC backend/Stackingproof.v
- COQC backend/Asmgenproof0.v
- COQC x86/Asmgenproof1.v
- COQC x86/Asmgenproof.v
- COQC driver/Compiler.v
- COQC driver/Complements.v
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make extraction
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- rm -f extraction/*.ml extraction/*.mli
- "coqtop"  -R lib compcert.lib  -R common compcert.common  -R x86_32 compcert.x86_32  -R x86 compcert.x86  -R backend compcert.backend  -R cfrontend compcert.cfrontend  -R driver compcert.driver  -R flocq compcert.flocq  -R exportclight compcert.exportclight  -R MenhirLib compcert.MenhirLib  -R cparser compcert.cparser -batch -load-vernac-source extraction/extraction.v
- File "/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6/extraction/extraction.v", line 160, characters 0-1084:
- Warning: The extraction is currently set to bypass opacity, the following
- opaque constant bodies have been accessed : solve_constraints_terminate.
-  [extraction-opaque-accessed,extraction]
- touch extraction/STAMP
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make ccomp
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- ocamlopt -o tools/modorder str.cmxa tools/modorder.ml
- cat VERSION \
- | sed -e 's|\(.*\)=\(.*\)|let \1 = \"\2\"|g' \
- >driver/Version.ml
- (echo "stdlib_path=/home/bench/.opam/ocaml-base-compiler.4.08.1/lib/compcert"; \
-          echo "prepro=gcc"; \
-          echo "linker=gcc"; \
-          echo "asm=gcc"; \
-  echo "prepro_options=-std=c99 -m32 -U__GNUC__ -E";\
-  echo "asm_options=-m32 -c";\
-  echo "linker_options=-m32";\
-          echo "arch=x86"; \
-          echo "model=32sse2"; \
-          echo "abi=standard"; \
-          echo "endianness=little"; \
-          echo "system=linux"; \
-          echo "has_runtime_lib=true"; \
-          echo "has_standard_headers=true"; \
-          echo "asm_supports_cfi=true"; \
-  echo "response_file_style=gnu";) \
-         > compcert.ini
- make -f Makefile.extr depend
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- menhir --table -v --no-stdlib -la 1 cparser/pre_parser.mly
- ocamllex -q cparser/Lexer.mll
- ocamllex -q lib/Tokenize.mll
- ocamllex -q lib/Readconfig.mll
- ocamllex -q lib/Responsefile.mll
- make -C cparser correct
- Built an LR(0) automaton with 602 states.
- make[3]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6/cparser'
- Built an LR(1) automaton with 602 states.
- 2 shift/reduce conflicts were silently solved.
- Built an LR(0) automaton with 602 states.
- Extra reductions on error were added in 102 states.
- Priority played a role in 0 of these states.
- Built an LR(1) automaton with 602 states.
- 2 shift/reduce conflicts were silently solved.
- Extra reductions on error were added in 102 states.
- Priority played a role in 0 of these states.
- Read 217 sample input sentences and 164 error messages.
- OK. The set of erroneous inputs is correct and irredundant.
- make[3]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6/cparser'
- Analyzing OCaml dependencies
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make -f Makefile.extr ccomp
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- OCAMLOPT driver/Version.ml
- OCAMLC   lib/Readconfig.mli
- OCAMLC   lib/Responsefile.mli
- OCAMLC   driver/Commandline.mli
- OCAMLC   driver/Configuration.mli
- OCAMLC   extraction/Datatypes.mli
- OCAMLC   extraction/BinNums.mli
- OCAMLC   extraction/Bool.mli
- OCAMLC   extraction/Orders.mli
- OCAMLC   extraction/EquivDec.mli
- OCAMLC   extraction/BoolEqual.mli
- OCAMLC   extraction/String0.mli
- OCAMLC   extraction/Errors.mli
- OCAMLC   extraction/Equalities.mli
- OCAMLC   extraction/Specif.mli
- OCAMLC   extraction/Memtype.mli
- OCAMLC   extraction/PeanoNat.mli
- OCAMLC   cparser/Machine.mli
- OCAMLC   cparser/C.mli
- OCAMLC   cparser/Diagnostics.mli
- OCAMLC   extraction/Ring.mli
- OCAMLC   lib/Printlines.mli
- OCAMLC   driver/Driveraux.mli
- OCAMLC   driver/Linker.mli
- OCAMLC   extraction/DecidableClass.mli
- OCAMLC   extraction/Cabs.mli
- OCAMLC   cparser/pre_parser_aux.mli
- OCAMLOPT cparser/pre_parser_messages.ml
- OCAMLC   cparser/Cleanup.mli
- OCAMLC   cparser/Checks.mli
- OCAMLC   cparser/Bitfields.mli
- OCAMLC   cparser/Parse.mli
- OCAMLC   lib/Tokenize.mli
- OCAMLC   extraction/UnionFind.mli
- OCAMLC   extraction/Compopts.mli
- OCAMLC   extraction/Compare_dec.mli
- OCAMLC   extraction/Mergesort.mli
- OCAMLC   driver/Clflags.ml
- OCAMLC   driver/Assembler.mli
- OCAMLOPT lib/Readconfig.ml
- OCAMLOPT lib/Responsefile.ml
- OCAMLOPT extraction/Datatypes.ml
- OCAMLC   extraction/Nat.mli
- OCAMLOPT extraction/BinNums.ml
- OCAMLC   extraction/BinPosDef.mli
- OCAMLC   extraction/List0.mli
- OCAMLC   extraction/Archi.mli
- OCAMLOPT extraction/Bool.ml
- OCAMLOPT extraction/Orders.ml
- OCAMLC   extraction/OrdersTac.mli
- OCAMLOPT extraction/EquivDec.ml
- OCAMLOPT extraction/BoolEqual.ml
- OCAMLOPT extraction/String0.ml
- OCAMLOPT extraction/Errors.ml
- OCAMLOPT extraction/Equalities.ml
- OCAMLC   extraction/DecidableType.mli
- OCAMLOPT extraction/Specif.ml
- OCAMLOPT extraction/Memtype.ml
- OCAMLOPT extraction/PeanoNat.ml
- OCAMLOPT cparser/Machine.ml
- OCAMLC   cparser/Env.mli
- OCAMLC   cparser/Cprint.mli
- OCAMLOPT extraction/Ring.ml
- OCAMLOPT lib/Printlines.ml
- OCAMLOPT extraction/DecidableClass.ml
- OCAMLC   cparser/Unblock.mli
- OCAMLC   cparser/Transform.mli
- OCAMLC   cparser/StructPassing.mli
- OCAMLC   cparser/Rename.mli
- OCAMLOPT extraction/Cabs.ml
- OCAMLOPT cparser/pre_parser_aux.ml
- OCAMLC   cparser/pre_parser.mli
- OCAMLC   cparser/Cflow.mli
- OCAMLC   cparser/Elab.mli
- OCAMLOPT lib/Tokenize.ml
- OCAMLOPT extraction/UnionFind.ml
- OCAMLOPT extraction/Compare_dec.ml
- OCAMLOPT extraction/Mergesort.ml
- OCAMLC   x86/CBuiltins.ml
- OCAMLOPT driver/Commandline.ml
- OCAMLOPT extraction/Nat.ml
- OCAMLOPT extraction/BinPosDef.ml
- OCAMLC   extraction/BinPos.mli
- OCAMLOPT extraction/List0.ml
- OCAMLOPT extraction/Archi.ml
- OCAMLC   extraction/Digits.mli
- OCAMLOPT extraction/OrdersTac.ml
- OCAMLC   extraction/OrderedType.mli
- OCAMLC   extraction/OrdersFacts.mli
- OCAMLOPT extraction/DecidableType.ml
- OCAMLC   extraction/FSetInterface.mli
- OCAMLOPT cparser/Env.ml
- OCAMLOPT cparser/Diagnostics.ml
- OCAMLOPT cparser/Cprint.ml
- OCAMLC   cparser/Cutil.mli
- OCAMLC   cparser/Ceval.mli
- OCAMLOPT x86/CBuiltins.ml
- OCAMLC   extraction/Alphabet.mli
- OCAMLC   extraction/FMapList.mli
- OCAMLOPT cparser/pre_parser.ml
- OCAMLC   cparser/ErrorReports.mli
- OCAMLOPT cparser/Cabshelper.ml
- OCAMLOPT driver/Configuration.ml
- OCAMLOPT extraction/BinPos.ml
- OCAMLC   extraction/Zpower.mli
- OCAMLC   extraction/BinNat.mli
- OCAMLOPT extraction/OrderedType.ml
- OCAMLC   extraction/OrdersAlt.mli
- OCAMLOPT extraction/OrdersFacts.ml
- OCAMLC   extraction/MSetInterface.mli
- OCAMLOPT extraction/FSetInterface.ml
- OCAMLOPT cparser/Cutil.ml
- OCAMLOPT extraction/Alphabet.ml
- OCAMLC   extraction/Grammar.mli
- OCAMLOPT extraction/FMapList.ml
- OCAMLOPT driver/Clflags.ml
- OCAMLOPT extraction/Zpower.ml
- OCAMLOPT extraction/BinNat.ml
- OCAMLC   extraction/BinInt.mli
- OCAMLOPT extraction/Digits.ml
- OCAMLOPT extraction/OrdersAlt.ml
- OCAMLOPT extraction/MSetInterface.ml
- OCAMLC   extraction/Znumtheory.mli
- OCAMLOPT backend/Fileinfo.ml
- OCAMLC   extraction/Decidableplus.mli
- OCAMLOPT cparser/Transform.ml
- OCAMLOPT cparser/Rename.ml
- OCAMLOPT extraction/Grammar.ml
- OCAMLC   extraction/Automaton.mli
- OCAMLOPT cparser/Checks.ml
- OCAMLOPT extraction/Compopts.ml
- OCAMLOPT driver/CommonOptions.ml
- OCAMLOPT extraction/BinInt.ml
- OCAMLC   extraction/ZArith_dec.mli
- OCAMLC   extraction/Zaux.mli
- OCAMLC   extraction/Zbool.mli
- OCAMLC   extraction/FLT.mli
- OCAMLC   extraction/Int0.mli
- OCAMLOPT extraction/Znumtheory.ml
- OCAMLOPT cparser/Ceval.ml
- OCAMLOPT extraction/Decidableplus.ml
- OCAMLOPT cparser/StructPassing.ml
- OCAMLOPT extraction/Automaton.ml
- OCAMLC   extraction/Interpreter_correct.mli
- OCAMLC   extraction/FMapAVL.mli
- OCAMLC   extraction/Validator_safe.mli
- OCAMLOPT cparser/ErrorReports.ml
- OCAMLOPT extraction/ZArith_dec.ml
- OCAMLC   extraction/Coqlib.mli
- OCAMLOPT extraction/Zaux.ml
- OCAMLOPT extraction/Zbool.ml
- OCAMLC   extraction/Bracket.mli
- OCAMLOPT extraction/FLT.ml
- OCAMLC   extraction/Maps.mli
- OCAMLOPT extraction/Int0.ml
- OCAMLC   extraction/MSetAVL.mli
- OCAMLC   extraction/Iteration.mli
- OCAMLC   extraction/Unityping.mli
- OCAMLOPT extraction/Interpreter_correct.ml
- OCAMLOPT extraction/Validator_safe.ml
- OCAMLC   extraction/Interpreter.mli
- OCAMLOPT cparser/PackedStructs.ml
- OCAMLOPT cparser/Cflow.ml
- OCAMLC   extraction/Postorder.mli
- OCAMLC   extraction/IntvSets.mli
- OCAMLC   extraction/FSetAVLplus.mli
- OCAMLOPT extraction/Coqlib.ml
- OCAMLC   extraction/Zbits.mli
- OCAMLOPT extraction/Bracket.ml
- OCAMLC   extraction/Round.mli
- OCAMLOPT extraction/Maps.ml
- OCAMLC   extraction/Ordered.mli
- OCAMLOPT extraction/MSetAVL.ml
- OCAMLC   extraction/FSetAVL.mli
- OCAMLC   extraction/Lattice.mli
- OCAMLOPT extraction/Iteration.ml
- OCAMLC   extraction/Heaps.mli
- OCAMLOPT extraction/Unityping.ml
- OCAMLOPT extraction/FMapAVL.ml
- OCAMLC   extraction/Validator_complete.mli
- OCAMLOPT extraction/Interpreter.ml
- OCAMLOPT extraction/Postorder.ml
- OCAMLOPT extraction/IntvSets.ml
- OCAMLOPT extraction/FSetAVLplus.ml
- OCAMLOPT extraction/Zbits.ml
- OCAMLC   extraction/Integers.mli
- OCAMLOPT extraction/Round.ml
- OCAMLC   extraction/Binary.mli
- OCAMLOPT extraction/Ordered.ml
- OCAMLOPT extraction/FSetAVL.ml
- OCAMLC   extraction/Registers.mli
- OCAMLOPT extraction/Lattice.ml
- OCAMLOPT extraction/Heaps.ml
- OCAMLC   extraction/Kildall.mli
- OCAMLC   extraction/Interpreter_complete.mli
- OCAMLC   extraction/Switch.mli
- OCAMLOPT extraction/Integers.ml
- OCAMLOPT extraction/Binary.ml
- OCAMLC   extraction/IEEE754_extra.mli
- OCAMLC   extraction/Bits.mli
- OCAMLOPT extraction/Registers.ml
- OCAMLOPT extraction/Kildall.ml
- OCAMLOPT extraction/IEEE754_extra.ml
- OCAMLOPT extraction/Bits.ml
- OCAMLC   extraction/Floats.mli
- OCAMLOPT extraction/Validator_complete.ml
- OCAMLC   extraction/Main.mli
- OCAMLOPT extraction/Switch.ml
- OCAMLOPT extraction/Floats.ml
- OCAMLC   extraction/AST.mli
- OCAMLC   lib/Camlcoq.ml
- OCAMLC   extraction/Values.mli
- OCAMLC   extraction/Ctypes.mli
- OCAMLC   common/Sections.mli
- OCAMLC   backend/AisAnnot.mli
- OCAMLC   extraction/Cminor.mli
- OCAMLC   extraction/Events.mli
- OCAMLOPT extraction/Interpreter_complete.ml
- OCAMLC   debug/DebugTypes.mli
- OCAMLC   extraction/Cminortyping.mli
- OCAMLC   extraction/Csharpminor.mli
- OCAMLOPT lib/Camlcoq.ml
- OCAMLOPT extraction/AST.ml
- OCAMLC   extraction/Op.mli
- OCAMLC   extraction/Memdata.mli
- OCAMLC   debug/DwarfTypes.mli
- OCAMLC   extraction/Determinism.mli
- OCAMLC   extraction/Builtins0.mli
- OCAMLC   extraction/Parser.mli
- OCAMLC   extraction/CminorSel.mli
- OCAMLC   extraction/ValueDomain.mli
- OCAMLC   extraction/Cminorgen.mli
- OCAMLC   extraction/CSEdomain.mli
- OCAMLOPT driver/Timing.ml
- OCAMLOPT extraction/Op.ml
- OCAMLC   extraction/Machregs.mli
- OCAMLC   extraction/RTL.mli
- OCAMLOPT common/PrintAST.ml
- OCAMLC   x86/Machregsaux.mli
- OCAMLC   extraction/Mach.mli
- OCAMLOPT extraction/Values.ml
- OCAMLOPT extraction/Ctypes.ml
- OCAMLC   extraction/Memory.mli
- OCAMLOPT common/Sections.ml
- OCAMLC   debug/Debug.mli
- OCAMLOPT extraction/Cminor.ml
- OCAMLC   extraction/Asm.mli
- OCAMLOPT debug/DwarfUtil.ml
- OCAMLC   debug/DwarfPrinter.mli
- OCAMLOPT driver/Driveraux.ml
- OCAMLC   extraction/Globalenvs.mli
- OCAMLOPT extraction/Events.ml
- OCAMLC   extraction/Builtins1.mli
- OCAMLOPT extraction/Main.ml
- OCAMLC   debug/DebugInformation.mli
- OCAMLC   extraction/Unusedglob.mli
- OCAMLOPT common/Switchaux.ml
- OCAMLOPT extraction/CminorSel.ml
- OCAMLC   extraction/SelectOp.mli
- OCAMLOPT backend/Selectionaux.ml
- OCAMLOPT extraction/Cminortyping.ml
- OCAMLC   extraction/Renumber.mli
- OCAMLOPT backend/RTLgenaux.ml
- OCAMLC   extraction/RTLgen.mli
- OCAMLC   cparser/ExtendedAsm.ml
- OCAMLC   extraction/ValueAOp.mli
- OCAMLC   extraction/Liveness.mli
- OCAMLC   extraction/NeedDomain.mli
- OCAMLOPT extraction/Csharpminor.ml
- OCAMLC   extraction/ConstpropOp.mli
- OCAMLOPT extraction/CSEdomain.ml
- OCAMLC   extraction/CombineOp.mli
- OCAMLC   extraction/Asmgen.mli
- OCAMLOPT driver/Assembler.ml
- OCAMLC   backend/Asmexpandaux.mli
- OCAMLC   x86/AsmToJSON.mli
- OCAMLOPT extraction/Machregs.ml
- OCAMLC   extraction/Locations.mli
- OCAMLOPT extraction/RTL.ml
- OCAMLOPT x86/PrintOp.ml
- OCAMLOPT extraction/Memdata.ml
- OCAMLC   extraction/Cop.mli
- OCAMLOPT debug/Debug.ml
- OCAMLOPT backend/PrintCminor.ml
- OCAMLC   extraction/Clight.mli
- OCAMLOPT extraction/Asm.ml
- OCAMLC   backend/PrintAsm.mli
- OCAMLOPT driver/Linker.ml
- OCAMLOPT extraction/Determinism.ml
- OCAMLOPT extraction/Builtins0.ml
- OCAMLC   extraction/Builtins.mli
- OCAMLOPT cparser/Unblock.ml
- OCAMLOPT extraction/Parser.ml
- OCAMLOPT cparser/Cleanup.ml
- OCAMLOPT cparser/Bitfields.ml
- OCAMLOPT debug/DebugInformation.ml
- OCAMLOPT extraction/Unusedglob.ml
- OCAMLC   extraction/Linear.mli
- OCAMLC   extraction/SimplLocals.mli
- OCAMLC   extraction/SplitLong.mli
- OCAMLOPT extraction/Renumber.ml
- OCAMLOPT extraction/RTLgen.ml
- OCAMLOPT extraction/ValueDomain.ml
- OCAMLOPT extraction/Liveness.ml
- OCAMLC   extraction/ValueAnalysis.mli
- OCAMLC   extraction/NeedOp.mli
- OCAMLC   extraction/Cshmgen.mli
- OCAMLOPT extraction/Cminorgen.ml
- OCAMLC   extraction/CleanupLabels.mli
- OCAMLOPT extraction/CombineOp.ml
- OCAMLC   extraction/CSE.mli
- OCAMLOPT backend/Asmexpandaux.ml
- OCAMLOPT x86/AsmToJSON.ml
- OCAMLOPT extraction/Locations.ml
- OCAMLC   backend/XTL.mli
- OCAMLC   extraction/Conventions1.mli
- OCAMLC   extraction/LTL.mli
- OCAMLOPT backend/PrintRTL.ml
- OCAMLOPT extraction/Mach.ml
- OCAMLOPT extraction/Memory.ml
- OCAMLC   extraction/Csyntax.mli
- OCAMLOPT backend/AisAnnot.ml
- OCAMLOPT backend/PrintAsmaux.ml
- OCAMLC   extraction/Csem.mli
- OCAMLOPT extraction/Builtins1.ml
- OCAMLC   extraction/Cexec.mli
- OCAMLOPT cparser/Elab.ml
- OCAMLC   driver/Frontend.mli
- OCAMLOPT debug/Dwarfgen.ml
- OCAMLC   extraction/Tunneling.mli
- OCAMLOPT extraction/Linear.ml
- OCAMLC   extraction/Bounds.mli
- OCAMLC   extraction/SimplExpr.mli
- OCAMLC   extraction/SelectLong.mli
- OCAMLC   extraction/Linearize.mli
- OCAMLC   extraction/Debugvar.mli
- OCAMLOPT extraction/ValueAOp.ml
- OCAMLOPT extraction/NeedDomain.ml
- OCAMLC   extraction/Deadcode.mli
- OCAMLC   extraction/Constprop.mli
- OCAMLOPT extraction/CleanupLabels.ml
- OCAMLOPT extraction/Asmgen.ml
- OCAMLOPT backend/XTL.ml
- OCAMLOPT extraction/Conventions1.ml
- OCAMLC   extraction/Conventions.mli
- OCAMLOPT x86/Machregsaux.ml
- OCAMLOPT extraction/LTL.ml
- OCAMLC   backend/IRC.mli
- OCAMLOPT backend/PrintMach.ml
- OCAMLOPT extraction/Cop.ml
- OCAMLC   extraction/Initializers.mli
- OCAMLOPT cparser/ExtendedAsm.ml
- OCAMLC   extraction/Ctyping.mli
- OCAMLOPT debug/DwarfPrinter.ml
- OCAMLOPT extraction/Globalenvs.ml
- OCAMLOPT extraction/Builtins.ml
- OCAMLOPT debug/DebugInit.ml
- OCAMLOPT extraction/Tunneling.ml
- OCAMLC   extraction/Tailcall.mli
- OCAMLOPT extraction/Bounds.ml
- OCAMLC   extraction/Stacklayout.mli
- OCAMLC   extraction/Lineartyping.mli
- OCAMLC   extraction/SelectDiv.mli
- OCAMLOPT backend/Linearizeaux.ml
- OCAMLC   cfrontend/C2C.ml
- OCAMLOPT extraction/Debugvar.ml
- OCAMLOPT extraction/ValueAnalysis.ml
- OCAMLOPT extraction/NeedOp.ml
- OCAMLOPT x86/Asmexpand.ml
- OCAMLOPT backend/Splitting.ml
- OCAMLOPT extraction/Conventions.ml
- OCAMLC   extraction/RTLtyping.mli
- OCAMLOPT backend/PrintXTL.ml
- OCAMLOPT backend/PrintLTL.ml
- OCAMLOPT extraction/Csyntax.ml
- OCAMLOPT extraction/Clight.ml
- OCAMLOPT extraction/Csem.ml
- OCAMLOPT extraction/Tailcall.ml
- OCAMLOPT extraction/Stacklayout.ml
- OCAMLOPT extraction/Lineartyping.ml
- OCAMLC   extraction/Stacking.mli
- OCAMLOPT extraction/SimplLocals.ml
- OCAMLOPT extraction/SimplExpr.ml
- OCAMLC   extraction/Selection.mli
- OCAMLOPT extraction/Linearize.ml
- OCAMLC   backend/Inliningaux.ml
- OCAMLOPT extraction/Deadcode.ml
- OCAMLOPT extraction/Cshmgen.ml
- OCAMLOPT extraction/CSE.ml
- OCAMLC   extraction/Allocation.mli
- OCAMLOPT extraction/RTLtyping.ml
- OCAMLOPT backend/IRC.ml
- OCAMLOPT extraction/Initializers.ml
- OCAMLOPT extraction/Ctyping.ml
- OCAMLOPT extraction/Cexec.ml
- OCAMLOPT cparser/Lexer.ml
- OCAMLOPT extraction/Stacking.ml
- OCAMLC   extraction/Inlining.mli
- OCAMLOPT backend/Regalloc.ml
- OCAMLC   extraction/Compiler.mli
- OCAMLOPT cfrontend/C2C.ml
- OCAMLOPT cparser/Parse.ml
- OCAMLOPT extraction/Allocation.ml
- OCAMLOPT cfrontend/PrintCsyntax.ml
- OCAMLOPT x86/TargetPrinter.ml
- OCAMLOPT cfrontend/CPragmas.ml
- OCAMLOPT extraction/SelectOp.ml
- OCAMLOPT backend/Inliningaux.ml
- OCAMLOPT extraction/ConstpropOp.ml
- OCAMLOPT cfrontend/PrintClight.ml
- OCAMLOPT driver/Interp.ml
- OCAMLOPT driver/Frontend.ml
- OCAMLOPT extraction/Inlining.ml
- OCAMLOPT backend/PrintAsm.ml
- OCAMLOPT extraction/SplitLong.ml
- OCAMLOPT extraction/SelectLong.ml
- OCAMLOPT extraction/Constprop.ml
- OCAMLOPT extraction/SelectDiv.ml
- OCAMLOPT extraction/Selection.ml
- OCAMLOPT extraction/Compiler.ml
- OCAMLOPT driver/Driver.ml
- Linking ccomp
- gcc: error: /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/menhirLib/menhirLib.o: No such file or directory
- File "caml_startup", line 1:
- Error: Error during linking
- make[2]: *** [Makefile.extr:93: ccomp] Error 2
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make[1]: *** [Makefile:162: ccomp] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
- make: *** [Makefile:138: all] Error 2
[ERROR] The compilation of coq-compcert failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-compcert.3.6 ===================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-compcert-21024-2dea01.env
# output-file          ~/.opam/log/coq-compcert-21024-2dea01.out
### output ###
# [...]
# OCAMLOPT extraction/Selection.ml
# OCAMLOPT extraction/Compiler.ml
# OCAMLOPT driver/Driver.ml
# Linking ccomp
# gcc: error: /home/bench/.opam/ocaml-base-compiler.4.08.1/lib/menhirLib/menhirLib.o: No such file or directory
# File "caml_startup", line 1:
# Error: Error during linking
# make[2]: *** [Makefile.extr:93: ccomp] Error 2
# make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
# make[1]: *** [Makefile:162: ccomp] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-compcert.3.6'
# make: *** [Makefile:138: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-compcert 3.6
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-compcert.3.6 coq.8.10.1' failed.
```