### PR TITLE
[coq.dev] Enable optimization when compiling under flambda

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -33,6 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    "-flambda-opts" "-O3 -unbox-closures"
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -27,6 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
+    "-flambda-opts" "-O3 -unbox-closures"
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]


### PR DESCRIPTION
This mimics upstream behavior. Options are a no-op when using a
regular compiler.

This is mainly useful for CI users of the dev package.

Note that this will create problems with Ocaml < 4.07 and flambda, but
this is documented [and the problems are there anyways even without
the options]