### PR TITLE
Fix dependencies of coq-flocq-quickchick.1.0.1

### DIFF
--- a/released/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.1/opam
+++ b/released/packages/coq-flocq-quickchick/coq-flocq-quickchick.1.0.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/digamma-ai/flocq-quickchick"
 bug-reports: "https://github.com/digamma-ai/flocq-quickchick/issues"
 depends: [
   "coq" {>= "8.9"}
-  "coq-quickchick" {>= "1.0.2"}
+  "coq-quickchick" {>= "1.0.2" & < "1.3.0"}
   "coq-flocq" {>= "3.1.0"}
 ]
 build: [


### PR DESCRIPTION
@p3rsik 
Error due to a recent upgrade of `coq-quickchick`: https://coq-bench.github.io/clean/Linux-x86_64-4.08.1-2.0.5/released/8.11.0/flocq-quickchick/1.0.1.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-flocq-quickchick.1.0.1 coq.8.11.0
Return code
7936
Duration
9 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-autoconf          0.1         Virtual package relying on autoconf installation
conf-findutils         1           Virtual package relying on findutils
conf-g++               1.0         Virtual package relying on the g++ compiler (for C++)
conf-m4                1           Virtual package relying on m4
conf-which             1           Virtual package relying on which
coq                    8.11.0      Formal proof management system
coq-ext-lib            0.11.1      A library of Coq definitions, theorems, and tactics
coq-flocq              3.2.0+8.11  (patched for Coq 8.11 compatibility by MSoegtropIMC) A floating-point formalization for the Coq system
coq-mathcomp-ssreflect 1.10.0      Small Scale Reflection
coq-quickchick         1.3.0       Randomized Property-Based Testing Plugin for Coq
coq-simple-io          1.3.0       IO monad for Coq
dune                   2.4.0       Fast, portable, and opinionated build system
menhir                 20200211    An LR(1) parser generator
menhirLib              20200211    Runtime support library for parsers generated by Menhir
menhirSdk              20200211    Compile-time library for auxiliary tools related to Menhir
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.08.1      The OCaml compiler (virtual package)
ocaml-base-compiler    4.08.1      Official release 4.08.1
ocaml-config           1           OCaml Switch Configuration
ocamlbuild             0.14.0      OCamlbuild is a build system with builtin rules to easily build most OCaml projects.
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.0).
The following actions will be performed:
  - install coq-flocq-quickchick 1.0.1
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-flocq-quickchick.1.0.1: http]
[coq-flocq-quickchick.1.0.1] downloaded from https://github.com/digamma-ai/flocq-quickchick/archive/1.0.1.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-flocq-quickchick: coq_makefile _CoqProject]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "coq_makefile" "-f" "_CoqProject" "-o" "Makefile" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq-quickchick.1.0.1)
Processing  1/2: [coq-flocq-quickchick: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq-quickchick.1.0.1)
- COQDEP VFILES
- COQC Generators.v
- File "./Generators.v", line 56, characters 0-20:
- Warning: Interpreting this declaration as if a global declaration prefixed by
- "Local", i.e. as a global declaration which shall not be available without
- qualification when imported. [local-declaration,scope]
- File "./Generators.v", line 56, characters 12-19:
- Error: The reference log_inf was not found in the current environment.
- 
- make[1]: *** [Makefile:678: Generators.vo] Error 1
- make: *** [Makefile:327: all] Error 2
[ERROR] The compilation of coq-flocq-quickchick failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-flocq-quickchick.1.0.1 =========================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq-quickchick.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-flocq-quickchick-954-e4db2f.env
# output-file          ~/.opam/log/coq-flocq-quickchick-954-e4db2f.out
### output ###
# COQDEP VFILES
# COQC Generators.v
# File "./Generators.v", line 56, characters 0-20:
# Warning: Interpreting this declaration as if a global declaration prefixed by
# "Local", i.e. as a global declaration which shall not be available without
# qualification when imported. [local-declaration,scope]
# File "./Generators.v", line 56, characters 12-19:
# Error: The reference log_inf was not found in the current environment.
# 
# make[1]: *** [Makefile:678: Generators.vo] Error 1
# make: *** [Makefile:327: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-flocq-quickchick 1.0.1
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-flocq-quickchick.1.0.1 coq.8.11.0' failed.
```