### PR TITLE
Publish coq-antivalence.1.0.0

### DIFF
--- a/released/packages/coq-antivalence/coq-antivalence.1.0.0/opam
+++ b/released/packages/coq-antivalence/coq-antivalence.1.0.0/opam
@@ -33,5 +33,6 @@ url {
 
 tags: [
   "category:Miscellaneous/Coq Extensions"
+  "logpath:Antivalence"
   "date:2020-05-06"
 ]

--- a/released/packages/coq-antivalence/coq-antivalence.1.0.0/opam
+++ b/released/packages/coq-antivalence/coq-antivalence.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A Coq plugin to generate type-inequality axioms for inductive definitions"
+description: """
+  Antivalence generates universally-quantified type inequality axioms, letting
+  you treat the set of inductive definitions in your program as a closed
+  inductive definition itself.  
+"""
+
+homepage: "https://github.com/ivanbakel/coq-antivalence"
+dev-repo: "git+https://github.com/ivanbakel/coq-antivalence.git"
+bug-reports: "https://github.com/ivanbakel/coq-antivalence/issues"
+maintainer: "ivb@vanbakel.io"
+authors: [
+  "Isaac van Bakel"
+]
+license: "MIT"
+
+depends: [
+  "coq" {>= "8.11" & < "8.12~"}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src: "https://github.com/ivanbakel/coq-antivalence/archive/1.0.0.tar.gz"
+  checksum: "sha256=a367cf9cd74b5fc644a23a802e695646ff688869363812295472f9baba60021f"
+}
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "date:2020-05-06"
+]


### PR DESCRIPTION
Inspired by [this StackOverflow answer](https://stackoverflow.com/questions/61289868/type-inequality-without-cardinality-arguments/61292226#61292226), `coq-antivalence` is a plugin that generates type inequality axioms. This lets users effectively treat the set of inductive definitions in scope as an inductive definition itself, including performing `inversion`-style proofs on polymorphic types.

Please see the [project main page](https://github.com/ivanbakel/coq-antivalence) for more details.

I would really appreciate any suggested improvements with regards to the package keywords or the category.