### PR TITLE
Package coq-menhirlib.20200619

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20200619/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200619/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20200619" }
+]
+tags: [
+  "date:2020-06-19"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20200619/archive.tar.gz"
+  checksum: [
+    "md5=6e35cccd708480b5662b5d1903adf069"
+    "sha512=fdc7621ee0e3d60aaececdcf99b54fae979b558c89a3194fb47a4cf624fefb4a50c027f30125286ab02a5b036a91385bc6dc6fa68b04ddd37259d42fa2a65ea1"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20200619`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.2