### PR TITLE
Mathcomp 1.9.0 and 1.10.0 does not compile on Coq dev version

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.10.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.10.0/opam
@@ -8,7 +8,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.7" & < "8.12~") | (= "dev"))} ]
+depends: [ "coq" { (>= "8.7" & < "8.12~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.9.0/opam
@@ -10,7 +10,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { (>= "8.7" & < "8.12~") | (= "dev") } ]
+depends: [ "coq" { (>= "8.7" & < "8.12~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
Because the following PR https://github.com/coq/coq/pull/11368 turns trailing maximal implicits into an error.

Here is an example
```
$ opam install coq-mathcomp-ssreflect.1.10.0
The following actions will be performed:
  ∗ install coq-mathcomp-ssreflect 1.10.0

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
[coq-mathcomp-ssreflect.1.10.0] found in cache

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
[ERROR] The compilation of coq-mathcomp-ssreflect failed at "/Users/anton/.opam/opam-init/hooks/sandbox.sh build
        make -C mathcomp/ssreflect -j 3".

#=== ERROR while compiling coq-mathcomp-ssreflect.1.10.0 ======================#
# context     2.0.6 | macos/x86_64 | ocaml-base-compiler.4.09.0 | https://coq.inria.fr/opam/released#2020-02-01 16:50
# path        ~/.opam/coqdev4.09/.opam-switch/build/coq-mathcomp-ssreflect.1.10.0
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -C mathcomp/ssreflect -j 3
# exit-code   2
# env-file    ~/.opam/log/coq-mathcomp-ssreflect-44187-1872ec.env
# output-file ~/.opam/log/coq-mathcomp-ssreflect-44187-1872ec.out
### output ###
# [...]
# Warning: Notation "_ * _" was already used in scope nat_scope.
# [notation-overridden,parsing]
# File "./bigop.v", line 516, characters 0-33:
# Warning: Declaring a scope implicitly is deprecated; use in advance an
# explicit "Declare Scope big_scope.". [undeclared-scope,deprecated]
# File "./bigop.v", line 1665, characters 0-56:
# Error: Argument F is a trailing implicit, so it can't be declared non
# maximal. Please use { } instead of [ ].
#
# make[2]: *** [bigop.vo] Error 1
# make[1]: *** [all] Error 2
# make: *** [this-build] Error 2



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build coq-mathcomp-ssreflect 1.10.0
└─
╶─ No changes have been performed
```