### PR TITLE
Add the ocamlbuild dependency to coq-of-ocaml

### DIFF
--- a/released/packages/coq-of-ocaml/coq-of-ocaml.1.1.1/opam
+++ b/released/packages/coq-of-ocaml/coq-of-ocaml.1.1.1/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-ruby" {build}
   "coq" {>= "8.4.5" & < "8.6"}
   "ocaml" {>= "4.02.0" & < "4.03.0"}
+  "ocamlbuild" {build}
   "smart-print"
   "yojson"
 ]

--- a/released/packages/coq-of-ocaml/coq-of-ocaml.1.2.1/opam
+++ b/released/packages/coq-of-ocaml/coq-of-ocaml.1.2.1/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-ruby" {build}
   "coq" {>= "8.5"}
   "ocaml" {>= "4.05.0" & < "4.06.0"}
+  "ocamlbuild" {build}
   "smart-print"
   "yojson"
 ]


### PR DESCRIPTION
Due to an update of `smart-print` which does not require `ocamlbuild` anymore.