### PR TITLE
coq-mathcomp-finmap 1.3.4 and 1.4.0 work on 8.11.0

### DIFF
--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.3.4/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.3.4/opam
@@ -10,7 +10,7 @@ license: "CeCILL-B"
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.7" & < "8.11~") }
+  "coq" { (>= "8.7" & < "8.12~") }
   "coq-mathcomp-ssreflect" { (>= "1.8.0" & < "1.11~") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.4.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.4.0/opam
@@ -10,7 +10,7 @@ license: "CeCILL-B"
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.7" & < "8.11~") }
+  "coq" { (>= "8.7" & < "8.12~") }
   "coq-mathcomp-ssreflect" { (>= "1.8.0" & < "1.11~") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]


### PR DESCRIPTION
These packages actually do not depend on `coq-mathcomp-bigenough`, but other packages like `coq-mathcomp-analysis` assume that they get `bigenough` along with `finmap`, so leaving unchanged for now.

cc: @CohenCyril 