### PR TITLE
Add release packages for coq-hott

### DIFF
--- a/released/packages/coq-hott/coq-hott.8.10/opam
+++ b/released/packages/coq-hott/coq-hott.8.10/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["bash" "-c" "./autogen.sh -skip-submodules || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.10" & < "8.11~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: [ "logpath:HoTT" ]
+url {
+  src: "https://github.com/HoTT/HoTT/archive/V8.10.tar.gz"
+  checksum: "sha512=55ee22f8ba0e84ddc0b61ab5f2d40373066a84016a0885320f0d5c9e9a2d59c91426f1cab20719ddcd50abe03f0709485747e377ae2736e6563feef37b6bbe29"
+}

--- a/released/packages/coq-hott/coq-hott.8.11/opam
+++ b/released/packages/coq-hott/coq-hott.8.11/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["bash" "-c" "./autogen.sh -skip-submodules || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.11" & < "8.12~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: [ "logpath:HoTT" ]
+url {
+  src: "https://github.com/HoTT/HoTT/archive/V8.11.tar.gz"
+  checksum: "sha512=b7970162bba57bd5ba31bbe2b493fa72788c5ab9fc23dc961b10396b511fa1baa07543293cb525603add500403ed6b4b1b3807389438d697a0d377375cf3da76"
+}

--- a/released/packages/coq-hott/coq-hott.8.7/opam
+++ b/released/packages/coq-hott/coq-hott.8.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["rm" ".gitmodules"]
+  ["bash" "-c" "./autogen.sh || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.7" & < "8.8~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: ["logpath:HoTT"]
+url {
+  src: "https://github.com/HoTT/HoTT/archive/V8.7.tar.gz"
+  checksum: "sha512=1f0b506eb321864f5fdd3c15be690218549ad9da8f01e8171bc859e3ba383c4347409b3d539f853b92b2e44f3a5ed22a7d49fe37e23e45575af7a25d5d8e4e49"
+}

--- a/released/packages/coq-hott/coq-hott.8.8/opam
+++ b/released/packages/coq-hott/coq-hott.8.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["rm" ".gitmodules"]
+  ["bash" "-c" "./autogen.sh || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.8" & < "8.9~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: ["logpath:HoTT"]
+url {
+  src: "https://github.com/HoTT/HoTT/archive/V8.8.tar.gz"
+  checksum: "sha512=9acfa003302929ef7ef162fbef8ccde38879d7f7adb25152f0bbfa6b28bb2809e080ef9242433bebef01ea66f4f2172ee2a6f0a0d770e23659e17996ffecc56d"
+}

--- a/released/packages/coq-hott/coq-hott.8.9/opam
+++ b/released/packages/coq-hott/coq-hott.8.9/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["bash" "-c" "./autogen.sh -skip-submodules || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.9" & < "8.10~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: ["logpath:HoTT"]
+url {
+  src: "https://github.com/HoTT/HoTT/archive/V8.9.tar.gz"
+  checksum: "sha512=e9937d500681ce7d8c40ded1097f19e95d843e5860a4279609870500c1650e013eb61b4ace8b2ab9937ff9946eec3b2eba8486e9e3b5f030ba437da7278e4f98"
+}


### PR DESCRIPTION
Closes HoTT/HoTT#1132

Question: Should we delete the per-version dev packages, or leave them?