### PR TITLE
Open Coq version bound for coq-ceramist.1.0.1

### DIFF
--- a/released/packages/coq-ceramist/coq-ceramist.1.0.1/opam
+++ b/released/packages/coq-ceramist/coq-ceramist.1.0.1/opam
@@ -18,7 +18,7 @@ authors: [
 ]
 license: "GPL-3.0-or-later"
 depends: [
-  "coq" {>= "8.11.0" & < "8.11.1"}
+  "coq" {>= "8.11.0"}
   "coq-mathcomp-ssreflect" {>= "1.10" & < "1.11~"}
   "coq-mathcomp-analysis" { >= "0.2.3" & < "0.3~" }
   "coq-infotheo" { >= "0.1" & < "0.2~" }


### PR DESCRIPTION
Made possible thanks to https://github.com/coq/opam-coq-archive/pull/1233