### PR TITLE
Fix Coq version for coq-metacoq-checker.1.0~alpha2+8.11

### DIFF
--- a/released/packages/coq-metacoq-checker/coq-metacoq-checker.1.0~alpha2+8.11/opam
+++ b/released/packages/coq-metacoq-checker/coq-metacoq-checker.1.0~alpha2+8.11/opam
@@ -24,7 +24,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.11" & < "8.12~"}
-  "coq-equations" { >= "1.2" }
+  "coq-equations" { >= "1.2" & < "1.2.2" }
   "coq-metacoq-template" {= version}
 ]
 synopsis: "Specification of Coq's type theory and reference checker implementation"


### PR DESCRIPTION
It seems there is a compilation issue with the new Coq version 8.11.2: https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.11.2/metacoq-checker/1.0~alpha2%2B8.11.html
CC @mattam82 
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-metacoq-checker.1.0~alpha2+8.11 coq.8.11.2
Return code
7936
Duration
4 m 36 s
Output
# Packages matching: installed
# Name               # Installed     # Synopsis
base-bigarray        base
base-threads         base
base-unix            base
conf-findutils       1               Virtual package relying on findutils
conf-m4              1               Virtual package relying on m4
coq                  8.11.2          Formal proof management system
coq-equations        1.2.2+8.11      A function definition package for Coq
coq-metacoq-template 1.0~alpha2+8.11 A quoting and unquoting library for Coq in Coq
num                  1.3             The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                4.09.1          The OCaml compiler (virtual package)
ocaml-base-compiler  4.09.1          Official release 4.09.1
ocaml-config         1               OCaml Switch Configuration
ocamlfind            1.8.1           A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.2).
The following actions will be performed:
  - install coq-metacoq-checker 1.0~alpha2+8.11
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[coq-metacoq-checker.1.0~alpha2+8.11] found in cache
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-metacoq-checker: sh]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "sh" "./configure.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11)
- make -C template-coq mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- rm -f Makefile.coq
- rm -f Makefile.plugin
- rm -f Makefile.template
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- make -C pcuic mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/pcuic'
- rm -f metacoq-config
- rm -f Makefile.plugin _PluginProject
- rm -f Makefile.pcuic _CoqProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/pcuic'
- make -C safechecker mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/safechecker'
- rm -f metacoq-config
- rm -f Makefile.plugin _PluginProject
- rm -f Makefile.safechecker _CoqProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/safechecker'
- make -C erasure mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/erasure'
- rm -f Makefile.plugin
- rm -f Makefile.erasure
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/erasure'
- make -C checker mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- rm -f Makefile.coq Makefile.plugin _CoqProject _PluginProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- make -C examples mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/examples'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/examples'
- make -C test-suite mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/test-suite'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/test-suite'
- make -C translations mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/translations'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/translations'
- ./configure.sh: 19: [: unexpected operator
- Building MetaCoq globally (default)
Processing  1/2: [coq-metacoq-checker: make checker]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" "checker" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11)
- make -C template-coq
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- coq_makefile -f _CoqProject -o Makefile.coq
- coq_makefile -f _TemplateCoqProject -o Makefile.template
- `which gsed || which sed` -i -e s/coqdeps/coqdeps.template/g Makefile.template
- coq_makefile -f _PluginProject -o Makefile.plugin
- Warning: no common logical root
- Warning: in such case INSTALLDEFAULTROOT must be defined
- Warning: the install-doc target is going to install files
- Warning: in orphan_MetaCoq.Template_Test_MetaCoq.Template
- `which gsed || which sed` -i -e s/coqdeps/coqdeps.plugin/g Makefile.plugin
- make -f Makefile.coq
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- COQDEP VFILES
- COQC theories/utils/MCList.v
- COQC theories/utils/MCRelations.v
- COQC theories/utils/MCProd.v
- COQC theories/utils/MCOption.v
- COQC theories/utils/MCSquash.v
- COQC theories/utils/MCArith.v
- COQC theories/utils/MCCompare.v
- COQC theories/utils/MCEquality.v
- COQC theories/utils/LibHypsNaming.v
- COQC theories/utils/MCString.v
- COQC theories/monad_utils.v
- COQC theories/config.v
- COQC theories/BasicAst.v
- COQC theories/utils/All_Forall.v
- COQC theories/utils.v
- COQC theories/Universes.v
- COQC theories/utils/wGraph.v
- COQC theories/Environment.v
- COQC theories/Ast.v
- COQC theories/common/uGraph.v
- COQC theories/AstUtils.v
- COQC theories/TemplateMonad/Common.v
- COQC theories/Induction.v
- COQC theories/WfInv.v
- COQC theories/TemplateMonad/Core.v
- COQC theories/TemplateMonad/Extractable.v
- COQC theories/TemplateMonad.v
- COQC theories/LiftSubst.v
- COQC theories/Constants.v
- COQC theories/UnivSubst.v
- COQC theories/Pretty.v
- COQC theories/EnvironmentTyping.v
- COQC theories/Extraction.v
- COQC theories/Typing.v
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 29, characters 0-41:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 31, characters 0-29:
- Warning: The identifier t__rec contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 32, characters 0-29:
- Warning: The identifier t__rect contains __ which is reserved for the
- extraction [extraction-reserved-identifier,extraction]
- File "./theories/Extraction.v", line 32, characters 0-29:
- Warning: The ide
[...] truncated
ed: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binPos.ml", line 262, characters 12-26:
- 262 |   let min = Pervasives.min
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binPos.ml", line 266, characters 12-26:
- 266 |   let max = Pervasives.max
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- CAMLC -c gen-src/ascii.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mSetInterface.ml
- CAMLC -c gen-src/mSetDecide.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mCCompare.ml
- CAMLC -c gen-src/string0.mli
- CAMLC -c gen-src/mSetProperties.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mSetFacts.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mSetList.ml
- CAMLC -c gen-src/universes0.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/binNat.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mSetDecide.ml
- File "gen-src/binNat.ml", line 46, characters 13-28:
- 46 |   let succ = Pervasives.succ
-                   ^^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binNat.ml", line 50, characters 22-36:
- 50 |   let pred = fun n -> Pervasives.max 0 (n-1)
-                            ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binNat.ml", line 66, characters 23-37:
- 66 |   let sub = fun n m -> Pervasives.max 0 (n-m)
-                             ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binNat.ml", line 108, characters 12-26:
- 108 |   let min = Pervasives.min
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binNat.ml", line 112, characters 12-26:
- 112 |   let max = Pervasives.max
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- CAMLC -c gen-src/environment.mli
- CAMLC -c gen-src/ast0.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/mSetProperties.ml
- CAMLC -c gen-src/astUtils.mli
- CAMLC -c gen-src/common0.mli
- CAMLC -c gen-src/ast_quoter.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/binInt.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/ascii.ml
- CAMLC -c gen-src/liftSubst.mli
- CAMLC -c gen-src/univSubst0.mli
- File "gen-src/binInt.ml", line 94, characters 13-28:
- 94 |   let succ = Pervasives.succ
-                   ^^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binInt.ml", line 98, characters 13-28:
- 98 |   let pred = Pervasives.pred
-                   ^^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binInt.ml", line 198, characters 12-26:
- 198 |   let max = Pervasives.max
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binInt.ml", line 202, characters 12-26:
- 202 |   let min = Pervasives.min
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binInt.ml", line 206, characters 12-26:
- 206 |   let abs = Pervasives.abs
-                   ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- File "gen-src/binInt.ml", line 219, characters 14-28:
- 219 |   let abs_N = Pervasives.abs
-                     ^^^^^^^^^^^^^^
- Alert deprecated: module Stdlib.Pervasives
- Use Stdlib instead.
- 
- If you need to stay compatible with OCaml < 4.07, you can use the 
- stdlib-shims library: https://github.com/ocaml/stdlib-shims
- CAMLC -c gen-src/pretty.mli
- CAMLC -c gen-src/extractable.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/string0.ml
- CAMLC -c gen-src/run_extractable.mli
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/universes0.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/environment.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/ast0.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/astUtils.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/common0.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/ast_quoter.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/liftSubst.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/univSubst0.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/extractable.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/ast_denoter.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/run_extractable.ml
- CAMLOPT -c -for-pack Metacoq_template_plugin gen-src/pretty.ml
- CAMLOPT -pack -o gen-src/metacoq_template_plugin.cmx
- CAMLOPT -a -o gen-src/metacoq_template_plugin.cmxa
- CAMLOPT -shared -o gen-src/metacoq_template_plugin.cmxs
- COQC theories/ExtractableLoader.v
- cp gen-src/metacoq_template_plugin.cm* build/
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/template-coq'
- make -C checker
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- cat metacoq-config > _CoqProject
- cat _CoqProject.in >> _CoqProject
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq
- make[2]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- COQDEP VFILES
- COQC theories/Reflect.v
- COQC theories/WeakeningEnv.v
- COQC theories/Checker.v
- COQC theories/Normal.v
- COQC theories/Closed.v
- COQC theories/Generation.v
- COQC theories/WcbvEval.v
- COQC theories/Retyping.v
- COQC theories/Weakening.v
- File "./theories/Weakening.v", line 1161, characters 9-20:
- Error: No such hypothesis: H
- 
- make[3]: *** [Makefile.coq:678: theories/Weakening.vo] Error 1
- make[2]: *** [Makefile.coq:327: all] Error 2
- make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- make[1]: *** [Makefile:4: coq] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
- make: *** [Makefile:63: checker] Error 2
[ERROR] The compilation of coq-metacoq-checker failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4 checker".
#=== ERROR while compiling coq-metacoq-checker.1.0~alpha2+8.11 ================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4 checker
# exit-code            2
# env-file             ~/.opam/log/coq-metacoq-checker-3881-6d07ae.env
# output-file          ~/.opam/log/coq-metacoq-checker-3881-6d07ae.out
### output ###
# [...]
# COQC theories/WcbvEval.v
# COQC theories/Retyping.v
# COQC theories/Weakening.v
# File "./theories/Weakening.v", line 1161, characters 9-20:
# Error: No such hypothesis: H
# 
# make[3]: *** [Makefile.coq:678: theories/Weakening.vo] Error 1
# make[2]: *** [Makefile.coq:327: all] Error 2
# make[2]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
# make[1]: *** [Makefile:4: coq] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-metacoq-checker.1.0~alpha2+8.11/checker'
# make: *** [Makefile:63: checker] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-metacoq-checker 1.0~alpha2+8.11
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-metacoq-checker.1.0~alpha2+8.11 coq.8.11.2' failed.
The middle of the output is truncated (maximum 20000 characters)
```
