### PR TITLE
Fix coq-tlc.20181116 Coq version

### DIFF
--- a/released/packages/coq-tlc/coq-tlc.20181116/opam
+++ b/released/packages/coq-tlc/coq-tlc.20181116/opam
@@ -19,7 +19,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.6"}
+  "coq" {>= "8.6" & < "8.11"}
 ]
 url {
   src: "http://tlc.gforge.inria.fr/releases/tlc-20181116.tar.gz"


### PR DESCRIPTION
@Armael The latest version of TLC appears to be broken with Coq 8.11:
```
Command
opam list; echo; ulimit -Sv 4000000; timeout 1h opam install -y -v coq-tlc.20181116 coq.8.11.0
Return code
7936
Duration
1 m 10 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.11.0      Formal proof management system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.09.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.09.0      Official release 4.09.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.0).
The following actions will be performed:
  - install coq-tlc 20181116
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-tlc.20181116: http]
[coq-tlc.20181116] downloaded from http://tlc.gforge.inria.fr/releases/tlc-20181116.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-tlc: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116)
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
- make -f Makefile.coq all
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
- Compiling LibTactics...
- Compiling LibAxioms...
- Compiling LibLogicCore...
- Compiling LibOld...
- Compiling LibListExec...
- Compiling LibHeap...
- Compiling LibListSort...
- Compiling LibExec...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTactics.v", line 58, characters 0-32:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTactics.v", line 103, characters 0-42:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope ltac_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTactics.v", line 631, characters 0-16:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTactics.v", line 5076, characters 0-196:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope let_scope.". [undeclared-scope,deprecated]
- Compiling LibOperation...
- Compiling LibTacticsDemos...
- Compiling LibEqual...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibEqual.v", line 862, characters 0-30:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibLogic...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTacticsDemos.v", line 1225, characters 0-37:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibTacticsDemos.v", line 1227, characters 0-33:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibLogic.v", line 513, characters 0-40:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibLogic.v", line 561, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibLogic.v", line 863, characters 0-33:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibLogic.v", line 921, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibMonoid...
- Compiling LibBool...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibBool.v", line 86, characters 0-32:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope Bool_scope.". [undeclared-scope,deprecated]
- Compiling LibReflect...
- Compiling LibSum...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibReflect.v", line 69, characters 0-42:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibReflect.v", line 71, characters 0-55:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibReflect.v", line 74, characters 0-100:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibProd...
- Compiling LibString...
- Compiling LibUnit...
- Compiling LibOption...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibProd.v", line 82, characters 0-42:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibRelation...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 294, characters 0-42:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1013, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1178, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1287, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1391, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1477, characters 2-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1477, characters 2-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1510, characters 2-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1510, characters 2-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1570, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1677, characters 2-32:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1677, characters 2-32:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1709, characters 2-32:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1709, characters 2-32:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1768, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1863, characters 0-29:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 1957, characters 0-59:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2100, characters 0-89:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2102, characters 0-111:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2188, characters 0-65:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2248, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2300, characters 0-19:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2360, characters 2-29:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibRelation.v", line 2360, characters 2-29:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibOrder...
- Compiling LibEpsilon...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 53, characters 0-33:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 59, characters 0-40:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 110, characters 0-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibChoice...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 152, characters 0-35:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 209, characters 62-66:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 213, characters 0-64:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 389, characters 0-48:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 453, characters 0-77:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope comp_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibOrder.v", line 1086, characters 0-102:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope comp_scope_reflect.". [undeclared-scope,deprecated]
- Compiling LibNat...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibNat.v", line 8, characters 0-88:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- Compiling LibInt...
- Compiling LibMin...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMin.v", line 11, characters 0-102:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibInt.v", line 10, characters 0-31:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibInt.v", line 23, characters 0-34:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope Int_scope.". [undeclared-scope,deprecated]
- Compiling LibWf...
- Compiling LibIntTactics...
- Compiling LibContainer...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibWf.v", line 7, characters 0-86:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibWf.v", line 250, characters 0-19:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibWf.v", line 281, characters 0-17:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibList...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibContainer.v", line 7, characters 0-99:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- Compiling LibFix...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibContainer.v", line 45, characters 0-46:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope container_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibIntTactics.v", line 20, characters 0-31:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 9, characters 0-129:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 7, characters 0-137:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 22, characters 0-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 23, characters 0-43:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 24, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 25, characters 0-46:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 26, characters 0-46:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 37, characters 0-33:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 56, characters 0-23:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 63, characters 0-23:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 74, characters 0-30:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 31, characters 0-74:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope liblist_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 464, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 553, characters 0-40:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 554, characters 0-36:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 555, characters 0-56:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 572, characters 0-52:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 727, characters 0-85:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 603, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 788, characters 0-26:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 1122, characters 0-20:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 926, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 1297, characters 2-46:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 1297, characters 2-46:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1316, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1316, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFix.v", line 1803, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1611, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1611, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1665, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1665, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1710, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1892, characters 0-31:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1916, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1916, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1948, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 1948, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2035, characters 0-35:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2232, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2232, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2629, characters 0-25:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2820, characters 0-26:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2956, characters 2-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 2956, characters 2-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3057, characters 0-25:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3141, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3141, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3501, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3501, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3571, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3571, characters 2-24:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3593, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibList.v", line 3604, characters 0-27:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibCore...
- Compiling LibSet...
- Compiling LibStream...
- Compiling LibListSub...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibListSub.v", line 11, characters 0-137:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibCore.v", line 7, characters 0-79:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- Compiling LibListZ...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 8, characters 0-77:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibSet.v", line 9, characters 0-134:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibSet.v", line 164, characters 0-104:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope set_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibSet.v", line 192, characters 0-22:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 137, characters 0-26:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 162, characters 0-23:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 163, characters 0-26:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 221, characters 0-38:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibStream.v", line 222, characters 0-37:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibListZ.v", line 8, characters 0-108:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibSet.v", line 1046, characters 0-56:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibGraph...
- Compiling LibFset...
- Compiling LibMultiset...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFset.v", line 55, characters 0-39:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope fset_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibGraph.v", line 17, characters 0-39:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 11, characters 0-134:
- Warning:
- New coercion path [total_order_to_total_preorder; total_preorder_to_preorder] : total_order >-> preorder is ambiguous with existing 
- [total_order_order; order_to_preorder] : total_order >-> preorder.
- [ambiguous-paths,typechecker]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFset.v", line 201, characters 0-39:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope fset_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 101, characters 0-28:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 102, characters 0-48:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 103, characters 0-30:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibMap...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 206, characters 0-56:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFset.v", line 269, characters 0-36:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- Compiling LibFun...
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMap.v", line 201, characters 0-45:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMap.v", line 202, characters 0-45:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMap.v", line 252, characters 34-61:
- Warning: The proof has remaining shelved goals
- [remaining-shelved-goals,tactics]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMap.v", line 253, characters 0-4:
- Error: Some unresolved existential variables remain
- 
- make[2]: *** [Makefile.coq:115: /home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMap.vo] Error 1
- make[2]: *** Waiting for unfinished jobs....
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFun.v", line 57, characters 0-88:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope fun_scope.". [undeclared-scope,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFun.v", line 176, characters 2-30:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFun.v", line 176, characters 2-30:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 625, characters 0-25:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
- make[1]: *** [Makefile:31: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
- make: *** [Makefile:8: all] Error 2
[ERROR] The compilation of coq-tlc failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-tlc.20181116 ===================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.09.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-tlc-9290-865888.env
# output-file          ~/.opam/log/coq-tlc-9290-865888.out
### output ###
# [...]
# File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibFun.v", line 176, characters 2-30:
# Warning: Adding and removing hints in the core database implicitly is
# deprecated. Please specify a hint database.
# [implicit-core-hint-db,deprecated]
# File "/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src/LibMultiset.v", line 625, characters 0-25:
# Warning: Adding and removing hints in the core database implicitly is
# deprecated. Please specify a hint database.
# [implicit-core-hint-db,deprecated]
# make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
# make[1]: *** [Makefile:31: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.0/.opam-switch/build/coq-tlc.20181116/src'
# make: *** [Makefile:8: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-tlc 20181116
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-tlc.20181116 coq.8.11.0' failed.
```