### PR TITLE
Fix dependencies of coq-monae.0.0.4

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.0.4/opam
+++ b/released/packages/coq-monae/coq-monae.0.0.4/opam
@@ -19,7 +19,7 @@ install: [
 ]
 depends: [
   "coq" { >= "8.10" & < "8.12~" }
-  "coq-infotheo" { >= "0.0.6" }
+  "coq-infotheo" { >= "0.0.6" & < "0.0.7" }
 ]
 synopsis: "Monae"
 description: """


### PR DESCRIPTION
Here are logs of the bug:
```
Command
opam list; echo; ulimit -Sv 4000000; timeout 1h opam install -y -v coq-monae.0.0.4 coq.8.11.0
Return code
7936
Duration
34 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.11.0      Formal proof management system
coq-infotheo           0.0.7       Infotheo
coq-mathcomp-algebra   1.10.0      Mathematical Components Library on Algebra
coq-mathcomp-analysis  0.2.3       An analysis library for mathematical components
coq-mathcomp-bigenough 1.0.0       A small library to do epsilon - N reasonning
coq-mathcomp-field     1.10.0      Mathematical Components Library on Fields
coq-mathcomp-fingroup  1.10.0      Mathematical Components Library on finite groups
coq-mathcomp-finmap    1.4.0       Finite sets, finite maps, finitely supported functions, orders
coq-mathcomp-solvable  1.10.0      Mathematical Components Library on finite groups (II)
coq-mathcomp-ssreflect 1.10.0      Small Scale Reflection
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.06.1      The OCaml compiler (virtual package)
ocaml-base-compiler    4.06.1      Official 4.06.1 release
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.0).
The following actions will be performed:
  - install coq-monae 0.0.4
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-monae.0.0.4: http]
[coq-monae.0.0.4] downloaded from https://github.com/affeldt-aist/monae/archive/0.0.4.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-monae: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-monae.0.0.4)
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq all
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-monae.0.0.4'
- COQDEP VFILES
- COQC monae_lib.v
- COQC smallstep.v
- COQC monad.v
- COQC fail_monad.v
- COQC monad_composition.v
- COQC category.v
- File "./fail_monad.v", line 779, characters 0-20:
- Warning: Ignoring canonical projection to MonadFail.base by Monad.class in
- monadType: redundant with MonadFail.baseType
- [redundant-canonical-projection,typechecker]
- COQC state_monad.v
- COQC proba_monad.v
- COQC example_spark.v
- File "./proba_monad.v", line 39, characters 36-41:
- Error: Unknown interpretation for notation "`Pr _".
- 
- make[2]: *** [Makefile.coq:677: proba_monad.vo] Error 1
- make[2]: *** Waiting for unfinished jobs....
- make[1]: *** [Makefile.coq:327: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-monae.0.0.4'
- make: *** [Makefile:2: all] Error 2
[ERROR] The compilation of coq-monae failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-monae.0.0.4 ====================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.06.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-monae.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-monae-15313-335865.env
# output-file          ~/.opam/log/coq-monae-15313-335865.out
### output ###
# [...]
# [redundant-canonical-projection,typechecker]
# COQC state_monad.v
# COQC proba_monad.v
# COQC example_spark.v
# File "./proba_monad.v", line 39, characters 36-41:
# Error: Unknown interpretation for notation "`Pr _".
# 
# make[2]: *** [Makefile.coq:677: proba_monad.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# make[1]: *** [Makefile.coq:327: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-monae.0.0.4'
# make: *** [Makefile:2: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-monae 0.0.4
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-monae.0.0.4 coq.8.11.0' failed.
```

I am guessing this is related to the recent release of `coq-infotheo`.