### PR TITLE
Fix Coq version for coq-infotheo.0.1.1

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.1.1/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.1.1/opam
@@ -25,7 +25,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.10" & < "8.12~"}
+  "coq" {>= "8.11" & < "8.12~"}
   "coq-mathcomp-field" {>= "1.11" & < "1.12~"}
   "coq-mathcomp-analysis"   {>= "0.3.1" & < "0.4~"}
 ]


### PR DESCRIPTION
Example of compilation error: https://coq-bench.github.io/clean/Linux-x86_64-4.06.1-2.0.5/released/8.10.1/infotheo/0.1.1.html It seems that the module `RbaseSymbolsImpl` was introduced by Coq 8.11. CC @affeldt-aist 
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-infotheo.0.1.1 coq.8.10.1
Return code
7936
Duration
14 m 21 s
Output
# Packages matching: installed
# Name                 # Installed # Synopsis
base-bigarray          base
base-threads           base
base-unix              base
conf-findutils         1           Virtual package relying on findutils
conf-m4                1           Virtual package relying on m4
coq                    8.10.1      Formal proof management system
coq-mathcomp-algebra   1.11.0      Mathematical Components Library on Algebra
coq-mathcomp-analysis  0.3.1       An analysis library for mathematical components
coq-mathcomp-bigenough 1.0.0       A small library to do epsilon - N reasonning
coq-mathcomp-field     1.11.0      Mathematical Components Library on Fields
coq-mathcomp-fingroup  1.11.0      Mathematical Components Library on finite groups
coq-mathcomp-finmap    1.5.0       Finite sets, finite maps, finitely supported functions, orders
coq-mathcomp-solvable  1.11.0      Mathematical Components Library on finite groups (II)
coq-mathcomp-ssreflect 1.11.0      Small Scale Reflection
num                    1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                  4.06.1      The OCaml compiler (virtual package)
ocaml-base-compiler    4.06.1      Official 4.06.1 release
ocaml-config           1           OCaml Switch Configuration
ocamlfind              1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.10.1).
The following actions will be performed:
  - install coq-infotheo 0.1.1
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-infotheo.0.1.1: http]
[coq-infotheo.0.1.1] downloaded from https://github.com/affeldt-aist/infotheo/archive/v0.1.1.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-infotheo: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-infotheo.0.1.1)
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq all
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-infotheo.0.1.1'
- COQDEP VFILES
- COQC lib/ssrZ.v
- COQC lib/ssrR.v
- COQC lib/ssr_ext.v
- COQC lib/f2.v
- COQC lib/euclid.v
- COQC lib/classical_sets_ext.v
- COQC ecc_modern/max_subset.v
- COQC lib/Reals_ext.v
- COQC lib/ssralg_ext.v
- COQC lib/num_occ.v
- COQC information_theory/kraft.v
- COQC ecc_modern/subgraph_partition.v
- COQC lib/logb.v
- COQC lib/natbin.v
- COQC lib/poly_ext.v
- COQC lib/vandermonde.v
- COQC lib/Ranalysis_ext.v
- COQC lib/bigop_ext.v
- COQC lib/Rbigop.v
- COQC lib/binary_entropy_function.v
- COQC ecc_modern/tanner.v
- COQC lib/hamming.v
- COQC probability/fdist.v
- COQC ecc_modern/summary.v
- COQC ecc_modern/tanner_partition.v
- COQC probability/proba.v
- COQC probability/fsdist.v
- COQC ecc_modern/degree_profile.v
- COQC lib/dft.v
- Warning: filter_index_enum is deprecated; use big_enumP instead
- Warning: filter_index_enum is deprecated; use big_enumP instead
- Warning: filter_index_enum is deprecated; use big_enumP instead
- Warning: filter_index_enum is deprecated; use big_enumP instead
- COQC probability/jfdist.v
- COQC information_theory/source_code.v
- COQC toy_examples/expected_value_variance.v
- COQC toy_examples/expected_value_variance_ordn.v
- COQC toy_examples/expected_value_variance_tuple.v
- COQC probability/convex_choice.v
- COQC probability/cinde.v
- COQC probability/convex_stone.v
- COQC probability/jensen.v
- COQC probability/ln_facts.v
- COQC probability/necset.v
- COQC probability/divergence.v
- COQC probability/variation_dist.v
- COQC probability/log_sum.v
- COQC information_theory/entropy.v
- COQC information_theory/chap2.v
- COQC information_theory/aep.v
- COQC information_theory/shannon_fano.v
- COQC information_theory/string_entropy.v
- COQC information_theory/source_coding_vl_converse.v
- COQC probability/partition_inequality.v
- COQC information_theory/typ_seq.v
- COQC probability/pinsker.v
- COQC information_theory/source_coding_fl_direct.v
- COQC information_theory/source_coding_fl_converse.v
- COQC information_theory/source_coding_vl_direct.v
- COQC toy_examples/conditional_entropy.v
- COQC information_theory/channel.v
- COQC information_theory/convex_fdist.v
- COQC information_theory/pproba.v
- COQC information_theory/channel_code.v
- COQC information_theory/joint_typ_seq.v
- COQC information_theory/erasure_channel.v
- COQC information_theory/binary_symmetric_channel.v
- COQC information_theory/types.v
- COQC information_theory/channel_coding_direct.v
- COQC ecc_classic/decoding.v
- COQC information_theory/jtypes.v
- COQC ecc_classic/linearcode.v
- COQC information_theory/conditional_divergence.v
- File "./ecc_classic/linearcode.v", line 826, characters 0-129:
- Warning: decoder_coercion does not respect the uniform inheritance condition
- [uniform-inheritance,typechecker]
- COQC ecc_classic/mceliece.v
- COQC ecc_classic/cyclic_code.v
- COQC ecc_classic/hamming_code.v
- COQC ecc_classic/repcode.v
- COQC ecc_modern/checksum.v
- COQC ecc_modern/ldpc_erasure.v
- COQC information_theory/error_exponent.v
- COQC information_theory/success_decode_bound.v
- COQC ecc_classic/poly_decoding.v
- COQC ecc_modern/summary_tanner.v
- COQC ecc_modern/stopping_set.v
- COQC information_theory/channel_coding_converse.v
- COQC ecc_classic/grs.v
- COQC ecc_modern/ldpc.v
- COQC ecc_classic/reed_solomon.v
- COQC ecc_classic/bch.v
- COQC ecc_modern/ldpc_algo.v
- File "./ecc_modern/ldpc_algo.v", line 170, characters 17-35:
- Error: The reference RbaseSymbolsImpl.R was not found in the current
- environment.
- 
- make[2]: *** [Makefile.coq:659: ecc_modern/ldpc_algo.vo] Error 1
- make[2]: *** Waiting for unfinished jobs....
- make[1]: *** [Makefile.coq:321: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-infotheo.0.1.1'
- make: *** [Makefile:2: all] Error 2
[ERROR] The compilation of coq-infotheo failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-infotheo.0.1.1 =================================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.06.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-infotheo.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-infotheo-21599-335865.env
# output-file          ~/.opam/log/coq-infotheo-21599-335865.out
### output ###
# [...]
# COQC ecc_classic/reed_solomon.v
# COQC ecc_classic/bch.v
# COQC ecc_modern/ldpc_algo.v
# File "./ecc_modern/ldpc_algo.v", line 170, characters 17-35:
# Error: The reference RbaseSymbolsImpl.R was not found in the current
# environment.
# 
# make[2]: *** [Makefile.coq:659: ecc_modern/ldpc_algo.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# make[1]: *** [Makefile.coq:321: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.06.1/.opam-switch/build/coq-infotheo.0.1.1'
# make: *** [Makefile:2: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-infotheo 0.1.1
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-infotheo.0.1.1 coq.8.10.1' failed.
```