### PR TITLE
[coq-hott] constraints: < 8.X --> < 8.X~

### DIFF
--- a/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
@@ -12,7 +12,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.10" & < "8.11"}
+  "coq" {>= "8.10" & < "8.11~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
@@ -12,7 +12,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.11" & < "8.12"}
+  "coq" {>= "8.11" & < "8.12~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
@@ -13,7 +13,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.7" & < "8.8"}
+  "coq" {>= "8.7" & < "8.8~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
@@ -13,7 +13,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.8" & < "8.9"}
+  "coq" {>= "8.8" & < "8.9~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"

--- a/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
@@ -12,7 +12,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.9" & < "8.10"}
+  "coq" {>= "8.9" & < "8.10~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"


### PR DESCRIPTION
We disallow, e.g., the 8.11 package from being installed with
8.12+alpha, 8.12+beta, 8.12+beta1, etc.