### PR TITLE
Mathcomp 1.9.0 compiles on Coq 8.11

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
@@ -10,7 +10,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { (>= "8.7" & < "8.11~") | (= "dev") } ]
+depends: [ "coq" { (>= "8.7" & < "8.12~") | (= "dev") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
Changing the constraint in coq-mathcomp-ssreflect.1.9.0 is enough to
get the following packages compiling with Coq 8.11.0:
coq-mathcomp-ssreflect         1.9.0       Small Scale Reflection
coq-mathcomp-algebra           1.9.0       Mathematical Components Library on Algebra
coq-mathcomp-character         1.9.0       Mathematical Components Library on character theory
coq-mathcomp-field             1.9.0       Mathematical Components Library on Fields
coq-mathcomp-fingroup          1.9.0       Mathematical Components Library on finite groups
coq-mathcomp-solvable          1.9.0       Mathematical Components Library on finite groups (II)