### PR TITLE
Fix deps of coq-pi-agm.1.2.4

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.10"}
   "coq-coquelicot" {>= "3" & < "4~"}
-  "coq-interval" {>= "3.1"}
+  "coq-interval" {>= "3.1" & < "4~"}
 ]
 tags: [ "keyword:real analysis" "keyword:pi" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Yves Bertot <yves.bertot@inria.fr>" ]


### PR DESCRIPTION
Related to the recent release of `coq-interval`. Example of error: https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.10.2/pi-agm/1.2.4.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-pi-agm.1.2.4 coq.8.10.2
Return code
7936
Duration
26 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-g++               1.0         Virtual package relying on the g++ compiler (for C++)
conf-m4                1           Virtual package relying on m4
coq                    8.10.2      Formal proof management system
coq-bignums            8.10.0      Bignums, the Coq library of arbitrary large numbers
coq-coquelicot         3.1.0       A Coq formalization of real analysis compatible with the standard library
coq-flocq              3.3.1       A formalization of floating-point arithmetic for the Coq system
coq-interval           4.0.0       A Coq tactic for proving bounds on real-valued expressions automatically
coq-mathcomp-ssreflect 1.11.0      Small Scale Reflection
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.09.1      The OCaml compiler (virtual package)
ocaml-base-compiler    4.09.1      Official release 4.09.1
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.10.2).
The following actions will be performed:
  - install coq-pi-agm 1.2.4
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-pi-agm.1.2.4: http]
[coq-pi-agm.1.2.4] downloaded from https://github.com/ybertot/pi-agm/archive/v1.2.4.zip
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-pi-agm: coq_makefile _CoqProject]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "coq_makefile" "-f" "_CoqProject" "-o" "Makefile" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-pi-agm.1.2.4)
Processing  1/2: [coq-pi-agm: make 4]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j" "4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-pi-agm.1.2.4)
- COQDEP VFILES
- *** Warning: in file agmpi.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file agmpi.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file generalities.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file generalities.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file rounding_correct.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file rounding_correct.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file alg2.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file alg2.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file rounding2.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file rounding2.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file hrounding_correct.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- *** Warning: in file hrounding_correct.v, library Interval.Interval_tactic is required and has not been found in the loadpath!
- COQC filter_Rlt.v
- COQC atan_derivative_improper_integral.v
- COQC arcsinh.v
- COQC rounding_big.v
- COQC computing.v
-      = 31415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679821480865132823066470938446095505822317253594081284811174502841027019385211055596446229489549303819644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412737245870066063155881748815209209628292540917153643678925903600113305305488204665213841469519415116094330572703657595919530921861173819326117931051185480744623799627495673518857527248912279381830119491298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051320005681271452635608277857713427577896091736371787214684409012249534301465495853710507922796892589235420199561121290219608640344181598136297747713099605187072113499999983729780499510597317328160963185950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473035982534904287554687311595628638823537875937519577818577805321712268066130019278766111959092164201967%bigZ
-      : BigZ.t_
- COQC generalities.v
- File "./generalities.v", line 4, characters 15-39:
- Error: Unable to locate library Interval.Interval_tactic.
- 
- make[1]: *** [Makefile:659: generalities.vo] Error 1
- make: *** [Makefile:321: all] Error 2
[ERROR] The compilation of coq-pi-agm failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j 4".
#=== ERROR while compiling coq-pi-agm.1.2.4 ===================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-pi-agm.1.2.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j 4
# exit-code            2
# env-file             ~/.opam/log/coq-pi-agm-32294-2dea01.env
# output-file          ~/.opam/log/coq-pi-agm-32294-2dea01.out
### output ###
# [...]
# COQC atan_derivative_improper_integral.v
# COQC arcsinh.v
# COQC rounding_big.v
# COQC computing.v
#      = 3141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117067982148086513282306647093844609550582231725359408128481117450284102701938521105559644622948954930381964428810975665933446128475648233786783165271201909145648566923460348610454326648213393607260249141273724587006606315588174881520920962829254091715364367892590360011330530548820466521384146[...]
#      : BigZ.t_
# COQC generalities.v
# File "./generalities.v", line 4, characters 15-39:
# Error: Unable to locate library Interval.Interval_tactic.
# 
# make[1]: *** [Makefile:659: generalities.vo] Error 1
# make: *** [Makefile:321: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-pi-agm 1.2.4
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-pi-agm.1.2.4 coq.8.10.2' failed.
```

@ybertot @silene 