### PR TITLE
Add {coq-libvalidsdp, coq-validsdp} 0.7.0

### DIFF
--- a/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.7.0/opam
+++ b/released/packages/coq-libvalidsdp/coq-libvalidsdp.0.7.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]
+
+homepage: "https://sourcesup.renater.fr/validsdp/"
+dev-repo: "git+https://github.com/validsdp/validsdp.git"
+bug-reports: "https://github.com/validsdp/validsdp/issues"
+license: "LGPL-2.1-or-later"
+
+build: [
+  ["sh" "-c" "./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.7" & < "8.12~"}
+  "coq-bignums"
+  "coq-flocq" {>= "3.1.0"}
+  "coq-coquelicot" {>= "3.0"}
+  "coq-interval" {>= "3.4.0" & < "4~"}
+  "coq-mathcomp-field" {>= "1.8" & < "1.11~"}
+  "ocamlfind" {build}
+  "conf-autoconf" {build}
+]
+synopsis: "LibValidSDP"
+description: """
+LibValidSDP is a library for the Coq formal proof assistant. It provides
+results mostly about rounding errors in the Cholesky decomposition algorithm
+used in the ValidSDP library which itself implements Coq tactics to prove
+multivariate inequalities using SDP solvers.
+
+Once installed, the following modules can be imported :
+From libValidSDP Require Import Rstruct.v misc.v real_matrix.v bounded.v float_spec.v fsum.v fcmsum.v binary64.v cholesky.v float_infnan_spec.v binary64_infnan.v cholesky_infnan.v flx64.v zulp.v coqinterval_infnan.v.
+"""
+
+tags: [
+  "keyword:libValidSDP"
+  "keyword:ValidSDP"
+  "keyword:floating-point arithmetic"
+  "keyword:Cholesky decomposition"
+  "category:libValidSDP"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:libValidSDP"
+]
+authors: [
+  "Pierre Roux <pierre.roux@onera.fr>"
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+]
+url {
+  src: "https://github.com/validsdp/validsdp/releases/download/v0.7.0/libvalidsdp-0.7.0.tar.gz"
+  checksum: "sha256=b9559939a14f56bdd1929fedf8c7d5e8a217ba5057686acad667b3d1b45fa14d"
+}

--- a/released/packages/coq-validsdp/coq-validsdp.0.7.0/opam
+++ b/released/packages/coq-validsdp/coq-validsdp.0.7.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Pierre Roux <pierre.roux@onera.fr>"
+]
+
+homepage: "https://sourcesup.renater.fr/validsdp/"
+dev-repo: "git+https://github.com/validsdp/validsdp.git"
+bug-reports: "https://github.com/validsdp/validsdp/issues"
+license: "LGPL-2.1-or-later"
+
+build: [
+  ["sh" "-c" "./configure"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+
+depends: [
+  "ocaml"
+  "coq" {>= "8.7" & < "8.12~"}
+  "coq-bignums"
+  "coq-flocq" {>= "3.1.0"}
+  "coq-interval" {>= "3.4.0" & < "4~"}
+  "coq-mathcomp-field" {>= "1.8" & < "1.11~"}
+  "coq-libvalidsdp" {= "0.7.0"}
+  "coq-mathcomp-multinomials" {>= "1.2"}
+  "coq-coqeal" {>= "1.0.0"}
+  "coq-paramcoq" {>= "1.1.0"}
+  "osdp" {>= "1.0"}
+  "ocamlfind" {build}
+  "conf-autoconf" {build}
+]
+synopsis: "ValidSDP"
+description: """
+ValidSDP is a library for the Coq formal proof assistant. It provides
+reflexive tactics to prove multivariate inequalities involving
+real-valued variables and rational constants, using SDP solvers as
+untrusted back-ends and verified checkers based on libValidSDP.
+
+Once installed, you can import the following modules:
+From Coq Require Import Reals.
+From ValidSDP Require Import validsdp.
+"""
+
+tags: [
+  "keyword:libValidSDP"
+  "keyword:ValidSDP"
+  "keyword:floating-point arithmetic"
+  "keyword:Cholesky decomposition"
+  "category:ValidSDP"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:ValidSDP"
+]
+authors: [
+  "Érik Martin-Dorel <erik.martin-dorel@irit.fr>"
+  "Pierre Roux <pierre.roux@onera.fr>"
+]
+url {
+  src: "https://github.com/validsdp/validsdp/releases/download/v0.7.0/validsdp-0.7.0.tar.gz"
+  checksum: "sha256=69f7d5f56b0e14bc9b927ff203d8ad8d699134a66b50c60deca58b78074ec1af"
+}


### PR DESCRIPTION
Compatible with Coq 8.7→8.11, MathComp 1.8.0→1.10.0

cf. this [Travis CI build](https://travis-ci.com/validsdp/validsdp/builds/150652941)

Cc @proux01 