### PR TITLE
Coq.Interval 3.4.1 doesn't compile with 8.11

### DIFF
--- a/released/packages/coq-interval/coq-interval.3.4.1/opam
+++ b/released/packages/coq-interval/coq-interval.3.4.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.7"}
+  "coq" {>= "8.7" & < "8.11~"}
   "coq-bignums"
   "coq-flocq" {>= "3.0"}
   "coq-mathcomp-ssreflect" {>= "1.6"}


### PR DESCRIPTION
@silene master does compile with 8.11 but contains a bunch of (potentially breaking) changes, maybe should that be a 4.0.0?
