### PR TITLE
Re-apply PR coq/opam-coq-archive#1237 (using coq_makefile)

### DIFF
--- a/extra-dev/packages/coq-bignums/coq-bignums.8.11.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.8.11.dev/opam
@@ -11,12 +11,12 @@ description: """
 Provides BigN, BigZ, BigQ that used to be part of Coq standard library < 8.6
 """
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 
 depends: [
   "ocaml"
   "coq" {>= "8.11" & < "8.12~"}
-  "dune" {>= "1.9.0"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
+++ b/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
@@ -11,12 +11,12 @@ description: """
 Provides BigN, BigZ, BigQ that used to be part of Coq standard library
 """
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 
 depends: [
   "ocaml"
   "coq" {= "dev"}
-  "dune" {>= "1.9.0"}
 ]
 
 tags: [


### PR DESCRIPTION
(Cc @proux01 @ejgallego FYI)

Transcript of commit message:

1. it seems [that initial PR](https://github.com/coq/opam-coq-archive/pull/1237) had been closed without a specific reason;
2. this new PR makes these two files equivalent:
    - https://github.com/coq/opam-coq-archive/blob/master/extra-dev/packages/coq-bignums/coq-bignums.dev/opam
    - https://github.com/coq/bignums/blob/master/coq-bignums.opam

See also:
* https://github.com/coq/coq/pull/11898 - which added a dedicated [`coq.opam.docker`](https://github.com/proux01/coq/blob/master/coq.opam.docker) file for `coqorg/coq:dev` using coq_makefile
* https://github.com/coq/coq/issues/11476 - for more context