### PR TITLE
Install more files in coq-engine-bench

### DIFF
--- a/extra-dev/packages/coq-engine-bench/coq-engine-bench.dev/opam
+++ b/extra-dev/packages/coq-engine-bench/coq-engine-bench.dev/opam
@@ -12,7 +12,7 @@ build: [
   [make "-j%{jobs}%" "coq"]
   [make "-j%{jobs}%" "coq-perf"]
 ]
-install: [make "coq-install"]
+install: [make "coq-install" "coq-install-perf"]
 depends: [
   "coq" {>= "8.11~"}
 ]


### PR DESCRIPTION
Mostly so that we get access to more logs on the Coq bench