### PR TITLE
finmap: including 8.12 in dependencies

### DIFF
--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
@@ -9,7 +9,7 @@ license: "CeCILL-B"
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.7" & < "8.12~") }
+  "coq" { (>= "8.7" & < "8.13~") }
   "coq-mathcomp-ssreflect" { (>= "1.11" & < "1.12~") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -11,8 +11,8 @@ build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/finmap'" ]
 depends: [
-  "coq" { (>= "8.7" & < "8.12~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.8.0" & < "1.11~") | (= "dev") }
+  "coq" { (>= "8.7" & < "8.13~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11" & < "1.12~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
 ]
 tags: [ "keyword:finmap" "keyword:finset" "keyword:multiset" "keyword:order"]


### PR DESCRIPTION
If it works with dev these days, I bet it works for 8.12 (this will also make our CI test finmap on 8.12)