### PR TITLE
coq-pi-agm 1.2.6, in response to changes in Reals

### DIFF
--- a/released/packages/coq-pi-agm/coq-pi-agm.1.2.6/opam
+++ b/released/packages/coq-pi-agm/coq-pi-agm.1.2.6/opam
@@ -9,7 +9,7 @@ build: [["coq_makefile" "-f" "_CoqProject" "-o" "Makefile" ]
 install: [ make "install" "DEST='%{lib}%/coq/user-contrib/pi_agm'" ]
 depends: [
   "ocaml"
-  "coq" {>= "8.10" & < "8.12~"}
+  "coq" {>= "8.12"}
   "coq-coquelicot" {>= "3" & < "4~"}
   "coq-interval" {>= "4"}
 ]
@@ -29,6 +29,6 @@ which is close to the one used in mpfr, for instance.
 The whole development can be used to produce mathematically proved and
 formally verified approximations of PI."""
 url {
-  src: "https://github.com/ybertot/pi-agm/archive/v1.2.5.zip"
-  checksum: "sha256=0cb93b44a7198bd157cb16a661b70e0e2ccf858bdbf142815740136b69b52627"
+  src: "https://github.com/ybertot/pi-agm/archive/v1.2.6.zip"
+  checksum: "sha256=f690dd8e464acafb4c14437a0ad09545a11f4ebd6771b05f4e7f74ca5c08a7ff"
 }


### PR DESCRIPTION
The function pos_half has been renamed into posreal_half
Boundaries have been added to previous version of the same package (1.2.5)