### PR TITLE
Fix dependency for coq-monae.0.0.6

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.0.6/opam
+++ b/released/packages/coq-monae/coq-monae.0.0.6/opam
@@ -20,7 +20,7 @@ install: [
 ]
 depends: [
   "coq" { >= "8.10" & < "8.12~" }
-  "coq-infotheo" { >= "0.0.7" }
+  "coq-infotheo" { >= "0.0.7" & < "0.1" }
 ]
 synopsis: "Monae"
 description: """


### PR DESCRIPTION
@affeldt-aist
Error log: https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.6/released/8.10.2/monae/0.0.6.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-monae.0.0.6 coq.8.10.2
Return code
7936
Duration
33 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.10.2      Formal proof management system
coq-infotheo           0.1         Infotheo
coq-mathcomp-algebra   1.10.0      Mathematical Components Library on Algebra
coq-mathcomp-analysis  0.2.3       An analysis library for mathematical components
coq-mathcomp-bigenough 1.0.0       A small library to do epsilon - N reasonning
coq-mathcomp-field     1.10.0      Mathematical Components Library on Fields
coq-mathcomp-fingroup  1.10.0      Mathematical Components Library on finite groups
coq-mathcomp-finmap    1.4.0       Finite sets, finite maps, finitely supported functions, orders
coq-mathcomp-solvable  1.10.0      Mathematical Components Library on finite groups (II)
coq-mathcomp-ssreflect 1.10.0      Small Scale Reflection
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.07.1      The OCaml compiler (virtual package)
ocaml-base-compiler    4.07.1      Official release 4.07.1
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.10.2).
The following actions will be performed:
  - install coq-monae 0.0.6
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-monae.0.0.6: http]
[coq-monae.0.0.6] downloaded from https://github.com/affeldt-aist/monae/archive/0.0.6.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-monae: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-monae.0.0.6)
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq all
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-monae.0.0.6'
- COQDEP VFILES
- COQC monae_lib.v
- COQC smallstep.v
- COQC monad.v
- COQC fail_monad.v
- COQC monad_composition.v
- COQC category.v
- File "./fail_monad.v", line 786, characters 0-20:
- Warning: Ignoring canonical projection to MonadFail.base by Monad.class in
- monadType: redundant with MonadFail.baseType
- [redundant-canonical-projection,typechecker]
- COQC state_monad.v
- COQC proba_monad.v
- COQC example_spark.v
- File "./proba_monad.v", line 94, characters 0-39:
- Error: Notation "_ <| _ |> _" is already defined at level 50 with arguments
- constr at next level, constr at level 200, constr at next level
- while it is now required to be at level 49 with arguments constr
- at next level, constr at level 200, constr at next level.
- 
- make[2]: *** [Makefile.coq:658: proba_monad.vo] Error 1
- make[2]: *** Waiting for unfinished jobs....
- make[1]: *** [Makefile.coq:321: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-monae.0.0.6'
- make: *** [Makefile:2: all] Error 2
[ERROR] The compilation of coq-monae failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-monae.0.0.6 ====================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-monae.0.0.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-monae-22543-335865.env
# output-file          ~/.opam/log/coq-monae-22543-335865.out
### output ###
# [...]
# COQC example_spark.v
# File "./proba_monad.v", line 94, characters 0-39:
# Error: Notation "_ <| _ |> _" is already defined at level 50 with arguments
# constr at next level, constr at level 200, constr at next level
# while it is now required to be at level 49 with arguments constr
# at next level, constr at level 200, constr at next level.
# 
# make[2]: *** [Makefile.coq:658: proba_monad.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# make[1]: *** [Makefile.coq:321: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-monae.0.0.6'
# make: *** [Makefile:2: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-monae 0.0.6
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-monae.0.0.6 coq.8.10.2' failed.
```