### PR TITLE
coq-equations.1.2.2+8.12 is only compatible with 8.12+beta1

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.1.2.2+8.12/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.1.2.2+8.12/opam
@@ -30,7 +30,7 @@ run-test: [
   [make "test-suite"]
 ]
 depends: [
-  "coq" {>= "8.12~" & < "8.13~"}
+  "coq" {= "8.12+beta1"}
 ]
 url {
   src:


### PR DESCRIPTION
cc: @mattam82 