### PR TITLE
Fix Coq version of coq-coquelicot.3.0.3

### DIFF
--- a/released/packages/coq-coquelicot/coq-coquelicot.3.0.3/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.0.3/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.8" & < "8.11"}
   "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
 tags: [ "keyword:real analysis" "keyword:topology" "keyword:filters" "keyword:metric spaces" "category:Mathematics/Real Calculus and Topology" "date:2019-07-22" ]


### PR DESCRIPTION
@silene The latest version of Coquelicot does not seem to compile with Coq 8.11.

Full logs:
```
Command
opam list; echo; ulimit -Sv 4000000; timeout 1h opam install -y -v coq-coquelicot.3.0.3 coq.8.11.0
Return code
7936
Duration
21 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.11.0      Formal proof management system
coq-mathcomp-ssreflect 1.10.0      Small Scale Reflection
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.09.0      The OCaml compiler (virtual package)
ocaml-base-compiler    4.09.0      Official release 4.09.0
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.0).
The following actions will be performed:
  - install coq-coquelicot 3.0.3
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-coquelicot.3.0.3: http]
[coq-coquelicot.3.0.3] downloaded from https://gforge.inria.fr/frs/download.php/file/38105/coquelicot-3.0.3.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-coquelicot: ./configure]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-coquelicot.3.0.3)
- checking for g++... g++
- checking whether the C++ compiler works... yes
- checking for C++ compiler default output file name... a.out
- checking for suffix of executables... 
- checking whether we are cross compiling... no
- checking for suffix of object files... o
- checking whether we are using the GNU C++ compiler... yes
- checking whether g++ accepts -g... yes
- checking for coqc... /home/bench/.opam/ocaml-base-compiler.4.09.0/bin/coqc
- checking for coqdep... /home/bench/.opam/ocaml-base-compiler.4.09.0/bin/coqdep
- checking for coqdoc... /home/bench/.opam/ocaml-base-compiler.4.09.0/bin/coqdoc
- checking for SSReflect... 
- yes
- configure: building remake...
- /usr/bin/ld: /tmp/ccrfKAx0.o: in function `main':
- remake.cpp:(.text.startup+0xae0): warning: the use of `tempnam' is dangerous, better use `mkstemp'
- configure: creating ./config.status
- config.status: creating Remakefile
Processing  1/2: [coq-coquelicot: ./remake]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./remake" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-coquelicot.3.0.3)
- Building theories/AutoDerive.vo
- Building theories/Compactness.vo
- Building theories/Complex.vo
- Building theories/Continuity.vo
- Building theories/Derive.vo
- Building theories/Hierarchy.vo
- Building theories/Derive_2d.vo
- Building theories/Rcomplements.vo
- Building theories/ElemFct.vo
- Building theories/Iter.vo
- Building theories/Lim_seq.vo
- Building theories/Equiv.vo
- Building theories/Rbar.vo
- Building theories/PSeries.vo
- Building theories/Lub.vo
- Building theories/Markov.vo
- Building theories/RInt.vo
- Building theories/Seq_fct.vo
- Building theories/Series.vo
- Building theories/RInt_analysis.vo
- Building theories/Coquelicot.vo
- Building theories/SF_seq.vo
- Building theories/KHInt.vo
- Building theories/RInt_gen.vo
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ | _ ]" was already used in scope fun_scope.
- [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ : _ | _ ]" was already used in scope fun_scope.
- [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ in _ & _ | _ ]" was already used in scope
- fun_scope. [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ in _ & _ ]" was already used in scope fun_scope.
- [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ in _ | _ ]" was already used in scope fun_scope.
- [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 95, characters 0-65:
- Warning: Notation "[ rel _ _ in _ ]" was already used in scope fun_scope.
- [notation-overridden,parsing]
- File "./theories/Rcomplements.v", line 661, characters 2-37:
- Warning: Duplicate clear of H [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 677, characters 2-20:
- Warning: Duplicate clear of n [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 1384, characters 2-54:
- Warning: Duplicate clear of n [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 1414, characters 2-54:
- Warning: Duplicate clear of n [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 1435, characters 2-49:
- Warning: Duplicate clear of Hl [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 1440, characters 2-26:
- Warning: Duplicate clear of Hl [duplicate-clear,ssr]
- File "./theories/Rcomplements.v", line 1657, characters 35-42:
- Error: The reference Rlength was not found in the current environment.
- 
- Failed to build theories/Rcomplements.vo
- Failed to build theories/Coquelicot.vo
- Failed to build theories/SF_seq.vo
- Failed to build theories/KHInt.vo
- Failed to build theories/RInt_gen.vo
- Failed to build theories/RInt.vo
- Failed to build theories/Seq_fct.vo
- Failed to build theories/Series.vo
- Failed to build theories/RInt_analysis.vo
- Failed to build theories/Rbar.vo
- Failed to build theories/Lub.vo
- Failed to build theories/Markov.vo
- Failed to build theories/Iter.vo
- Failed to build theories/Lim_seq.vo
- Failed to build theories/Equiv.vo
- Failed to build theories/Derive.vo
- Failed to build theories/Hierarchy.vo
- Failed to build theories/ElemFct.vo
- Failed to build theories/AutoDerive.vo
- Failed to build theories/Compactness.vo
- Failed to build theories/Derive_2d.vo
- Failed to build all
- Failed to build theories/Continuity.vo
- Failed to build theories/Complex.vo
- Failed to build theories/PSeries.vo
[ERROR] The compilation of coq-coquelicot failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build ./remake -j4".
#=== ERROR while compiling coq-coquelicot.3.0.3 ===============================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.09.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-coquelicot.3.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./remake -j4
# exit-code            1
# env-file             ~/.opam/log/coq-coquelicot-11839-2dea01.env
# output-file          ~/.opam/log/coq-coquelicot-11839-2dea01.out
### output ###
# [...]
# Failed to build theories/Lim_seq.vo
# Failed to build theories/Equiv.vo
# Failed to build theories/Derive.vo
# Failed to build theories/Hierarchy.vo
# Failed to build theories/ElemFct.vo
# Failed to build theories/AutoDerive.vo
# Failed to build theories/Compactness.vo
# Failed to build theories/Derive_2d.vo
# Failed to build all
# Failed to build theories/Continuity.vo
# Failed to build theories/Complex.vo
# Failed to build theories/PSeries.vo
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-coquelicot 3.0.3
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-coquelicot.3.0.3 coq.8.11.0' failed.
```