### PR TITLE
Fix coq-interval version for pi-agm

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.2/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.8" & < "8.9~"}
   "coq-coquelicot" {>= "3" & < "4~"}
-  "coq-interval" {>= "3.1"}
+  "coq-interval" {>= "3.1" & < "4"}
 ]
 tags: [ "keyword:real analysis" "keyword:pi" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Yves Bertot <yves.bertot@inria.fr>" ]

--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.3/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.9" & < "8.10~"}
   "coq-coquelicot" {>= "3" & < "4~"}
-  "coq-interval" {>= "3.1"}
+  "coq-interval" {>= "3.1" & < "4"}
 ]
 tags: [ "keyword:real analysis" "keyword:pi" "category:Mathematics/Real Calculus and Topology" ]
 authors: [ "Yves Bertot <yves.bertot@inria.fr>" ]


### PR DESCRIPTION
This is a follow up of https://github.com/coq/opam-coq-archive/pull/1310 Actually, there are been similar errors for these versions too.