### PR TITLE
Fix coq-poltac.0.8.8 Coq version

### DIFF
--- a/released/packages/coq-poltac/coq-poltac.0.8.8/opam
+++ b/released/packages/coq-poltac/coq-poltac.0.8.8/opam
@@ -12,7 +12,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/PolTac"]
 depends: [
   "ocaml"
-  "coq" {>= "8.8~"}
+  "coq" {>= "8.8~" & < "8.11"}
 ]
 synopsis:
   "A set of tactics to deal with inequalities in Coq over N, Z and R:"


### PR DESCRIPTION
@thery Poltac seems incompatible with Coq 8.11:
```
Command
opam list; echo; ulimit -Sv 4000000; timeout 1h opam install -y -v coq-poltac.0.8.8 coq.8.11.0
Return code
7936
Duration
44 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.11.0      Formal proof management system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.09.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.09.0      Official release 4.09.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.0).
The following actions will be performed:
  - install coq-poltac 0.8.8
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-poltac.0.8.8: http]
[coq-poltac.0.8.8] downloaded from https://github.com/thery/PolTac/archive/8.8.zip
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  2/2: [coq-poltac: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "install" "make" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-poltac.0.8.8)
- /home/bench/.opam/ocaml-base-compiler.4.09.0/bin//coq_makefile -f _CoqProject -o Makefile.coq
- COQDEP VFILES
- COQC PolAuxList.v
- COQC PolSBase.v
- COQC NAux.v
- COQC Replace2.v
- COQC P.v
- COQC PolAux.v
- COQC RPolS.v
- COQC RGroundTac.v
- COQC RSignTac.v
- COQC NatGroundTac.v
- File "./NatGroundTac.v", line 25, characters 0-77:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "./NatGroundTac.v", line 26, characters 0-76:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- COQC NatSignTac.v
- COQC NGroundTac.v
- File "./NGroundTac.v", line 16, characters 0-54:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "./NGroundTac.v", line 17, characters 0-69:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- COQC NSignTac.v
- COQC ZSignTac.v
- COQC ZPolS.v
- COQC NatPolS.v
- COQC NPolS.v
- COQC PolFBase.v
- COQC RPolF.v
- COQC ZPolF.v
- COQC NatPolF.v
- COQC NPolF.v
- COQC PolRBase.v
- COQC RPolR.v
- COQC ZPolR.v
- COQC NatPolR.v
- COQC NPolR.v
- COQC PolTac.v
- COQC Natex.v
- File "./Natex.v", line 5, characters 0-5:
- Error: Tactic failure.
- 
- make[1]: *** [Makefile.coq:678: Natex.vo] Error 1
- make: *** [Makefile.coq:327: all] Error 2
[ERROR] The installation of coq-poltac failed at "make".
Processing  2/2: [coq-poltac: rm]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "remove" "rm" "-R" "/home/bench/.opam/ocaml-base-compiler.4.09.0/lib/coq/user-contrib/PolTac" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-poltac.0.8.8)
- rm: cannot remove '/home/bench/.opam/ocaml-base-compiler.4.09.0/lib/coq/user-contrib/PolTac': No such file or directory
#=== ERROR while installing coq-poltac.0.8.8 ==================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.09.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-poltac.0.8.8
# command              ~/.opam/opam-init/hooks/sandbox.sh install make
# exit-code            2
# env-file             ~/.opam/log/coq-poltac-5553-865888.env
# output-file          ~/.opam/log/coq-poltac-5553-865888.out
### output ###
# [...]
# COQC PolRBase.v
# COQC RPolR.v
# COQC ZPolR.v
# COQC NatPolR.v
# COQC NPolR.v
# COQC PolTac.v
# COQC Natex.v
# File "./Natex.v", line 5, characters 0-5:
# Error: Tactic failure.
# 
# make[1]: *** [Makefile.coq:678: Natex.vo] Error 1
# make: *** [Makefile.coq:327: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - install coq-poltac 0.8.8
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-poltac.0.8.8 coq.8.11.0' failed.
```