### PR TITLE
Added opam files for flocq and gappa plugin patched for Coq 8.11

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.3.2.0+8.11/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.2.0+8.11/opam
@@ -12,6 +12,8 @@ build: [
 install: ["./remake" "install"]
 depends: [
   "coq" {= "8.11.0"}
+  ("conf-g++" {build} | "conf-clang" {build})
+  "conf-autoconf" {build}
 ]
 tags: [ "keyword:floating point arithmetic" "logpath:Flocq" ]
 authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]

--- a/released/packages/coq-flocq/coq-flocq.3.2.0+8.11/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.2.0+8.11/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "guillaume.melquiond@inria.fr"
+homepage: "http://flocq.gforge.inria.fr/"
+dev-repo: "git+https://gitlab.inria.fr/flocq/flocq.git"
+bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  ["./autogen.sh"]
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+]
+install: ["./remake" "install"]
+depends: [
+  "coq" {= "8.11.0"}
+]
+tags: [ "keyword:floating point arithmetic" "logpath:Flocq" ]
+authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
+synopsis: "(patched for Coq 8.11 compatibility by MSoegtropIMC) A floating-point formalization for the Coq system"
+url {
+  src: "https://github.com/MSoegtropIMC/flocq/archive/66482a0775e39770dde8bebc4c896d8d47980e1a.tar.gz"
+  checksum: "sha512=46f9f9a0e3005dc6cc90bd6023803a963c828623d6236ac5cbcf158bb1c74153340908c4bcfce938d670625fd94058898b4fac836983fa479a55941c8b34d8e5"
+}

--- a/released/packages/coq-gappa/coq-gappa.1.4.2+8.11/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.2+8.11/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "guillaume.melquiond@inria.fr"
+homepage: "http://gappa.gforge.inria.fr/"
+dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
+license: "LGPL-2.1-only"
+build: [
+  ["./autogen.sh"]
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+]
+install: ["./remake" "install"]
+depends: [
+  "ocaml"
+  "camlp5"
+  "coq" {= "8.11.0"}
+  "coq-flocq" {= "3.2.0+8.11"}
+  ("conf-g++" {build} | "conf-clang" {build})
+  "conf-autoconf" {build}
+]
+tags: [ "keyword:floating point arithmetic" "keyword:interval arithmetic" "keyword:decision procedure" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "logpath:Gappa" ]
+authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
+synopsis: "(patched for Coq 8.11 compatibility by MSoegtropIMC) A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
+url {
+  src: "https://github.com/MSoegtropIMC/gappa-coq/archive/d6f5177181c35f07ff50bd5c173ee13528e06576.tar.gz"
+  checksum: "sha512=857eca02eff8900579fb370bc3c7b46d36ee82e4fba315c64f423b8e02a3f820d2424a518cc124f916db27717456c786987b49df10fefdfb2e7dd835305f218b"
+}


### PR DESCRIPTION
This commit adds opam files for Flocq and Gappa-plugin which correspond to the respective latest versions patched for Coq 8.11. The patches are identical to those delivered with the Coq Windows installer for Coq 8.11.

See the Flocq / Gappa sections in:
(https://github.com/coq/coq/blob/v8.11/dev/ci/ci-basic-overlay.sh)