### PR TITLE
move package to github.com/coq-community + version for 8.11

### DIFF
--- a/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
+++ b/released/packages/coq-high-school-geometry/coq-high-school-geometry.1.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "thery@sophia.inria.fr"
-homepage: "https://gforge.inria.fr/plugins/scmgit/cgi-bin/gitweb.cgi?p=coq-contribs/high-school-geometry.git;a=tree"
+homepage: "https://github.com/coq-community/HighSchoolGeometry/"
 license: "LGPL 2"
 build: [
   ["./configure.sh"]
@@ -25,6 +25,6 @@ description: """
 This library is dedicated to high-shool geometry teaching.
 The axiomatisation for affine euclidean space is in a non analytic setting."""
 url {
-  src: "https://github.com/thery/HighSchoolGeometry/archive/v1.0.0.tar.gz"
+  src: "https://github.com/coq-community/HighSchoolGeometry/archive/v1.0.0.tar.gz"
   checksum: "md5=cf03f84a71cee31d4fe870fa567cc3dd"
 }

--- a/released/packages/coq-high-school-geometry/coq-high-school-geometry.8.11.0/opam
+++ b/released/packages/coq-high-school-geometry/coq-high-school-geometry.8.11.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Laurent.Thery@inria.fr"
+
+homepage: "https://github.com/coq-community/HighSchoolGeometry"
+dev-repo: "git+https://github.com/coq-community/HighSchoolGeometry.git"
+bug-reports: "https://github.com/coq-community/HighSchoolGeometry/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Geometry in Coq for French high-school"
+description: """
+This Coq library is dedicated to high-shool geometry teaching.
+The axiomatisation for affine Euclidean space is in a non analytic setting."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.11" & < "8.13~"}
+]
+
+tags: [
+  "category:Mathematics/Geometry/General"
+  "keyword:geometry"
+  "keyword:teaching"
+  "keyword:high school"
+  "logpath:HighSchoolGeometry"
+]
+authors: [
+  "Frédérique Guilhot"
+]
+url {
+  src:
+    "https://github.com/coq-community/HighSchoolGeometry/archive/v8.11.tar.gz"
+  checksum: "md5=f320fb63bd4f24727ecafb07ed6486bc"
+}

--- a/released/packages/coq-high-school-geometry/coq-high-school-geometry.8.6.0/opam
+++ b/released/packages/coq-high-school-geometry/coq-high-school-geometry.8.6.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "Hugo.Herbelin@inria.fr"
-homepage: "https://github.com/coq-contribs/high-school-geometry"
+maintainer: "Laurent.Thery@inria.fr"
+homepage: "https://github.com/coq-community/HighSchoolGeometry"
 license: "LGPL 2.1"
 build: [make "-j%{jobs}%"]
 install: [make "install"]
@@ -11,15 +11,14 @@ depends: [
 ]
 tags: [ "keyword: geometry" "keyword: teaching" "keyword: high-school" "category: Mathematics/Geometry/General" "date: 2004-01" ]
 authors: [ "Frédérique Guilhot <Frederique.Guilhot@sophia.inria.fr> [http://www-sop.inria.fr/lemme/Frederique.Guilhot/index.html]" ]
-bug-reports: "https://github.com/coq-contribs/high-school-geometry/issues"
-dev-repo: "git+https://github.com/coq-contribs/high-school-geometry.git"
+bug-reports: "https://github.com/coq-community/HighSchoolGeometry/issues"
+dev-repo: "git+https://github.com/coq-community/HighSchoolGeometry/high-school-geometry.git"
 synopsis: "Geometry for French high-school"
 description: """
 This library is dedicated to high-shool geometry teaching.
 The axiomatisation for affine euclidean space is in a non analytic setting."""
-flags: light-uninstall
 url {
   src:
-    "https://github.com/coq-contribs/high-school-geometry/archive/v8.6.0.tar.gz"
+    "https://github.com/coq-community/HighSchoolGeometry/releases/download/v1.0.0/high-school-geometry-8.6.0.tar.gz"
   checksum: "md5=13e7473956daec17fac8316e8e01a436"
 }


### PR DESCRIPTION
coq-high-school-geometry is now installed from coq-community