### PR TITLE
change the tag for the MathComp packages from 1.11.0+beta1 to 1.11+beta1

### DIFF
--- a/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.1.11+beta1/opam
@@ -22,6 +22,6 @@ numbers, polynomials, matrices, vector spaces...
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }

--- a/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.0/opam
+++ b/extra-dev/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.0/opam
@@ -20,7 +20,7 @@ install: [
 ]
 depends: [
   "coq" { ((>= "8.7" & < "8.12~") | = "dev") }
-  "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~")}
+  "coq-mathcomp-field"       {(>= "1.11" & < "1.12~")}
   "coq-mathcomp-finmap"      {(>= "1.5.0" & < "1.6~")}
 ]
 synopsis: "An analysis library for mathematical components"

--- a/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-character/coq-mathcomp-character.1.11+beta1/opam
@@ -20,6 +20,6 @@ representations, characters and class functions.
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }

--- a/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-field/coq-mathcomp-field.1.11+beta1/opam
@@ -20,6 +20,6 @@ galois theory, algebraic numbers, cyclotomic polynomials...
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }

--- a/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.1.11+beta1/opam
@@ -20,6 +20,6 @@ group quotients, group morphisms, group presentation, group action...
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
@@ -10,7 +10,7 @@ build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
   "coq" { (>= "8.7" & < "8.12~") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-ssreflect" { (>= "1.11" & < "1.12~") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]
 tags: [ "keyword:finmap" "keyword:finset" "keyword:multiset" "keyword:order" "date:2020-04-06" "logpath:mathcomp.finmap"]

--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.1/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.1/opam
@@ -15,7 +15,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.7" & < "8.12~"}
-  "coq-mathcomp-ssreflect" {>= "1.11.0" & < "1.12~"}
+  "coq-mathcomp-ssreflect" {>= "1.11" & < "1.12~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {>= "1.0.0" & < "1.1~"}
   "coq-mathcomp-finmap"    {>= "1.5" & < "1.6~"}

--- a/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.0.5/opam
+++ b/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.0.5/opam
@@ -11,7 +11,7 @@ build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
   "coq" { (>= "8.7" & < "8.12~") }
-  "coq-mathcomp-field"       {(>= "1.11.0" & <= "1.12~")}
+  "coq-mathcomp-field"       {(>= "1.11" & <= "1.12~")}
   "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1~")}
 ]
 

--- a/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.1.11+beta1/opam
@@ -20,6 +20,6 @@ This library contains more definitions and theorems about finite groups.
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }

--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.11+beta1/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.11+beta1/opam
@@ -24,6 +24,6 @@ and prime numbers, big operators
 """
 
 url {
-src: "http://github.com/math-comp/math-comp/archive/mathcomp-1.11.0+beta1.tar.gz"
-checksum: "sha256=0f71bb8b512416881984e18b922d2bae78bc00819492f4ab28348d2d9488a517"
+src: "https://github.com/math-comp/math-comp/archive/mathcomp-1.11+beta1.tar.gz"
+checksum: "sha256=412e3bd8faae4c52a4e1651a3ea3ad949ae6f93a2ffbb579f0ebd4662d5d418e"
 }


### PR DESCRIPTION
This change follows a discussion that occurred on Zulip about the naming convention for tags.