### PR TITLE
Fix timeout to solve dependencies of coq-chick-blog

### DIFF
--- a/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
+++ b/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
@@ -21,9 +21,6 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
 ]
-conflicts: [
-  "ocaml-secondary-compiler"
-]
 tags: [
   "date:2019-11-26"
   "keyword:blog"

--- a/released/packages/coq-chick-blog/coq-chick-blog.1.0.1/opam
+++ b/released/packages/coq-chick-blog/coq-chick-blog.1.0.1/opam
@@ -21,9 +21,6 @@ depends: [
   "ocaml"
   "ocamlfind" {build}
 ]
-conflicts: [
-  "ocaml-secondary-compiler"
-]
 tags: [
   "date:2019-11-26"
   "keyword:blog"


### PR DESCRIPTION
For this package, there are often issue with the resolution of dependencies: https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.6/released/8.4.5/chick-blog/1.0.0.html

If think this is related to the `conflict` clause, which is not really useful (just slower to install with the secondary compiler, which should not be needed with modern versions of OCaml anyway).