### PR TITLE
Fix coq-cfml.20181201 dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ before_script:
   - echo CI_RUNNER_TAGS=${CI_RUNNER_TAGS}
   - export OPAM_VARIANT=$(if echo $CI_RUNNER_TAGS | grep -q no-sandbox; then echo "plain"; else echo "sandbox"; fi)
   - echo OPAM_VARIANT=${OPAM_VARIANT}
-  - export OPAM_VERSION=2.0.5
+  - export OPAM_VERSION=2.0.6
   - export OPAM_ROOT_DIR=${HOME}/opam-root-${COMPILER}-${OPAM_VERSION}-${OPAM_VARIANT}
   - export OPAM_ROOT_CACHE=${HOME}/opam-cache/cache-${COMPILER}-${OPAM_VERSION}-${OPAM_VARIANT}.tgz
   - export EXTRA_OPAM="ocamlbuild" # some packages build extracted code this way

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -14,7 +14,7 @@ depends: [
   "pprint"
   "base-bytes"
   "coq" {>= "8.6"}
-  "coq-tlc" {>= "20181116"}
+  "coq-tlc" {>= "20181116" & < "20200328"}
 ]
 url {
   src:


### PR DESCRIPTION
@Armael The latest update of `coq-tlc` did break this package https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.6/released/8.10.2/cfml/20181201.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-cfml.20181201 coq.8.10.2
Return code
7936
Duration
31 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-bytes          base        Bytes library distributed with the OCaml compiler
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.10.2      Formal proof management system
coq-tlc             20200328    TLC: A Library for Classical Coq
dune                2.4.0       Fast, portable, and opinionated build system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.07.1      The OCaml compiler (virtual package)
ocaml-base-compiler 4.07.1      Official release 4.07.1
ocaml-config        1           OCaml Switch Configuration
ocamlbuild          0.14.0      OCamlbuild is a build system with builtin rules to easily build most OCaml projects.
ocamlfind           1.8.1       A library manager for OCaml
pprint              20200316    A pretty-printing combinator library and rendering engine
[NOTE] Package coq is already installed (current version is 8.10.2).
The following actions will be performed:
  - install coq-cfml 20181201
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-cfml.20181201: http]
[coq-cfml.20181201] downloaded from https://gitlab.inria.fr/charguer/cfml/repository/20181201/archive.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-cfml: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201)
- make CFML=/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201 -C lib/coq proof
- rm -f generator/cfml_config.ml
- sed -e 's|@@PREFIX@@|/home/bench/.opam/ocaml-base-compiler.4.07.1|' \
-     -e 's|@@BINDIR@@|/home/bench/.opam/ocaml-base-compiler.4.07.1/bin|' \
-     -e 's|@@LIBDIR@@|/home/bench/.opam/ocaml-base-compiler.4.07.1/lib/cfml|' \
-     generator/cfml_config.ml.in > generator/cfml_config.ml
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201/lib/coq'
- make -C generator
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201/generator'
- ocamlbuild -j 4 -classic-display -I lex -I parsing -I typing -I utils -cflags "-g" -lflags "-g" -use-ocamlfind -package pprint main.native makecmj.native
- ocamlfind ocamldep -package pprint -modules main.ml > main.ml.depends
- ocamlfind ocamldep -package pprint -modules cfml_config.ml > cfml_config.ml.depends
- ocamlfind ocamldep -package pprint -modules characteristic.mli > characteristic.mli.depends
- ocamlfind ocamldep -package pprint -modules formula.mli > formula.mli.depends
- ocamlfind ocamldep -package pprint -modules coq.ml > coq.ml.depends
- ocamlfind ocamldep -package pprint -modules mytools.mli > mytools.mli.depends
- ocamlfind ocamldep -package pprint -modules parsing/location.mli > parsing/location.mli.depends
- ocamlfind ocamldep -package pprint -modules utils/warnings.mli > utils/warnings.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/warnings.cmi utils/warnings.mli
- ocamlfind ocamlc -c -g -package pprint -I parsing -I lex -I utils -I typing -o parsing/location.cmi parsing/location.mli
- make[1]: *** No rule to make target 'proof'.  Stop.
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201/lib/coq'
- make: *** [Makefile:25: coqlib] Error 2
- make: *** Waiting for unfinished jobs....
- ocamlfind ocamldep -package pprint -modules renaming.ml > renaming.ml.depends
- ocamlfind ocamldep -package pprint -modules utils/clflags.mli > utils/clflags.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/ident.mli > typing/ident.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o mytools.cmi mytools.mli
- ocamlfind ocamldep -package pprint -modules typing/path.mli > typing/path.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/ident.cmi typing/ident.mli
- ocamlfind ocamlc -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/clflags.cmi utils/clflags.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/path.cmi typing/path.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o renaming.cmo renaming.ml
- + ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o renaming.cmo renaming.ml
- File "renaming.ml", line 241, characters 4-20:
- Warning 3: deprecated: Stdlib.String.uppercase
- Use String.uppercase_ascii instead.
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o coq.cmo coq.ml
- ocamlfind ocamldep -package pprint -modules typing/typedtree.mli > typing/typedtree.mli.depends
- ocamlfind ocamldep -package pprint -modules parsing/asttypes.mli > parsing/asttypes.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/env.mli > typing/env.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/annot.mli > typing/annot.mli.depends
- ocamlfind ocamldep -package pprint -modules utils/consistbl.mli > utils/consistbl.mli.depends
- ocamlfind ocamldep -package pprint -modules parsing/longident.mli > parsing/longident.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/types.mli > typing/types.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I parsing -I lex -I utils -I typing -o parsing/asttypes.cmi parsing/asttypes.mli
- ocamlfind ocamldep -package pprint -modules typing/primitive.mli > typing/primitive.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/primitive.cmi typing/primitive.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/annot.cmi typing/annot.mli
- ocamlfind ocamlc -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/consistbl.cmi utils/consistbl.mli
- ocamlfind ocamlc -c -g -package pprint -I parsing -I lex -I utils -I typing -o parsing/longident.cmi parsing/longident.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/types.cmi typing/types.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/env.cmi typing/env.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o formula.cmi formula.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typedtree.cmi typing/typedtree.mli
- ocamlfind ocamldep -package pprint -modules formula_to_coq.mli > formula_to_coq.mli.depends
- ocamlfind ocamldep -package pprint -modules normalize.mli > normalize.mli.depends
- ocamlfind ocamldep -package pprint -modules parsing/parsetree.mli > parsing/parsetree.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I parsing -I lex -I utils -I typing -o parsing/parsetree.cmi parsing/parsetree.mli
- ocamlfind ocamldep -package pprint -modules parse_type.mli > parse_type.mli.depends
- ocamlfind ocamldep -package pprint -modules print_coq.mli > print_coq.mli.depends
- ocamlfind ocamldep -package pprint -modules print_past.mli > print_past.mli.depends
- ocamlfind ocamldep -package pprint -modules print_tast.mli > print_tast.mli.depends
- ocamlfind ocamldep -package pprint -modules settings.mli > settings.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/typetexp.mli > typing/typetexp.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o cfml_config.cmo cfml_config.ml
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o characteristic.cmi characteristic.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o formula_to_coq.cmi formula_to_coq.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o normalize.cmi normalize.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o parse_type.cmi parse_type.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o print_coq.cmi print_coq.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o print_past.cmi print_past.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o print_tast.cmi print_tast.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o settings.cmi settings.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typetexp.cmi typing/typetexp.mli
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o main.cmo main.ml
- ocamlfind ocamldep -package pprint -modules characteristic.ml > characteristic.ml.depends
- ocamlfind ocamldep -package pprint -modules utils/clflags.ml > utils/clflags.ml.depends
- ocamlfind ocamldep -package pprint -modules utils/config.ml > utils/config.ml.depends
- ocamlfind ocamldep -package pprint -modules utils/config.mli > utils/config.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/config.cmi utils/config.mli
- ocamlfind ocamlopt -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/config.cmx utils/config.ml
- ocamlfind ocamldep -package pprint -modules mytools.ml > mytools.ml.depends
- ocamlfind ocamldep -package pprint -modules parsing/location.ml > parsing/location.ml.depends
- /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamllex.opt -q parsing/linenum.mll
- ocamlfind ocamldep -package pprint -modules parsing/linenum.ml > parsing/linenum.ml.depends
- ocamlfind oca
[...] truncated
int -I parsing -I lex -I utils -I typing -o parsing/lexer.cmx parsing/lexer.ml
- ocamlfind ocamldep -package pprint -modules typing/typemod.ml > typing/typemod.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/typemod.mli > typing/typemod.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/includemod.mli > typing/includemod.mli.depends
- ocamlfind ocamldep -package pprint -modules typing/includecore.mli > typing/includecore.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includecore.cmi typing/includecore.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includemod.cmi typing/includemod.mli
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typemod.cmi typing/typemod.mli
- ocamlfind ocamldep -package pprint -modules typing/includemod.ml > typing/includemod.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/includeclass.ml > typing/includeclass.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/includeclass.mli > typing/includeclass.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includeclass.cmi typing/includeclass.mli
- ocamlfind ocamldep -package pprint -modules typing/includecore.ml > typing/includecore.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/mtype.ml > typing/mtype.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/mtype.mli > typing/mtype.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/mtype.cmi typing/mtype.mli
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includeclass.cmx typing/includeclass.ml
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includecore.cmx typing/includecore.ml
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/mtype.cmx typing/mtype.ml
- ocamlfind ocamldep -package pprint -modules typing/typeclass.ml > typing/typeclass.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/typeclass.mli > typing/typeclass.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typeclass.cmi typing/typeclass.mli
- ocamlfind ocamldep -package pprint -modules typing/typedecl.ml > typing/typedecl.ml.depends
- ocamlfind ocamldep -package pprint -modules typing/typedecl.mli > typing/typedecl.mli.depends
- ocamlfind ocamlc -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typedecl.cmi typing/typedecl.mli
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typedecl.cmx typing/typedecl.ml
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/includemod.cmx typing/includemod.ml
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typeclass.cmx typing/typeclass.ml
- ocamlfind ocamlopt -c -g -package pprint -I utils -I lex -I parsing -I typing -o utils/ccomp.cmx utils/ccomp.ml
- ocamlfind ocamlopt -c -g -package pprint -I parsing -I lex -I utils -I typing -o parsing/parse.cmx parsing/parse.ml
- ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typemod.cmx typing/typemod.ml
- + ocamlfind ocamlopt -c -g -package pprint -I typing -I lex -I utils -I parsing -o typing/typemod.cmx typing/typemod.ml
- File "typing/typemod.ml", line 1231, characters 23-40:
- Warning 3: deprecated: Stdlib.String.capitalize
- Use String.capitalize_ascii instead.
- ocamlfind ocamldep -package pprint -modules print_coq.ml > print_coq.ml.depends
- ocamlfind ocamldep -package pprint -modules settings.ml > settings.ml.depends
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o cfml_config.cmx cfml_config.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o characteristic.cmx characteristic.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o formula_to_coq.cmx formula_to_coq.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o normalize.cmx normalize.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o parse_type.cmx parse_type.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o print_coq.cmx print_coq.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o settings.cmx settings.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o main.cmx main.ml
- ocamlfind ocamlopt -g -linkpkg -package pprint -I utils -I parsing -I typing cfml_config.cmx utils/misc.cmx parsing/linenum.cmx utils/terminfo.cmx utils/warnings.cmx parsing/location.cmx mytools.cmx typing/ident.cmx typing/path.cmx utils/config.cmx utils/clflags.cmx renaming.cmx coq.cmx formula.cmx parsing/longident.cmx typing/primitive.cmx typing/types.cmx print_past.cmx typing/btype.cmx typing/predef.cmx typing/datarepr.cmx utils/tbl.cmx typing/subst.cmx utils/consistbl.cmx typing/env.cmx typing/ctype.cmx typing/oprint.cmx typing/printtyp.cmx typing/typedtree.cmx print_type.cmx print_tast.cmx typing/parmatch.cmx typing/stypes.cmx typing/typetexp.cmx typing/typecore.cmx characteristic.cmx formula_to_coq.cmx normalize.cmx parsing/syntaxerr.cmx parsing/parser.cmx parsing/lexer.cmx parsing/parse.cmx typing/includeclass.cmx typing/includecore.cmx typing/mtype.cmx typing/includemod.cmx typing/typedecl.cmx typing/typeclass.cmx typing/typemod.cmx utils/ccomp.cmx parse_type.cmx print_coq.cmx settings.cmx main.cmx -o main.native
- ocamlfind ocamldep -package pprint -modules makecmj.ml > makecmj.ml.depends
- ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o makecmj.cmo makecmj.ml
- ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o makecmj.cmx makecmj.ml
- ocamlfind ocamlopt -g -linkpkg -package pprint -I utils -I parsing -I typing cfml_config.cmx utils/misc.cmx parsing/linenum.cmx utils/terminfo.cmx utils/warnings.cmx parsing/location.cmx mytools.cmx parsing/longident.cmx typing/ident.cmx typing/path.cmx utils/config.cmx utils/clflags.cmx renaming.cmx typing/primitive.cmx typing/types.cmx normalize.cmx parsing/syntaxerr.cmx parsing/parser.cmx parsing/lexer.cmx parsing/parse.cmx typing/btype.cmx typing/predef.cmx typing/datarepr.cmx utils/tbl.cmx typing/subst.cmx utils/consistbl.cmx typing/env.cmx typing/ctype.cmx typing/oprint.cmx typing/printtyp.cmx typing/includeclass.cmx typing/typedtree.cmx typing/includecore.cmx typing/mtype.cmx typing/includemod.cmx typing/parmatch.cmx typing/stypes.cmx typing/typetexp.cmx typing/typecore.cmx typing/typedecl.cmx typing/typeclass.cmx typing/typemod.cmx utils/ccomp.cmx parse_type.cmx settings.cmx makecmj.cmx -o makecmj.native
- # Parallel statistics: { count(total): 13(194), max: 10, min: 2, average(total): 3.692(1.180) }
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201/generator'
[ERROR] The compilation of coq-cfml failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-cfml.20181201 ==================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-cfml-22411-865888.env
# output-file          ~/.opam/log/coq-cfml-22411-865888.out
### output ###
# [...]
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o normalize.cmx normalize.ml
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o parse_type.cmx parse_type.ml
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o print_coq.cmx print_coq.ml
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o settings.cmx settings.ml
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o main.cmx main.ml
# ocamlfind ocamlopt -g -linkpkg -package pprint -I utils -I parsing -I typing cfml_config.cmx utils/misc.cmx parsing/linenum.cmx utils/terminfo.cmx utils/warnings.cmx parsing/location.cmx mytools.cmx typing/ident.cmx typing/path.cmx utils/config.cmx utils/clflags.cmx renaming.cmx coq.cmx formula.cmx parsing/longident.cmx typing/primitive.cmx typing/types.cmx print_past.cmx typing/btype.cmx typ[...]
# ocamlfind ocamldep -package pprint -modules makecmj.ml > makecmj.ml.depends
# ocamlfind ocamlc -c -g -package pprint -I lex -I utils -I parsing -I typing -o makecmj.cmo makecmj.ml
# ocamlfind ocamlopt -c -g -package pprint -I lex -I utils -I parsing -I typing -o makecmj.cmx makecmj.ml
# ocamlfind ocamlopt -g -linkpkg -package pprint -I utils -I parsing -I typing cfml_config.cmx utils/misc.cmx parsing/linenum.cmx utils/terminfo.cmx utils/warnings.cmx parsing/location.cmx mytools.cmx parsing/longident.cmx typing/ident.cmx typing/path.cmx utils/config.cmx utils/clflags.cmx renaming.cmx typing/primitive.cmx typing/types.cmx normalize.cmx parsing/syntaxerr.cmx parsing/parser.cmx [...]
# # Parallel statistics: { count(total): 13(194), max: 10, min: 2, average(total): 3.692(1.180) }
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-cfml.20181201/generator'
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-cfml 20181201
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-cfml.20181201 coq.8.10.2' failed.
The middle of the output is truncated (maximum 20000 characters)
```