### PR TITLE
Fix Coq version of coq-mathcomp-analysis.0.3.1

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.1/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.1/opam
@@ -19,7 +19,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {(>= "8.7" & < "8.12~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.12~") | (= "dev")}
   "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~")}
   "coq-mathcomp-finmap"      {(>= "1.5.0" & < "1.6~")}
 ]


### PR DESCRIPTION
Example of error: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.6/released/8.9.0/mathcomp-analysis/0.3.1.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-mathcomp-analysis.0.3.1 coq.8.9.0
Return code
7936
Duration
55 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-num               base        Num library distributed with the OCaml compiler
base-threads           base
base-unix              base
camlp5                 7.12        Preprocessor-pretty-printer of OCaml
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.9.0       Formal proof management system
coq-mathcomp-algebra   1.11.0      Mathematical Components Library on Algebra
coq-mathcomp-bigenough 1.0.0       A small library to do epsilon - N reasonning
coq-mathcomp-field     1.11.0      Mathematical Components Library on Fields
coq-mathcomp-fingroup  1.11.0      Mathematical Components Library on finite groups
coq-mathcomp-finmap    1.5.0       Finite sets, finite maps, finitely supported functions, orders
coq-mathcomp-solvable  1.11.0      Mathematical Components Library on finite groups (II)
coq-mathcomp-ssreflect 1.11.0      Small Scale Reflection
num                    0           The Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.05.0      The OCaml compiler (virtual package)
ocaml-base-compiler    4.05.0      Official 4.05.0 release
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.9.0).
The following actions will be performed:
  - install coq-mathcomp-analysis 0.3.1
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-mathcomp-analysis.0.3.1: http]
[coq-mathcomp-analysis.0.3.1] downloaded from https://github.com/math-comp/analysis/archive/0.3.1.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-mathcomp-analysis: make config]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "INSTMODE=global" "config" (CWD=/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1)
Processing  1/2: [coq-mathcomp-analysis: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1)
- /home/bench/.opam/ocaml-base-compiler.4.05.0/bin/coq_makefile  -f _CoqProject -o Makefile.coq
- make -f Makefile.coq 
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1'
- COQDEP VFILES
- COQC theories/boolp.v
- COQC theories/prodnormedzmodule.v
- COQC theories/forms.v
- COQC theories/altreals/xfinmap.v
- File "./theories/prodnormedzmodule.v", line 67, characters 0-25:
- Warning: Ignoring canonical projection to NngNumDef by Sub in nngnum_subType:
- redundant with nngnum_subType [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 67, characters 0-25:
- Warning: Ignoring canonical projection to num_of_nng by val in
- nngnum_subType: redundant with nngnum_subType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 67, characters 0-25:
- Warning: Ignoring canonical projection to nngnum_of by sub_sort in
- nngnum_subType: redundant with nngnum_subType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 68, characters 0-24:
- Warning: Ignoring canonical projection to nngnum_of by Equality.sort in
- nngnum_eqType: redundant with nngnum_eqType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 69, characters 0-28:
- Warning: Ignoring canonical projection to nngnum_of by Choice.sort in
- nngnum_choiceType: redundant with nngnum_choiceType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 70, characters 0-28:
- Warning: Ignoring canonical projection to nngnum_of by Order.POrder.sort in
- nngnum_porderType: redundant with nngnum_porderType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 71, characters 0-29:
- Warning: Ignoring canonical projection to nngnum_of by Order.Lattice.sort in
- nngnum_latticeType: redundant with nngnum_latticeType
- [redundant-canonical-projection,typechecker]
- File "./theories/prodnormedzmodule.v", line 72, characters 0-27:
- Warning: Ignoring canonical projection to nngnum_of by Order.Total.sort in
- nngnum_orderType: redundant with nngnum_orderType
- [redundant-canonical-projection,typechecker]
- COQC theories/classical_sets.v
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: perm_eq_small is deprecated; use perm_small_eq instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- File "./theories/prodnormedzmodule.v", line 194, characters 0-25:
- Warning: Ignoring canonical projection to prod by Num.NormedZmodule.sort in
- @normedZmodType: redundant with @normedZmodType
- [redundant-canonical-projection,typechecker]
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- File "./theories/forms.v", line 160, characters 0-52:
- Warning: class_of_axiom does not respect the uniform inheritance condition
- [uniform-inheritance,typechecker]
- File "./theories/forms.v", line 176, characters 0-48:
- Warning: additiver does not respect the uniform inheritance condition
- [uniform-inheritance,typechecker]
- File "./theories/forms.v", line 177, characters 0-45:
- Warning: linearr does not respect the uniform inheritance condition
- [uniform-inheritance,typechecker]
- File "./theories/forms.v", line 178, characters 0-20:
- Warning: Ignoring canonical projection to apply by GRing.Additive.apply in
- additiver: redundant with additiver
- [redundant-canonical-projection,typechecker]
- File "./theories/forms.v", line 179, characters 0-18:
- Warning: Ignoring canonical projection to apply by GRing.Linear.apply in
- linearr: redundant with linearr [redundant-canonical-projection,typechecker]
- File "./theories/forms.v", line 180, characters 0-20:
- Warning: Ignoring canonical projection to applyr_head by GRing.Additive.apply
- in additivel: redundant with additivel
- [redundant-canonical-projection,typechecker]
- File "./theories/forms.v", line 181, characters 0-18:
- Warning: Ignoring canonical projection to applyr_head by GRing.Linear.apply
- in linearl: redundant with linearl
- [redundant-canonical-projection,typechecker]
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- Warning: uniq_perm_eq is deprecated; use uniq_perm instead
- COQC theories/reals.v
- COQC theories/posnum.v
- COQC theories/Rstruct.v
- COQC theories/altreals/discrete.v
- COQC theories/ereal.v
- File "./theories/ereal.v", line 41, characters 0-61:
- Warning: real_of_er does not respect the uniform inheritance condition
- [uniform-inheritance,typechecker]
- COQC theories/topology.v
- COQC theories/Rbar.v
- COQC theories/altreals/realseq.v
- File "./theories/topology.v", line 1785, characters 17-21:
- Error:
- Syntax error: 'locally' or 'topologicalType' 'of' expected after '[' (in [constr:operconstr]).
- 
- make[2]: *** [Makefile.coq:662: theories/topology.vo] Error 1
- make[2]: *** Waiting for unfinished jobs....
- make[1]: *** [Makefile.coq:327: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1'
- make: *** [Makefile.common:63: this-build] Error 2
[ERROR] The compilation of coq-mathcomp-analysis failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-mathcomp-analysis.0.3.1 ========================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-mathcomp-analysis-21349-2dea01.env
# output-file          ~/.opam/log/coq-mathcomp-analysis-21349-2dea01.out
### output ###
# [...]
# COQC theories/topology.v
# COQC theories/Rbar.v
# COQC theories/altreals/realseq.v
# File "./theories/topology.v", line 1785, characters 17-21:
# Error:
# Syntax error: 'locally' or 'topologicalType' 'of' expected after '[' (in [constr:operconstr]).
# 
# make[2]: *** [Makefile.coq:662: theories/topology.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# make[1]: *** [Makefile.coq:327: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.05.0/.opam-switch/build/coq-mathcomp-analysis.0.3.1'
# make: *** [Makefile.common:63: this-build] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-mathcomp-analysis 0.3.1
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-mathcomp-analysis.0.3.1 coq.8.9.0' failed.
```
I think this is related to the Coq version. @CohenCyril 