### PR TITLE
Fix Coq version of coq-tlc.20200328

### DIFF
--- a/released/packages/coq-tlc/coq-tlc.20200328/opam
+++ b/released/packages/coq-tlc/coq-tlc.20200328/opam
@@ -14,7 +14,7 @@ Provides an alternative to the core of the Coq standard library, using classic d
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { >= "8.8" }
+  "coq" { >= "8.10" }
 ]
 
 tags: [


### PR DESCRIPTION
@fpottier 
Here is the error with Coq 8.9 (same kind of error with Coq 8.8): https://coq-bench.github.io/clean/Linux-x86_64-4.04.2-2.0.5/released/8.9.0/tlc/20200328.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-tlc.20200328 coq.8.9.0
Return code
7936
Duration
10 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-num            base        Num library distributed with the OCaml compiler
base-threads        base
base-unix           base
camlp5              7.11        Preprocessor-pretty-printer of OCaml
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.9.0       Formal proof management system
num                 0           The Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.04.2      The OCaml compiler (virtual package)
ocaml-base-compiler 4.04.2      Official 4.04.2 release
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.9.0).
The following actions will be performed:
  - install coq-tlc 20200328
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-tlc.20200328: http]
[coq-tlc.20200328] downloaded from https://github.com/charguer/tlc/archive/20200328.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-tlc: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328)
- make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
- make -f Makefile.coq all
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
- Compiling LibTactics...
- File "/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src/LibTactics.v", line 49, characters 8-13:
- Error:
- Syntax error: 'Equivalent' 'Keys' expected after 'Declare' (in [vernac:command]).
- 
- make[2]: *** [Makefile.coq:113: /home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src/LibTactics.vo] Error 1
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
- make[1]: *** [Makefile:28: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
- make: *** [Makefile:3: all] Error 2
[ERROR] The compilation of coq-tlc failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-tlc.20200328 ===================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-tlc-401-0a5907.env
# output-file          ~/.opam/log/coq-tlc-401-0a5907.out
### output ###
# [...]
# make -f Makefile.coq all
# make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
# Compiling LibTactics...
# File "/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src/LibTactics.v", line 49, characters 8-13:
# Error:
# Syntax error: 'Equivalent' 'Keys' expected after 'Declare' (in [vernac:command]).
# 
# make[2]: *** [Makefile.coq:113: /home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src/LibTactics.vo] Error 1
# make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
# make[1]: *** [Makefile:28: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.04.2/.opam-switch/build/coq-tlc.20200328/src'
# make: *** [Makefile:3: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-tlc 20200328
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-tlc.20200328 coq.8.9.0' failed.
```