### PR TITLE
Package coq-semantics.8.11.1

### DIFF
--- a/released/packages/coq-semantics/coq-semantics.8.11.1/opam
+++ b/released/packages/coq-semantics/coq-semantics.8.11.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "kartiksinghal@gmail.com"
+homepage: "https://github.com/coq-community/semantics"
+dev-repo: "git+https://github.com/coq-community/semantics.git"
+bug-reports: "https://github.com/coq-community/semantics/issues"
+license: "MIT"
+
+synopsis: "A survey of semantics styles, from natural semantics through structural operational, axiomatic, and denotational semantics, to abstract interpretation"
+description: """
+This is a survey of programming language semantics styles
+for a miniature example of a programming language, with their encoding
+in Coq, the proofs of equivalence of different styles, and the proof
+of soundess of tools obtained from axiomatic semantics or abstract
+interpretation.  The tools can be run inside Coq, thus making them
+available for proof by reflection, and the code can also be extracted
+and connected to a yacc-based parser, thanks to the use of a functor
+parameterized by a module type of strings.  A hand-written parser is
+also provided in Coq, but there are no proofs associated.
+"""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq"
+  "ocamlbuild" {build}
+]
+
+tags: [
+  "category:Computer Science/Semantics"
+  "category:Compilation/Semantics"
+  "keyword:natural semantics"
+  "keyword:denotational semantics"
+  "keyword:axiomatic semantics"
+  "keyword:Hoare logic"
+  "keyword:Dijkstra weakest pre-condition calculus"
+  "keyword:abstract interpretation"
+  "keyword:intervals"
+  "logpath:Semantics"
+]
+authors: [
+  "Yves Bertot"
+]
+url {
+  src: "https://github.com/coq-community/semantics/archive/8.11.1.tar.gz"
+  checksum: [
+    "md5=ac39ad750a2a6c4f4934f6467f5afc77"
+    "sha512=a8922cc966b94e69bb277f1a0e5dc38a0afb4ce52d50dc2ed1b3d76449a884c3a291466dca11ef021fc1b21f8db8f687cf2af5a932439de6fe443255d6df2311"
+  ]
+}


### PR DESCRIPTION
### `coq-semantics.8.11.1`
A survey of semantics styles, from natural semantics through structural operational, axiomatic, and denotational semantics, to abstract interpretation
This is a survey of programming language semantics styles
for a miniature example of a programming language, with their encoding
in Coq, the proofs of equivalence of different styles, and the proof
of soundess of tools obtained from axiomatic semantics or abstract
interpretation.  The tools can be run inside Coq, thus making them
available for proof by reflection, and the code can also be extracted
and connected to a yacc-based parser, thanks to the use of a functor
parameterized by a module type of strings.  A hand-written parser is
also provided in Coq, but there are no proofs associated.



---
* Homepage: https://github.com/coq-community/semantics
* Source repo: git+https://github.com/coq-community/semantics.git
* Bug tracker: https://github.com/coq-community/semantics/issues

---
:camel: Pull-request generated by opam-publish v2.0.2