### PR TITLE
Add coq-bignums.8.12.dev (using coq_makefile)

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.8.12.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.12.dev/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Laurent.Thery@inria.fr"
+
+homepage: "https://github.com/coq/bignums"
+dev-repo: "git+https://github.com/coq/bignums.git"
+bug-reports: "https://github.com/coq/bignums/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Bignums, the Coq library of arbitrary large numbers"
+description: """
+Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.6
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+
+depends: [
+  "ocaml"
+  "coq" {>= "8.12" & < "8.13~"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "category:Mathematics/Arithmetic and Number Theory/Rational numbers"
+  "keyword:integer numbers"
+  "keyword:rational numbers"
+  "keyword:arithmetic"
+  "keyword:arbitrary-precision"
+  "logpath:Bignums"
+]
+authors: [
+  "Laurent Théry"
+  "Benjamin Grégoire"
+  "Arnaud Spiwack"
+  "Evgeny Makarov"
+  "Pierre Letouzey"
+]
+
+url {
+  src: "git+https://github.com/coq/bignums.git#v8.12"
+}


### PR DESCRIPTION
Needed to enable nightly build of Docker image `coqorg/coq:8.12-alpha`