### PR TITLE
Add Coq-Interval patched for Coq 8.11.0

### DIFF
--- a/released/packages/coq-interval/coq-interval.3.4.1+8.11/files/rlist.patch
+++ b/released/packages/coq-interval/coq-interval.3.4.1+8.11/files/rlist.patch
@@ -1,0 +1,141 @@
+diff/patch file created on Fri, Dec 20, 2019  6:11:49 PM with:
+difftar-folder.sh tarballs/interval-839a03e1bddbafab868fbceee59abe678e32a0f3.tar.gz interval-839a03e1bddbafab868fbceee59abe678e32a0f3 1
+TARFILE= tarballs/interval-839a03e1bddbafab868fbceee59abe678e32a0f3.tar.gz
+FOLDER= interval-839a03e1bddbafab868fbceee59abe678e32a0f3
+TARSTRIP= 1
+TARPREFIX= interval-839a03e1bddbafab868fbceee59abe678e32a0f3/
+ORIGFOLDER= interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig
+--- interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig/src/Integral/Bertrand.v	2019-07-20 09:48:54.000000000 +0200
++++ interval-839a03e1bddbafab868fbceee59abe678e32a0f3/src/Integral/Bertrand.v	2019-12-20 15:10:07.777216000 +0100
+@@ -1,6 +1,6 @@
+ From Coq Require Import Reals ZArith Psatz Fourier_util.
+ From Coquelicot Require Import Coquelicot AutoDerive.
+-From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool ssrnat bigop.
++From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool bigop.
+ 
+ Require Import Stdlib.
+ Require Import Coquelicot.
+@@ -8,6 +8,8 @@
+ Require Import Sig.
+ Require Import Interval.
+ 
++From mathcomp.ssreflect Require Import ssrnat.
++
+ Section powerRZMissing.
+ 
+ Lemma powerRZ_ind (P : Z -> (R -> R) -> Prop) :
+@@ -186,7 +188,7 @@
+ pose f'gplusfg' := (fun t : R => plus (f'g t) (fg' t)).
+ apply (is_RInt_ext (fun x => minus (f'gplusfg' x) (fg' x))) => [x HX|].
+ rewrite /f'gplusfg' /fg' /f /g /f'g.
+-by rewrite /minus -plus_assoc plus_opp_r plus_zero_r /scal.
++by rewrite /minus -Hierarchy.plus_assoc plus_opp_r plus_zero_r /scal.
+ apply: is_RInt_minus.
+ - apply: (is_RInt_ext (fun t : R => plus (scal (f' t) (g t)) (scal (f t) (g' t)))) =>[x Hx|].
+     by [].
+--- interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig/src/Integral/Integral.v	2019-07-20 09:48:54.000000000 +0200
++++ interval-839a03e1bddbafab868fbceee59abe678e32a0f3/src/Integral/Integral.v	2019-12-20 15:10:07.780217100 +0100
+@@ -242,7 +242,7 @@
+         exact: Rlt_le.
+       apply: Rplus_le_compat_r.
+       move: (Hu _ Hfau). rewrite /ball_norm /minus.
+-      rewrite -{2}[If]opp_opp -opp_plus norm_opp plus_comm.
++      rewrite -{2}[If]opp_opp -opp_plus norm_opp Hierarchy.plus_comm.
+       exact: Rlt_le.
+       rewrite /pos_div_2 /=; lra.
+       rewrite -opp_minus -[minus (RInt f a v) If]opp_minus. rewrite -opp_plus.
+@@ -274,7 +274,7 @@
+   unfold minus.
+   apply is_RInt_swap in HI1.
+   have HC := (is_RInt_Chasles _ _ _ _ _ _ HI1 HI2).
+-  rewrite plus_comm.
++  rewrite Hierarchy.plus_comm.
+   move: (H _ _ Qbu2 Qbv2) => /= .
+   move => /(_ _ HC) Hle.
+   apply: Rle_lt_trans Hle _.
+--- interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig/src/Missing/Coquelicot.v	2019-07-20 09:48:54.000000000 +0200
++++ interval-839a03e1bddbafab868fbceee59abe678e32a0f3/src/Missing/Coquelicot.v	2019-12-20 15:10:07.787214200 +0100
+@@ -1,10 +1,13 @@
+ From Coq Require Import Reals Psatz.
+ From Coquelicot Require Import Coquelicot.
+-From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq fintype bigop.
++From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype seq fintype bigop.
+ 
+ Require Import Stdlib.
+ Require Import MathComp.
+ 
++(* This needs to be here to have the Delimit Scope N_scope with num active *)
++From mathcomp.ssreflect Require Import ssrnat.
++
+ Lemma continuous_Rinv x :
+   x <> 0 ->
+   continuous (fun x => / x) x.
+@@ -631,7 +634,7 @@
+ 
+ rewrite /=.
+ apply: (filterlim_ext (fun x => minus (exp (-(lam * a)) / lam) (exp (-(lam * x)) / lam))).
+-move => x;rewrite /minus plus_comm; congr plus. rewrite /opp /=; field; lra.
++move => x; rewrite /minus Hierarchy.plus_comm; congr plus. rewrite /opp /=; field; lra.
+ rewrite /opp /=; field; lra.
+ rewrite /minus.
+ apply: (filterlim_comp _ _ _ (fun x => opp (exp (-(lam * x)) / lam)) (fun x => plus (exp (- (lam * a)) / lam) x) (Rbar_locally p_infty) (locally (0)) (locally (exp (- (lam * a)) / lam))); last first.
+--- interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig/src/Poly/Datatypes.v	2019-07-20 09:48:54.000000000 +0200
++++ interval-839a03e1bddbafab868fbceee59abe678e32a0f3/src/Poly/Datatypes.v	2019-12-20 15:10:07.791212700 +0100
+@@ -22,7 +22,7 @@
+ 
+ From Coq Require Import ZArith Reals.
+ From Coquelicot Require Import Coquelicot.
+-From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq fintype bigop.
++From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype seq fintype bigop.
+ From Flocq Require Import Core.
+ 
+ Require Import Stdlib.
+@@ -31,6 +31,8 @@
+ Require Import Xreal.
+ Require Import Basic_rec.
+ 
++From mathcomp.ssreflect Require Import ssrnat.
++
+ Set Implicit Arguments.
+ Unset Strict Implicit.
+ Unset Printing Implicit Defensive.
+@@ -256,7 +258,9 @@
+ Section PrecIsPropagated.
+ Variable u : U.
+ 
+-Definition add := map2 (C.add u) id.
++Locate id.
++
++Definition add := map2 (C.add u) ssrfun.id.
+ 
+ Definition sub := map2 (C.sub u) C.opp.
+ 
+@@ -575,6 +579,8 @@
+ by move=> i /andP [Hi _]; rewrite nth_default // Rmult_0_l.
+ Qed.
+ 
++Print Scopes.
++
+ Lemma coef_deriv p i :
+   nth (deriv tt p) i = (nth p i.+1 * INR i.+1)%R.
+ Proof.
+--- interval-839a03e1bddbafab868fbceee59abe678e32a0f3.orig/src/Poly/Taylor_model_sharp.v	2019-07-20 09:48:54.000000000 +0200
++++ interval-839a03e1bddbafab868fbceee59abe678e32a0f3/src/Poly/Taylor_model_sharp.v	2019-12-20 15:10:07.794210100 +0100
+@@ -23,7 +23,7 @@
+ From Coq Require Import ZArith Psatz Reals.
+ From Flocq Require Import Raux.
+ From Coquelicot Require Import Coquelicot.
+-From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq fintype bigop.
++From mathcomp.ssreflect Require Import ssreflect ssrfun ssrbool eqtype seq fintype bigop.
+ 
+ Require Import Stdlib.
+ Require Import MathComp.
+@@ -38,6 +38,8 @@
+ Require Import Basic_rec.
+ Require Import Bound.
+ 
++From mathcomp.ssreflect Require Import ssrnat.
++
+ (********************************************************************)
+ (** This theory implements Taylor models with interval polynomials for
+     univariate real-valued functions. The implemented algorithms rely

--- a/released/packages/coq-interval/coq-interval.3.4.1+8.11/opam
+++ b/released/packages/coq-interval/coq-interval.3.4.1+8.11/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "guillaume.melquiond@inria.fr"
+homepage: "http://coq-interval.gforge.inria.fr/"
+dev-repo: "git+https://gitlab.inria.fr/coqinterval/interval.git"
+bug-reports: "https://gitlab.inria.fr/coqinterval/interval/issues"
+license: "CeCILL-C"
+build: [
+  ["./autogen.sh"]
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+]
+patches: "rlist.patch"
+extra-files: ["rlist.patch" "sha512=45d4b23e5a66b4f8d98ee53754974a0d17500e651165f675b9e7e7815aa9e465003fb274950efb66961d5e72bf613bb8502bd3574c139e2ac34173f9b1fcf82d"]
+install: ["./remake" "install"]
+depends: [
+  "coq" {= "8.11.0"}
+  "coq-bignums"
+  "coq-flocq" {= "3.2.0+8.11"}
+  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-coquelicot" {>= "3.0"}
+  ("conf-g++" {build} | "conf-clang" {build})
+  "conf-autoconf" {build}
+]
+tags: [ "keyword:interval arithmetic" "keyword:decision procedure" "keyword:floating point arithmetic" "keyword:reflexive tactic" "keyword:taylor models" "category:Mathematics/Real Calculus and Topology" "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures" "logpath:Interval"]
+authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
+synopsis: "(patched for Coq 8.11 compatibility by MSoegtropIMC) A Coq tactic for proving bounds on real-valued expressions automatically"
+url {
+  src: "https://gitlab.inria.fr/coqinterval/interval/-/archive/839a03e1bddbafab868fbceee59abe678e32a0f3.tar.gz"
+  checksum: "sha512=0365f94286eaa7d401961d80ad7ecc6fdc7b8d2dcb3d0d08c3f44cff951b10379a1ab9f222d4da2a3a8c496e8d400a45d1f1108bb73644a818cce2baee1feba4"
+}


### PR DESCRIPTION
This adds a version of Coq-Interval patched for Coq 8.11.0.

This is the same version as delivered in the Coq 8.11.0 Windows installer (the Coq platform prototype). See the interval section in (https://github.com/coq/coq/blob/v8.11/dev/ci/ci-basic-overlay.sh) and the patch (https://github.com/coq/coq/blob/v8.11/dev/build/windows/patches_coq/interval.patch)

For a discussion see my previous similar PRs #1183, #1184, #1189.

@silene : FYI.