### PR TITLE
Package coq-menhirlib.20200624

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20200624" }
+]
+tags: [
+  "date:2020-06-24"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20200624/archive.tar.gz"
+  checksum: [
+    "md5=c37ff53a4a69059e1f8223067b91bb8b"
+    "sha512=68cd165bd65c93fc9b14820a032b6d760674b3e811d8536c2e26e10f9fc5892720564f109484f12f8d08d849c2983c2eaf350d76ab1122a5b8a3c7674ab2bd39"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20200624`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.2