### PR TITLE
RELEASE coq-printf 1.0.2 and 2.0.0

### DIFF
--- a/released/packages/coq-printf/coq-printf.1.0.0/opam
+++ b/released/packages/coq-printf/coq-printf.1.0.0/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/gmalecha/coq-printf"
 dev-repo: "git+https://github.com/gmalecha/coq-printf"
 bug-reports: "https://github.com/gmalecha/coq-printf/issues"
 authors: ["Gregory Malecha"]
-license: "BSD"
+license: "MIT"
 build: [
   [make "-j%{jobs}%"]
 ]

--- a/released/packages/coq-printf/coq-printf.1.0.2/opam
+++ b/released/packages/coq-printf/coq-printf.1.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "coq" {>= "8.8" & < "8.12~"}
 ]
 tags: [
-  "date:2020-03-18"
+  "date:2020-04-05"
   "logpath:Printf"
 ]
 synopsis:
@@ -24,6 +24,6 @@ synopsis:
 description: "Library providing implementation of sprintf for Coq"
 
 url {
-  src: "https://github.com/gmalecha/coq-printf/archive/v1.0.1.tar.gz"
-  checksum: "sha512=41870c51fc40f751fbb6e793a5b54b2f9cbddc43efc860758c0af0b291f5a9454583676e87a5584b28a5e72ebdcdd0f903c743160c501b3d940fe232738d718d"
+  src: "https://github.com/gmalecha/coq-printf/archive/v1.0.2.tar.gz"
+  checksum: "sha512=1c26cef48739674e5a286a4e2fd9a85b735c998e43c4c400719b0daaa9117a5f64657e7f6fb43149c3af064436ee4eba7ef79619623ef93af904ea833a84f396"
 }

--- a/released/packages/coq-printf/coq-printf.2.0.0/opam
+++ b/released/packages/coq-printf/coq-printf.2.0.0/opam
@@ -13,10 +13,10 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.8" & < "8.12~"}
+  "coq" {>= "8.11" & < "8.12~"}
 ]
 tags: [
-  "date:2020-03-18"
+  "date:2020-04-05"
   "logpath:Printf"
 ]
 synopsis:
@@ -24,6 +24,6 @@ synopsis:
 description: "Library providing implementation of sprintf for Coq"
 
 url {
-  src: "https://github.com/gmalecha/coq-printf/archive/v1.0.1.tar.gz"
-  checksum: "sha512=41870c51fc40f751fbb6e793a5b54b2f9cbddc43efc860758c0af0b291f5a9454583676e87a5584b28a5e72ebdcdd0f903c743160c501b3d940fe232738d718d"
+  src: "https://github.com/gmalecha/coq-printf/archive/v2.0.0.tar.gz"
+  checksum: "sha512=5add49c9ea66f6e8d707da99a542665366d9548065706b583c9dfd6727d2f144f64d629e70fd83dd72d071d39ec8316e35b6b1b551ec3f60d7487efba4c6110a"
 }


### PR DESCRIPTION
- also fix license on previous versions