### PR TITLE
Add a coq-fiat-crypto-legacy-extra package

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-legacy-extra/coq-fiat-crypto-legacy-extra.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-legacy-extra/coq-fiat-crypto-legacy-extra.dev/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT"
+build: [
+  ["git" "submodule" "update" "--init" "--recursive"]
+  [make "-j%{jobs}%" "coq" "selected-specific-display" "coqprime-all"]
+  [make "-j%{jobs}%" "specific-vo-lt-10gb"]
+  [make "specific-vo-lt-20gb"]
+]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {>= "8.7~"}
+  "coq-bignums"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis:
+  "Cryptographic Primitive Code Generation in Fiat (legacy pipeline + many large examples)."
+tags: ["logpath:Crypto"]
+url {
+  src: "git+https://github.com/mit-plv/fiat-crypto.git#sp2019latest"
+}


### PR DESCRIPTION
This is to be used for profiling on the bench only, and only for some
jobs, as it builds many extra files and takes a long time.