### PR TITLE
mark reglang 1.1 as compatible with Coq 8.12 and MathComp 1.11.0

### DIFF
--- a/released/packages/coq-reglang/coq-reglang.1.1/opam
+++ b/released/packages/coq-reglang/coq-reglang.1.1/opam
@@ -17,8 +17,8 @@ decidability results and closure properties of regular languages."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.7" & < "8.12~"}
-  "coq-mathcomp-ssreflect" {>= "1.9" & < "1.11~"}
+  "coq" {>= "8.7" & < "8.13~"}
+  "coq-mathcomp-ssreflect" {>= "1.9" & < "1.12~"}
 ]
 
 tags: [


### PR DESCRIPTION
cc: @chdoc 