### PR TITLE
[extra-dev] Mark coq-mathcomp-ssreflect.dev compatible with Coq 8.12(+alpha)

### DIFF
--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -9,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { (>= "8.7" & < "8.12~") | (= "dev") } ]
+depends: [ "coq" { (>= "8.7" & < "8.13~") | (= "dev") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
indeed after opening PR https://github.com/math-comp/math-comp/pull/524, the following job passed:
https://gitlab.com/math-comp/math-comp/-/jobs/584865065

Cc @palmskog @CohenCyril FYI

