### PR TITLE
Fix dependency of coq-mathcomp-multinomials.1.5

### DIFF
--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5/opam
@@ -18,7 +18,7 @@ depends: [
   "coq-mathcomp-ssreflect" {>= "1.8.0" & < "1.11~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {>= "1.0.0" & < "1.1~"}
-  "coq-mathcomp-finmap"    {>= "1.4" & < "1.5~"}
+  "coq-mathcomp-finmap"    {>= "1.4" & < "1.4.1"}
 ]
 tags: [
   "keyword:multinomials"


### PR DESCRIPTION
@strub 
https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.6/released/8.10.0/mathcomp-multinomials/1.5.html
The last update of `coq-mathcomp-finmap` generates the following error:
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-mathcomp-multinomials.1.5 coq.8.10.0
Return code
7936
Duration
38 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-num               base        Num library distributed with the OCaml compiler
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.10.0      Formal proof management system
coq-mathcomp-algebra   1.10.0      Mathematical Components Library on Algebra
coq-mathcomp-bigenough 1.0.0       A small library to do epsilon - N reasonning
coq-mathcomp-fingroup  1.10.0      Mathematical Components Library on finite groups
coq-mathcomp-finmap    1.4.1       Finite sets, finite maps, finitely supported functions, orders
coq-mathcomp-ssreflect 1.10.0      Small Scale Reflection
num                    0           The Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.05.0      The OCaml compiler (virtual package)
ocaml-base-compiler    4.05.0      Official 4.05.0 release
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.10.0).
The following actions will be performed:
  - install coq-mathcomp-multinomials 1.5
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-mathcomp-multinomials.1.5: http]
[coq-mathcomp-multinomials.1.5] downloaded from https://github.com/math-comp/multinomials/archive/1.5.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-mathcomp-multinomials: make config]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "INSTMODE=global" "config" (CWD=/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5)
Processing  1/2: [coq-mathcomp-multinomials: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5)
- /home/bench/.opam/ocaml-base-compiler.4.05.0/bin/coq_makefile  -f _CoqProject -o Makefile.coq
- make -f Makefile.coq 
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5'
- COQDEP VFILES
- COQC src/xfinmap.v
- COQC src/ssrcomplements.v
- COQC src/freeg.v
- COQC src/monalg.v
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eq_refl is deprecated; use perm_refl instead
- Warning: perm_eq_refl is deprecated; use perm_refl instead
- Warning: perm_eq_refl is deprecated; use perm_refl instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: perm_eqP is deprecated; use permP instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: eq_big_perm is deprecated; use perm_big instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_refl is deprecated; use perm_refl instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: perm_eq_uniq is deprecated; use perm_uniq instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_sym is deprecated; use perm_sym instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_trans is deprecated; use perm_trans instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- Warning: perm_eq_mem is deprecated; use perm_mem instead
- COQC src/mpoly.v
- File "./src/mpoly.v", line 633, characters 14-30:
- Error:
- In environment
- n : nat
- x : phantom (Order.Lattice.class_of ?bT) (Order.Lattice.class ?bT)
- The term "x" has type
-  "phantom (Order.Lattice.class_of ?bT) (Order.Lattice.class ?bT)"
- while it is expected to have type
-  "phantom (Order.Lattice.class_of 'X_{1.. n}) ?b".
- 
- make[2]: *** [Makefile.coq:658: src/mpoly.vo] Error 1
- make[1]: *** [Makefile.coq:321: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5'
- make: *** [Makefile.common:67: this-build] Error 2
[ERROR] The compilation of coq-mathcomp-multinomials failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-mathcomp-multinomials.1.5 ======================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-mathcomp-multinomials-31422-2dea01.env
# output-file          ~/.opam/log/coq-mathcomp-multinomials-31422-2dea01.out
### output ###
# [...]
# In environment
# n : nat
# x : phantom (Order.Lattice.class_of ?bT) (Order.Lattice.class ?bT)
# The term "x" has type
#  "phantom (Order.Lattice.class_of ?bT) (Order.Lattice.class ?bT)"
# while it is expected to have type
#  "phantom (Order.Lattice.class_of 'X_{1.. n}) ?b".
# 
# make[2]: *** [Makefile.coq:658: src/mpoly.vo] Error 1
# make[1]: *** [Makefile.coq:321: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-multinomials.1.5'
# make: *** [Makefile.common:67: this-build] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-mathcomp-multinomials 1.5
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-mathcomp-multinomials.1.5 coq.8.10.0' failed.
```