### PR TITLE
Added patched versions of CompCert for Coq 8.10 and 8.11

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.5+8.10/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.5+8.10/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  "ia32-macosx" {os = "macos"}
+  "ia32-cygwin" {os = "cygwin"}
+  "-bindir" "%{bin}%"
+  "-libdir" "%{lib}%/compcert"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0644" "VERSION" "%{lib}%/coq/user-contrib/compcert/"]
+]
+depends: [
+  "ocaml" {< "4.08.0"}
+  # This are the release versions of Coq which include this version of compcert
+  # See compcert_CI_REF in
+  # https://github.com/coq/coq/blob/V8.10.0/dev/ci/ci-basic-overlay.sh
+  # https://github.com/coq/coq/blob/V8.10.1/dev/ci/ci-basic-overlay.sh
+  # https://github.com/coq/coq/blob/V8.10.2/dev/ci/ci-basic-overlay.sh 
+  "coq" {= "8.10.0" | = "8.10.1" | = "8.10.2"}
+  "menhir" {>= "20180530" & <= "20181113"}
+]
+synopsis: "The CompCert C compiler (patched for Coq 8.10.X compatibility)"
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2019-02-27"
+]
+url {
+  src: "https://github.com/MSoegtropIMC/CompCert/archive/v3.5_coq_8.10.tar.gz"
+  checksum: "sha256=d810db1c48ba63215415b5d383a622f0c38a79decfb8405e687b63ebfb65a7df"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.6+8.11/files/compat-8-11.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.6+8.11/files/compat-8-11.patch
@@ -1,0 +1,148 @@
+diff --git a/backend/Inliningproof.v b/backend/Inliningproof.v
+index 181f40bf..cc84b1cc 100644
+--- a/backend/Inliningproof.v
++++ b/backend/Inliningproof.v
+@@ -744,7 +744,7 @@ Lemma match_stacks_free_right:
+   match_stacks F m m1' stk stk' sp.
+ Proof.
+   intros. eapply match_stacks_invariant; eauto.
+-  intros. eapply Mem.perm_free_1; eauto.
++  intros. eapply Mem.perm_free_1; eauto with ordered_type.
+   intros. eapply Mem.perm_free_3; eauto.
+ Qed.
+ 
+@@ -1043,7 +1043,7 @@ Proof.
+   eapply match_stacks_bound with (bound := sp').
+   eapply match_stacks_invariant; eauto.
+     intros. eapply Mem.perm_free_3; eauto.
+-    intros. eapply Mem.perm_free_1; eauto.
++    intros. eapply Mem.perm_free_1; eauto with ordered_type.
+     intros. eapply Mem.perm_free_3; eauto.
+   erewrite Mem.nextblock_free; eauto. red in VB; xomega.
+   eapply agree_val_regs; eauto.
+@@ -1135,7 +1135,7 @@ Proof.
+   eapply match_stacks_bound with (bound := sp').
+   eapply match_stacks_invariant; eauto.
+     intros. eapply Mem.perm_free_3; eauto.
+-    intros. eapply Mem.perm_free_1; eauto.
++    intros. eapply Mem.perm_free_1; eauto with ordered_type.
+     intros. eapply Mem.perm_free_3; eauto.
+   erewrite Mem.nextblock_free; eauto. red in VB; xomega.
+   destruct or; simpl. apply agree_val_reg; auto. auto.
+@@ -1182,7 +1182,7 @@ Proof.
+     subst b1. rewrite D in H8; inv H8. eelim Plt_strict; eauto.
+     intros. eapply Mem.perm_alloc_1; eauto.
+     intros. exploit Mem.perm_alloc_inv. eexact A. eauto.
+-    rewrite dec_eq_false; auto.
++    rewrite dec_eq_false; auto with ordered_type.
+   auto. auto. auto. eauto. auto.
+   rewrite H5. apply agree_regs_init_regs. eauto. auto. inv H1; auto. congruence. auto.
+   eapply Mem.valid_new_block; eauto.
+diff --git a/backend/ValueAnalysis.v b/backend/ValueAnalysis.v
+index 8dbb67a7..2b233900 100644
+--- a/backend/ValueAnalysis.v
++++ b/backend/ValueAnalysis.v
+@@ -1148,10 +1148,10 @@ Proof.
+ - constructor.
+ - assert (Plt sp bound') by eauto with va.
+   eapply sound_stack_public_call; eauto. apply IHsound_stack; intros.
+-  apply INV. xomega. rewrite SAME; auto. xomega. auto. auto.
++  apply INV. xomega. rewrite SAME; auto with ordered_type. xomega. auto. auto.
+ - assert (Plt sp bound') by eauto with va.
+   eapply sound_stack_private_call; eauto. apply IHsound_stack; intros.
+-  apply INV. xomega. rewrite SAME; auto. xomega. auto. auto.
++  apply INV. xomega. rewrite SAME; auto with ordered_type. xomega. auto. auto.
+   apply bmatch_ext with m; auto. intros. apply INV. xomega. auto. auto. auto.
+ Qed.
+ 
+@@ -1362,7 +1362,7 @@ Proof.
+   apply sound_stack_exten with bc.
+   apply sound_stack_inv with m. auto.
+   intros. apply Q. red. eapply Plt_trans; eauto.
+-  rewrite C; auto.
++  rewrite C; auto with ordered_type.
+   exact AA.
+ * (* public builtin call *)
+   exploit anonymize_stack; eauto.
+@@ -1381,7 +1381,7 @@ Proof.
+   apply sound_stack_exten with bc.
+   apply sound_stack_inv with m. auto.
+   intros. apply Q. red. eapply Plt_trans; eauto.
+-  rewrite C; auto.
++  rewrite C; auto with ordered_type.
+   exact AA.
+   }
+   unfold transfer_builtin in TR.
+diff --git a/lib/Heaps.v b/lib/Heaps.v
+index 9fa07a1d..85343998 100644
+--- a/lib/Heaps.v
++++ b/lib/Heaps.v
+@@ -256,14 +256,14 @@ Proof.
+   eapply gt_heap_trans with y; eauto. red; auto.
+ - intuition.
+   eapply lt_heap_trans; eauto. red; auto.
+-  eapply gt_heap_trans; eauto. red; auto.
++  eapply gt_heap_trans; eauto. red; auto with ordered_type.
+ - intuition. eapply gt_heap_trans; eauto. red; auto.
+ - rewrite e3 in *; simpl in *. intuition.
+   eapply lt_heap_trans with y; eauto. red; auto.
+   eapply gt_heap_trans; eauto. red; auto.
+ - intuition.
+   eapply lt_heap_trans with y; eauto. red; auto.
+-  eapply gt_heap_trans; eauto. red; auto.
++  eapply gt_heap_trans; eauto. red; auto with ordered_type.
+   eapply gt_heap_trans with x; eauto. red; auto.
+ - rewrite e3 in *; simpl in *; intuition.
+   eapply gt_heap_trans; eauto. red; auto.
+@@ -308,7 +308,7 @@ Proof.
+   intros. unfold insert.
+   case_eq (partition x h). intros a b EQ; simpl.
+   assert (E.eq y x \/ ~E.eq y x).
+-    destruct (E.compare y x); auto.
++    destruct (E.compare y x); auto with ordered_type.
+     right; red; intros. elim (E.lt_not_eq l). apply E.eq_sym; auto.
+   destruct H0.
+   tauto.
+diff --git a/lib/Ordered.v b/lib/Ordered.v
+index bcf24cbd..1adbd330 100644
+--- a/lib/Ordered.v
++++ b/lib/Ordered.v
+@@ -21,6 +21,8 @@ Require Import Coqlib.
+ Require Import Maps.
+ Require Import Integers.
+ 
++Create HintDb ordered_type.
++
+ (** The ordered type of positive numbers *)
+ 
+ Module OrderedPositive <: OrderedType.
+@@ -173,17 +175,17 @@ Definition eq (x y: t) :=
+ 
+ Lemma eq_refl : forall x : t, eq x x.
+ Proof.
+-  intros; split; auto.
++  intros; split; auto with ordered_type.
+ Qed.
+ 
+ Lemma eq_sym : forall x y : t, eq x y -> eq y x.
+ Proof.
+-  unfold eq; intros. intuition auto.
++  unfold eq; intros. intuition auto with ordered_type.
+ Qed.
+ 
+ Lemma eq_trans : forall x y z : t, eq x y -> eq y z -> eq x z.
+ Proof.
+-  unfold eq; intros. intuition eauto.
++  unfold eq; intros. intuition eauto with ordered_type.
+ Qed.
+ 
+ Definition lt (x y: t) :=
+@@ -201,7 +203,7 @@ Proof.
+   case (A.compare (fst x) (fst z)); intro.
+   assumption.
+   generalize (A.lt_not_eq H2); intro. elim H5.
+-  apply A.eq_trans with (fst z). auto. auto.
++  apply A.eq_trans with (fst z). auto. auto with ordered_type.
+   generalize (@A.lt_not_eq (fst z) (fst y)); intro.
+   elim H5. apply A.lt_trans with (fst x); auto.
+   apply A.eq_sym; auto.

--- a/released/packages/coq-compcert/coq-compcert.3.6+8.11/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.6+8.11/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  "ia32-macosx" {os = "macos"}
+  "ia32-cygwin" {os = "cygwin"}
+  "-bindir" "%{bin}%"
+  "-libdir" "%{lib}%/compcert"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+patches: "compat-8-11.patch"
+extra-files: ["compat-8-11.patch" "sha256=1d54e39e9cda9ce8a408158580c09d0d76ff2accbd7524d1986aee4a7b0563dd"]
+install: [
+  [make "install"]
+  ["install" "-m" "0644" "VERSION" "%{lib}%/coq/user-contrib/compcert/"]
+]
+depends: [
+  # This are the release versions of Coq which include this version of compcert
+  # See compcert_CI_REF in
+  # https://github.com/coq/coq/blob/V8.11.0/dev/ci/ci-basic-overlay.sh
+  # See make_addon_compcert in
+  # https://github.com/coq/coq/blob/V8.11.0/dev/build/windows/makecoq_mingw.sh
+  "coq" {= "8.11.0"}
+  "menhir" {>= "20190626" & < "20200123"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (patched for Coq 8.11 compatibility)"
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2019-10-02"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.6.tar.gz"
+  checksum: "sha256=7a77839f6b990ab632ba14feccf4f17da189f0e3b95d6ce2ef0986e4caebc575"
+}


### PR DESCRIPTION
This commit adds two opam files for CompCert which correspond to CompCert 3.5 patched for Coq 8.10 and CompCert 3.6 patched for Coq 8.11. The patches are identical to those delivered with the Coq Windows installers for Coq 8.10 and Coq 8.11.

See the CompCert sections in:
(https://github.com/coq/coq/blob/v8.10/dev/ci/ci-basic-overlay.sh)

(https://github.com/coq/coq/blob/v8.11/dev/ci/ci-basic-overlay.sh)