### PR TITLE
Specify the OCaml version for coq-chick-blog

### DIFF
--- a/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
+++ b/released/packages/coq-chick-blog/coq-chick-blog.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "coq-moment"
   "coq" {< "8.9~"}
   "lwt"
-  "ocaml"
+  "ocaml" {>= "4.03"}
   "ocamlfind" {build}
 ]
 tags: [

--- a/released/packages/coq-chick-blog/coq-chick-blog.1.0.1/opam
+++ b/released/packages/coq-chick-blog/coq-chick-blog.1.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "coq-moment"
   "coq"
   "lwt"
-  "ocaml"
+  "ocaml" {>= "4.03"}
   "ocamlfind" {build}
 ]
 tags: [


### PR DESCRIPTION
The aim is to reduce the dependency time resolution of this package which often fails, like in https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.6/released/8.4.6~camlp4/chick-blog/1.0.1.html
![image](https://user-images.githubusercontent.com/316665/86580224-b57eec00-bf7e-11ea-9793-c79e61d7d33f.png)
