### PR TITLE
Package coq-menhirlib.20200525

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20200525/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200525/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20200525" }
+]
+tags: [
+  "date:2020-05-25"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20200525/archive.tar.gz"
+  checksum: [
+    "md5=382b76757ae8343f42bca7de3bd70efb"
+    "sha512=d5cf05b9174fff08922b8a815188cc353ae756dd2ea50df634d407e3bc13c083765b756f484ad08545e8fade36b622f8c498ebb13d0398d724e87bf8bcdfd580"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20200525`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.2