### PR TITLE
Fix Coq version of coq-libhyps.1.0.1

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.1.0.1/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.1.0.1/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 
 depends: [
-  "coq" {(>= "8.9" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Seems to fail to install with Coq 8.9 @Matafou https://coq-bench.github.io/clean/Linux-x86_64-4.02.3-2.0.6/released/8.9.1/libhyps/1.0.1.html :
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-libhyps.1.0.1 coq.8.9.1
Return code
7936
Duration
8 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-num            base        Num library distributed with the OCaml compiler
base-ocamlbuild     base        OCamlbuild binary and libraries distributed with the OCaml compiler
base-threads        base
base-unix           base
camlp5              7.12        Preprocessor-pretty-printer of OCaml
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.9.1       Formal proof management system
num                 0           The Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.02.3      The OCaml compiler (virtual package)
ocaml-base-compiler 4.02.3      Official 4.02.3 release
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.9.1).
The following actions will be performed:
  - install coq-libhyps 1.0.1
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-libhyps.1.0.1: http]
[coq-libhyps.1.0.1] downloaded from https://github.com/Matafou/LibHyps/archive/libhyps-1.0.1.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-libhyps: ./configure.sh]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.02.3/.opam-switch/build/coq-libhyps.1.0.1)
Processing  1/2: [coq-libhyps: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.02.3/.opam-switch/build/coq-libhyps.1.0.1)
- COQDEP VFILES
- COQC LibHyps/LibDecomp.v
- COQC LibHyps/LibSpecialize.v
- COQC LibHyps/TacNewHyps.v
- COQC LibHyps/LibHypsNaming.v
- File "./LibHyps/LibHypsNaming.v", line 410, characters 8-13:
- Error:
- Syntax error: 'Equivalent' 'Keys' expected after 'Declare' (in [vernac:command]).
- 
- make[1]: *** [Makefile:662: LibHyps/LibHypsNaming.vo] Error 1
- make: *** [Makefile:327: all] Error 2
[ERROR] The compilation of coq-libhyps failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-libhyps.1.0.1 ==================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.02.3/.opam-switch/build/coq-libhyps.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-libhyps-31667-e4db2f.env
# output-file          ~/.opam/log/coq-libhyps-31667-e4db2f.out
### output ###
# COQDEP VFILES
# COQC LibHyps/LibDecomp.v
# COQC LibHyps/LibSpecialize.v
# COQC LibHyps/TacNewHyps.v
# COQC LibHyps/LibHypsNaming.v
# File "./LibHyps/LibHypsNaming.v", line 410, characters 8-13:
# Error:
# Syntax error: 'Equivalent' 'Keys' expected after 'Declare' (in [vernac:command]).
# 
# make[1]: *** [Makefile:662: LibHyps/LibHypsNaming.vo] Error 1
# make: *** [Makefile:327: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-libhyps 1.0.1
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-libhyps.1.0.1 coq.8.9.1' failed.
```