### PR TITLE
Added CompCert 3.7 patched for Coq 8.12 (platform variants)

### DIFF
--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
@@ -1,0 +1,81 @@
+From b7980c83620ca556b83b8c396ea7a2bc81810222 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Wed, 29 Apr 2020 15:40:13 +0200
+Subject: [PATCH 1/9] Install "compcert.config" file along the Coq development
+
+The file contains various parameters about the target processor and ABI,
+useful for VST and possibly other users of CompCert as a Coq library.
+
+It is in "var=val" syntax so that it can be included directly from
+a Makefile or a shell script.
+---
+ .gitignore |  1 +
+ Makefile   | 19 ++++++++++++++++++-
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/.gitignore b/.gitignore
+index da883cff..5ee5f7ad 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -30,6 +30,7 @@
+ /.depend
+ /.depend.extr
+ /compcert.ini
++/compcert.config
+ /x86/ConstpropOp.v
+ /x86/SelectOp.v
+ /x86/SelectLong.v
+diff --git a/Makefile b/Makefile
+index af069e3f..8c0be846 100644
+--- a/Makefile
++++ b/Makefile
+@@ -142,6 +142,9 @@ endif
+ ifeq ($(CLIGHTGEN),true)
+ 	$(MAKE) clightgen
+ endif
++ifeq ($(INSTALL_COQDEV),true)
++	$(MAKE) compcert.config
++endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
+@@ -219,6 +222,19 @@ compcert.ini: Makefile.config
+ 	 echo "response_file_style=$(RESPONSEFILE)";) \
+         > compcert.ini
+ 
++compcert.config: Makefile.config
++	(echo "# CompCert configuration parameters"; \
++        echo "COMPCERT_ARCH=$(ARCH)"; \
++        echo "COMPCERT_MODEL=$(MODEL)"; \
++        echo "COMPCERT_ABI=$(ABI)"; \
++        echo "COMPCERT_ENDIANNESS=$(ENDIANNESS)"; \
++        echo "COMPCERT_BITSIZE=$(BITSIZE)"; \
++        echo "COMPCERT_SYSTEM=$(SYSTEM)"; \
++        echo "COMPCERT_VERSION=$(BUILDVERSION)"; \
++        echo "COMPCERT_BUILDNR=$(BUILDNR)"; \
++        echo "COMPCERT_TAG=$(TAG)" \
++        ) > compcert.config
++
+ driver/Version.ml: VERSION
+ 	cat VERSION \
+ 	| sed -e 's|\(.*\)=\(.*\)|let \1 = \"\2\"|g' \
+@@ -253,6 +269,7 @@ ifeq ($(INSTALL_COQDEV),true)
+           install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
+ 	done
+ 	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
+@@ -262,7 +279,7 @@ clean:
+ 	rm -f $(patsubst %, %/.*.aux, $(DIRS))
+ 	rm -rf doc/html doc/*.glob
+ 	rm -f driver/Version.ml
+-	rm -f compcert.ini
++	rm -f compcert.ini compcert.config
+ 	rm -f extraction/STAMP extraction/*.ml extraction/*.mli .depend.extr
+ 	rm -f tools/ndfun tools/modorder tools/*.cm? tools/*.o
+ 	rm -f $(GENERATED) .depend
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
@@ -1,0 +1,60 @@
+From cea50ef9277668cb77ddf537fcff28b16988704e Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Sun, 3 May 2020 09:43:14 +0200
+Subject: [PATCH 2/9] Dual-license
+ aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
+
+The corresponding files in all other ports are dual-licensed
+(GPL + non-commercial), there is no reason it should be different for
+aarch64.
+---
+ aarch64/Archi.v             | 3 +++
+ aarch64/CBuiltins.ml        | 3 +++
+ aarch64/extractionMachdep.v | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index aef4ab77..24431cb2 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/CBuiltins.ml b/aarch64/CBuiltins.ml
+index fdc1372d..dfd5b768 100644
+--- a/aarch64/CBuiltins.ml
++++ b/aarch64/CBuiltins.ml
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/extractionMachdep.v b/aarch64/extractionMachdep.v
+index e82056e2..5f26dc28 100644
+--- a/aarch64/extractionMachdep.v
++++ b/aarch64/extractionMachdep.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0003-Update-the-list-of-dual-licensed-files.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0003-Update-the-list-of-dual-licensed-files.patch
@@ -1,0 +1,28 @@
+From 16878a61f7126b54567763787bc16fc7a83c45f6 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 10:51:47 +0200
+Subject: [PATCH 3/9] Update the list of dual-licensed files
+
+Closes: #351
+---
+ LICENSE | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE b/LICENSE
+index 5a7ae79f..61b84219 100644
+--- a/LICENSE
++++ b/LICENSE
+@@ -46,8 +46,8 @@ option) any later version:
+ 
+   all files in the exportclight/ directory
+ 
+-  the Archi.v, CBuiltins.ml, and extractionMachdep.v files
+-  in directories arm, powerpc, riscV, x86, x86_32, x86_64
++  the Archi.v, Builtins1.v, CBuiltins.ml, and extractionMachdep.v files
++  in directories aarch64, arm, powerpc, riscV, x86, x86_32, x86_64
+ 
+   extraction/extraction.v
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0004-Use-Coq-platform-supplied-Flocq.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0004-Use-Coq-platform-supplied-Flocq.patch
@@ -1,0 +1,123 @@
+From 4accc3dd195b098fab44c392c51d9b441b162140 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 16:25:19 +0200
+Subject: [PATCH 4/9] Use Coq platform supplied Flocq
+
+---
+ aarch64/Archi.v     | 2 +-
+ arm/Archi.v         | 2 +-
+ lib/Floats.v        | 2 +-
+ lib/IEEE754_extra.v | 2 +-
+ powerpc/Archi.v     | 2 +-
+ riscV/Archi.v       | 2 +-
+ x86_32/Archi.v      | 2 +-
+ x86_64/Archi.v      | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index 24431cb2..6c5655d8 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -16,7 +16,7 @@
+ (** Architecture-dependent parameters for AArch64 *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+diff --git a/arm/Archi.v b/arm/Archi.v
+index 16d6c71d..9b4cc96a 100644
+--- a/arm/Archi.v
++++ b/arm/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for ARM *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/lib/Floats.v b/lib/Floats.v
+index 13350dd0..ea9e220d 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -17,7 +17,7 @@
+ (** Formalization of floating-point numbers, using the Flocq library. *)
+ 
+ Require Import Coqlib Zbits Integers.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+diff --git a/lib/IEEE754_extra.v b/lib/IEEE754_extra.v
+index c23149be..d546c7d3 100644
+--- a/lib/IEEE754_extra.v
++++ b/lib/IEEE754_extra.v
+@@ -20,7 +20,7 @@
+ Require Import Psatz.
+ Require Import Bool.
+ Require Import Eqdep_dec.
+-(*From Flocq *)
++From Flocq
+ Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
+ 
+ Local Open Scope Z_scope.
+diff --git a/powerpc/Archi.v b/powerpc/Archi.v
+index 10f38391..5ada45f4 100644
+--- a/powerpc/Archi.v
++++ b/powerpc/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for PowerPC *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/riscV/Archi.v b/riscV/Archi.v
+index 61d129d0..4a929aac 100644
+--- a/riscV/Archi.v
++++ b/riscV/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for RISC-V *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Parameter ptr64 : bool.
+diff --git a/x86_32/Archi.v b/x86_32/Archi.v
+index e9d05c14..b5e4b638 100644
+--- a/x86_32/Archi.v
++++ b/x86_32/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 32-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/x86_64/Archi.v b/x86_64/Archi.v
+index 959d8dc1..59502b4a 100644
+--- a/x86_64/Archi.v
++++ b/x86_64/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 64-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0005-Import-ListNotations-explicitly.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0005-Import-ListNotations-explicitly.patch
@@ -1,0 +1,26 @@
+From 48d9cbd2dd476ccf59b9327040e86f41911ab484 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 12:04:38 +0200
+Subject: [PATCH 5/9] Import ListNotations explicitly
+
+So as not to depend on an implicit import from module Program.
+(See PR #352.)
+---
+ lib/Floats.v | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Floats.v b/lib/Floats.v
+index ea9e220d..25a55620 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -22,6 +22,7 @@ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+ Require Archi.
++Import ListNotations.
+ 
+ Close Scope R_scope.
+ Open Scope Z_scope.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
@@ -1,0 +1,121 @@
+From e2c86f5a76387c8642566ce2e35449e71566d772 Mon Sep 17 00:00:00 2001
+From: Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>
+Date: Mon, 4 May 2020 11:37:49 +0200
+Subject: [PATCH 6/9] Coq-MenhirLib: explicit import ListNotations (#354)
+
+import ListNotations wherever it is necessary so that we do not rely on it being exported by Program.  (See #352.)
+
+This is a backport from upstream: https://gitlab.inria.fr/fpottier/menhir/-/commit/53f94fa42c80ab1728383e9d2b19006180b14a78
+---
+ MenhirLib/Alphabet.v             | 3 ++-
+ MenhirLib/Grammar.v              | 3 ++-
+ MenhirLib/Interpreter.v          | 2 ++
+ MenhirLib/Interpreter_complete.v | 3 ++-
+ MenhirLib/Interpreter_correct.v  | 3 ++-
+ MenhirLib/Validator_complete.v   | 1 +
+ MenhirLib/Validator_safe.v       | 1 +
+ 7 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/MenhirLib/Alphabet.v b/MenhirLib/Alphabet.v
+index 29070e3d..530e3b4a 100644
+--- a/MenhirLib/Alphabet.v
++++ b/MenhirLib/Alphabet.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import Omega List Syntax Relations RelationClasses.
++From Coq Require Import Omega List Relations RelationClasses.
++Import ListNotations.
+ 
+ Local Obligation Tactic := intros.
+ 
+diff --git a/MenhirLib/Grammar.v b/MenhirLib/Grammar.v
+index a371318b..9be374e8 100644
+--- a/MenhirLib/Grammar.v
++++ b/MenhirLib/Grammar.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Orders.
++From Coq Require Import List Orders.
++Import ListNotations.
+ Require Import Alphabet.
+ 
+ (** The terminal non-terminal alphabets of the grammar. **)
+diff --git a/MenhirLib/Interpreter.v b/MenhirLib/Interpreter.v
+index 568597ba..c36ca614 100644
+--- a/MenhirLib/Interpreter.v
++++ b/MenhirLib/Interpreter.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Grammar Validator_safe.
+@@ -82,6 +83,7 @@ Proof. by rewrite /cast -Eqdep_dec.eq_rect_eq_dec. Qed.
+ CoInductive buffer : Type :=
+   Buf_cons { buf_head : token; buf_tail : buffer }.
+ 
++Declare Scope buffer_scope.
+ Delimit Scope buffer_scope with buf.
+ Bind Scope buffer_scope with buffer.
+ 
+diff --git a/MenhirLib/Interpreter_complete.v b/MenhirLib/Interpreter_complete.v
+index ec69592b..51f2524b 100644
+--- a/MenhirLib/Interpreter_complete.v
++++ b/MenhirLib/Interpreter_complete.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Arith.
++From Coq Require Import List Arith.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Import Alphabet Grammar.
+ Require Automaton Interpreter Validator_complete.
+diff --git a/MenhirLib/Interpreter_correct.v b/MenhirLib/Interpreter_correct.v
+index 1325f610..083be5b7 100644
+--- a/MenhirLib/Interpreter_correct.v
++++ b/MenhirLib/Interpreter_correct.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax.
++From Coq Require Import List.
++Import ListNotations.
+ Require Import Alphabet.
+ Require Grammar Automaton Interpreter.
+ From Coq.ssr Require Import ssreflect.
+diff --git a/MenhirLib/Validator_complete.v b/MenhirLib/Validator_complete.v
+index ebb74500..9ba3e53c 100644
+--- a/MenhirLib/Validator_complete.v
++++ b/MenhirLib/Validator_complete.v
+@@ -13,6 +13,7 @@
+ 
+ From Coq Require Import List Syntax Derive.
+ From Coq.ssr Require Import ssreflect.
++Import ListNotations.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+ 
+diff --git a/MenhirLib/Validator_safe.v b/MenhirLib/Validator_safe.v
+index 628d2009..e7a54b47 100644
+--- a/MenhirLib/Validator_safe.v
++++ b/MenhirLib/Validator_safe.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax Derive.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0007-Use-ocamlfind-to-find-menhirLib.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0007-Use-ocamlfind-to-find-menhirLib.patch
@@ -1,0 +1,25 @@
+From 6a8204d46faa6776265ed7320b498f63b1e87bba Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 20:55:41 +0200
+Subject: [PATCH 7/9] Use ocamlfind to find menhirLib
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 6bd7ed0e..edf85dd4 100755
+--- a/configure
++++ b/configure
+@@ -582,7 +582,7 @@ case "$menhir_ver" in
+   20[0-9][0-9][0-9][0-9][0-9][0-9])
+       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
+           echo "version $menhir_ver -- good!"
+-          menhir_dir=$(menhir --suggest-menhirLib | tr -d '\r' | tr '\\' '/')
++          menhir_dir=$(ocamlfind -query menhirLib | tr -d '\r' | tr '\\' '/')
+           if test -z "$menhir_dir"; then
+               echo "Error: cannot determine the location of the Menhir API library."
+               echo "This can be due to an incorrect Menhir package."
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
@@ -1,0 +1,25 @@
+From 1feb12c82ec9c047256238d187c228b5464058ac Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Tue, 5 May 2020 17:10:06 +0200
+Subject: [PATCH 8/9] Use platform supplied menhirlib as suggested by jhjourdan
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 8c0be846..132a6cb5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ driver/Version.ml: VERSION
+ 
+ cparser/Parser.v: cparser/Parser.vy
+ 	@rm -f $@
+-	$(MENHIR) --coq --coq-lib-path compcert.MenhirLib --coq-no-version-check cparser/Parser.vy
++	$(MENHIR) --coq cparser/Parser.vy
+ 	@chmod a-w $@
+ 
+ depend: $(GENERATED) depend1
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
@@ -1,0 +1,51 @@
+From 172f55fd1e330a6eb9b06931b67c87ed1f1b1b94 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 21:08:37 +0200
+Subject: [PATCH 9/9] Don't build MenhirLib (platform version is used)
+
+---
+ Makefile | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 132a6cb5..56302b85 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,10 +23,10 @@ endif
+ 
+ DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
+   flocq/Core flocq/Prop flocq/Calc flocq/IEEE754 \
+-  exportclight MenhirLib cparser
++  exportclight cparser
+ 
+ RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight \
+-  MenhirLib cparser
++  cparser
+ 
+ COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
+ 
+@@ -109,12 +109,6 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+ 
+ PARSER=Cabs.v Parser.v
+ 
+-# MenhirLib
+-
+-MENHIRLIB=Alphabet.v Automaton.v Grammar.v Interpreter_complete.v \
+-  Interpreter_correct.v Interpreter.v Main.v Validator_complete.v \
+-  Validator_safe.v Validator_classes.v
+-
+ # Putting everything together (in driver/)
+ 
+ DRIVER=Compopts.v Compiler.v Complements.v
+@@ -122,7 +116,7 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ # All source files
+ 
+ FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+-  $(MENHIRLIB) $(PARSER)
++  $(PARSER)
+ 
+ # Generated source files
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/opam
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+version: "3.7"
+build: [
+  ["./configure"
+  "amd64-linux" {os = "linux"}
+  "amd64-macosx" {os = "macos"}
+  "amd64-linux" {os = "win32"}
+  "-prefix" "%{prefix}%/variants/compcert64"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert64/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+patches: [
+  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
+  "0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
+  "0003-Update-the-list-of-dual-licensed-files.patch"
+  "0004-Use-Coq-platform-supplied-Flocq.patch"
+  "0005-Import-ListNotations-explicitly.patch"
+  "0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch"
+  "0007-Use-ocamlfind-to-find-menhirLib.patch"
+  "0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
+  "0009-Don-t-build-MenhirLib-platform-version-is-used.patch"
+]
+extra-files: [
+  ["0001-Install-compcert.config-file-along-the-Coq-developme.patch" "sha256=62e36964ed3d06a213caea8639be51641c25df3c4ea384e01ce57d015de698d3"]
+  ["0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch" "sha256=1af58e827aa24be60e115878b9f70f1bf715f83bb1b91da8e2a9d749f4195d29"]
+  ["0003-Update-the-list-of-dual-licensed-files.patch" "sha256=bf91c7d3e2177620296838658cafbeffdd50d8d1ef56649b56a35644410e1337"]
+  ["0004-Use-Coq-platform-supplied-Flocq.patch" "sha256=83261a1fae459c319c0288a543787d3abcadaa2cccb1c34543c9784fe645f942"]
+  ["0005-Import-ListNotations-explicitly.patch" "sha256=c4f29203e8dcaa17c76543ad77dabefdb555588567d4f6055cd53e19a9c81081"]
+  ["0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch" "sha256=3b7f59d4736d36878bbe3c0fed80e7db1ae75b9c8a5a9c90a57df2c1a4f4ae78"]
+  ["0007-Use-ocamlfind-to-find-menhirLib.patch" "sha256=df3f103977fa02bd339f6a8537da6bd4eaf1baa54c9675508e3bd16dbe11464e"]
+  ["0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch" "sha256=bcd2eb6eafb5a71fd0ee8ecf6f1b100b06723c636adb0ef2f915fa0ac3585c64"]
+  ["0009-Don-t-build-MenhirLib-platform-version-is-used.patch" "sha256=77835a85124eb1e8afefdcaf9eaa5beab64ed0fea22fceab78b7fd550778c857"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.12" & < "8.13"}
+  "coq-flocq" {>= "3.2.1"}
+  "coq-menhirlib" {>= "20190626"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (64 bit, using coq-platform supplied version of Flocq)"
+description: "This package installs the 64 bit version of CompCert.
+For coexistence with the 32 bit version, the files are installed in:
+%{prefix}%/variants/compcert64/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert64/lib/compcert  (C library)
+%{lib}%/coq/user-contrib/compcert64  (Coq library)
+Please note that the coq module path is compcert and not compcert64,
+so the files cannot be directly Required as compcert64.
+Instead -Q or -R options must be used to bind the compcert64 folder
+to the module path compcert. This is more convenient if one development
+uses both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert64.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert64"
+  "date:2020-04-29"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.7.tar.gz"
+  checksum: "sha256=ceee1b2ed6c2576cb66eb7a0f2669dcf85e65c0fc68385f0781b0ca4edb87eb0"
+}

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
@@ -1,0 +1,81 @@
+From b7980c83620ca556b83b8c396ea7a2bc81810222 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Wed, 29 Apr 2020 15:40:13 +0200
+Subject: [PATCH 1/9] Install "compcert.config" file along the Coq development
+
+The file contains various parameters about the target processor and ABI,
+useful for VST and possibly other users of CompCert as a Coq library.
+
+It is in "var=val" syntax so that it can be included directly from
+a Makefile or a shell script.
+---
+ .gitignore |  1 +
+ Makefile   | 19 ++++++++++++++++++-
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/.gitignore b/.gitignore
+index da883cff..5ee5f7ad 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -30,6 +30,7 @@
+ /.depend
+ /.depend.extr
+ /compcert.ini
++/compcert.config
+ /x86/ConstpropOp.v
+ /x86/SelectOp.v
+ /x86/SelectLong.v
+diff --git a/Makefile b/Makefile
+index af069e3f..8c0be846 100644
+--- a/Makefile
++++ b/Makefile
+@@ -142,6 +142,9 @@ endif
+ ifeq ($(CLIGHTGEN),true)
+ 	$(MAKE) clightgen
+ endif
++ifeq ($(INSTALL_COQDEV),true)
++	$(MAKE) compcert.config
++endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
+@@ -219,6 +222,19 @@ compcert.ini: Makefile.config
+ 	 echo "response_file_style=$(RESPONSEFILE)";) \
+         > compcert.ini
+ 
++compcert.config: Makefile.config
++	(echo "# CompCert configuration parameters"; \
++        echo "COMPCERT_ARCH=$(ARCH)"; \
++        echo "COMPCERT_MODEL=$(MODEL)"; \
++        echo "COMPCERT_ABI=$(ABI)"; \
++        echo "COMPCERT_ENDIANNESS=$(ENDIANNESS)"; \
++        echo "COMPCERT_BITSIZE=$(BITSIZE)"; \
++        echo "COMPCERT_SYSTEM=$(SYSTEM)"; \
++        echo "COMPCERT_VERSION=$(BUILDVERSION)"; \
++        echo "COMPCERT_BUILDNR=$(BUILDNR)"; \
++        echo "COMPCERT_TAG=$(TAG)" \
++        ) > compcert.config
++
+ driver/Version.ml: VERSION
+ 	cat VERSION \
+ 	| sed -e 's|\(.*\)=\(.*\)|let \1 = \"\2\"|g' \
+@@ -253,6 +269,7 @@ ifeq ($(INSTALL_COQDEV),true)
+           install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
+ 	done
+ 	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
+@@ -262,7 +279,7 @@ clean:
+ 	rm -f $(patsubst %, %/.*.aux, $(DIRS))
+ 	rm -rf doc/html doc/*.glob
+ 	rm -f driver/Version.ml
+-	rm -f compcert.ini
++	rm -f compcert.ini compcert.config
+ 	rm -f extraction/STAMP extraction/*.ml extraction/*.mli .depend.extr
+ 	rm -f tools/ndfun tools/modorder tools/*.cm? tools/*.o
+ 	rm -f $(GENERATED) .depend
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
@@ -1,0 +1,60 @@
+From cea50ef9277668cb77ddf537fcff28b16988704e Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Sun, 3 May 2020 09:43:14 +0200
+Subject: [PATCH 2/9] Dual-license
+ aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
+
+The corresponding files in all other ports are dual-licensed
+(GPL + non-commercial), there is no reason it should be different for
+aarch64.
+---
+ aarch64/Archi.v             | 3 +++
+ aarch64/CBuiltins.ml        | 3 +++
+ aarch64/extractionMachdep.v | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index aef4ab77..24431cb2 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/CBuiltins.ml b/aarch64/CBuiltins.ml
+index fdc1372d..dfd5b768 100644
+--- a/aarch64/CBuiltins.ml
++++ b/aarch64/CBuiltins.ml
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/extractionMachdep.v b/aarch64/extractionMachdep.v
+index e82056e2..5f26dc28 100644
+--- a/aarch64/extractionMachdep.v
++++ b/aarch64/extractionMachdep.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0003-Update-the-list-of-dual-licensed-files.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0003-Update-the-list-of-dual-licensed-files.patch
@@ -1,0 +1,28 @@
+From 16878a61f7126b54567763787bc16fc7a83c45f6 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 10:51:47 +0200
+Subject: [PATCH 3/9] Update the list of dual-licensed files
+
+Closes: #351
+---
+ LICENSE | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE b/LICENSE
+index 5a7ae79f..61b84219 100644
+--- a/LICENSE
++++ b/LICENSE
+@@ -46,8 +46,8 @@ option) any later version:
+ 
+   all files in the exportclight/ directory
+ 
+-  the Archi.v, CBuiltins.ml, and extractionMachdep.v files
+-  in directories arm, powerpc, riscV, x86, x86_32, x86_64
++  the Archi.v, Builtins1.v, CBuiltins.ml, and extractionMachdep.v files
++  in directories aarch64, arm, powerpc, riscV, x86, x86_32, x86_64
+ 
+   extraction/extraction.v
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0004-Use-Coq-platform-supplied-Flocq.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0004-Use-Coq-platform-supplied-Flocq.patch
@@ -1,0 +1,123 @@
+From 4accc3dd195b098fab44c392c51d9b441b162140 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 16:25:19 +0200
+Subject: [PATCH 4/9] Use Coq platform supplied Flocq
+
+---
+ aarch64/Archi.v     | 2 +-
+ arm/Archi.v         | 2 +-
+ lib/Floats.v        | 2 +-
+ lib/IEEE754_extra.v | 2 +-
+ powerpc/Archi.v     | 2 +-
+ riscV/Archi.v       | 2 +-
+ x86_32/Archi.v      | 2 +-
+ x86_64/Archi.v      | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index 24431cb2..6c5655d8 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -16,7 +16,7 @@
+ (** Architecture-dependent parameters for AArch64 *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+diff --git a/arm/Archi.v b/arm/Archi.v
+index 16d6c71d..9b4cc96a 100644
+--- a/arm/Archi.v
++++ b/arm/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for ARM *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/lib/Floats.v b/lib/Floats.v
+index 13350dd0..ea9e220d 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -17,7 +17,7 @@
+ (** Formalization of floating-point numbers, using the Flocq library. *)
+ 
+ Require Import Coqlib Zbits Integers.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+diff --git a/lib/IEEE754_extra.v b/lib/IEEE754_extra.v
+index c23149be..d546c7d3 100644
+--- a/lib/IEEE754_extra.v
++++ b/lib/IEEE754_extra.v
+@@ -20,7 +20,7 @@
+ Require Import Psatz.
+ Require Import Bool.
+ Require Import Eqdep_dec.
+-(*From Flocq *)
++From Flocq
+ Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
+ 
+ Local Open Scope Z_scope.
+diff --git a/powerpc/Archi.v b/powerpc/Archi.v
+index 10f38391..5ada45f4 100644
+--- a/powerpc/Archi.v
++++ b/powerpc/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for PowerPC *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/riscV/Archi.v b/riscV/Archi.v
+index 61d129d0..4a929aac 100644
+--- a/riscV/Archi.v
++++ b/riscV/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for RISC-V *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Parameter ptr64 : bool.
+diff --git a/x86_32/Archi.v b/x86_32/Archi.v
+index e9d05c14..b5e4b638 100644
+--- a/x86_32/Archi.v
++++ b/x86_32/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 32-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/x86_64/Archi.v b/x86_64/Archi.v
+index 959d8dc1..59502b4a 100644
+--- a/x86_64/Archi.v
++++ b/x86_64/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 64-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0005-Import-ListNotations-explicitly.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0005-Import-ListNotations-explicitly.patch
@@ -1,0 +1,26 @@
+From 48d9cbd2dd476ccf59b9327040e86f41911ab484 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 12:04:38 +0200
+Subject: [PATCH 5/9] Import ListNotations explicitly
+
+So as not to depend on an implicit import from module Program.
+(See PR #352.)
+---
+ lib/Floats.v | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Floats.v b/lib/Floats.v
+index ea9e220d..25a55620 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -22,6 +22,7 @@ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+ Require Archi.
++Import ListNotations.
+ 
+ Close Scope R_scope.
+ Open Scope Z_scope.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
@@ -1,0 +1,121 @@
+From e2c86f5a76387c8642566ce2e35449e71566d772 Mon Sep 17 00:00:00 2001
+From: Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>
+Date: Mon, 4 May 2020 11:37:49 +0200
+Subject: [PATCH 6/9] Coq-MenhirLib: explicit import ListNotations (#354)
+
+import ListNotations wherever it is necessary so that we do not rely on it being exported by Program.  (See #352.)
+
+This is a backport from upstream: https://gitlab.inria.fr/fpottier/menhir/-/commit/53f94fa42c80ab1728383e9d2b19006180b14a78
+---
+ MenhirLib/Alphabet.v             | 3 ++-
+ MenhirLib/Grammar.v              | 3 ++-
+ MenhirLib/Interpreter.v          | 2 ++
+ MenhirLib/Interpreter_complete.v | 3 ++-
+ MenhirLib/Interpreter_correct.v  | 3 ++-
+ MenhirLib/Validator_complete.v   | 1 +
+ MenhirLib/Validator_safe.v       | 1 +
+ 7 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/MenhirLib/Alphabet.v b/MenhirLib/Alphabet.v
+index 29070e3d..530e3b4a 100644
+--- a/MenhirLib/Alphabet.v
++++ b/MenhirLib/Alphabet.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import Omega List Syntax Relations RelationClasses.
++From Coq Require Import Omega List Relations RelationClasses.
++Import ListNotations.
+ 
+ Local Obligation Tactic := intros.
+ 
+diff --git a/MenhirLib/Grammar.v b/MenhirLib/Grammar.v
+index a371318b..9be374e8 100644
+--- a/MenhirLib/Grammar.v
++++ b/MenhirLib/Grammar.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Orders.
++From Coq Require Import List Orders.
++Import ListNotations.
+ Require Import Alphabet.
+ 
+ (** The terminal non-terminal alphabets of the grammar. **)
+diff --git a/MenhirLib/Interpreter.v b/MenhirLib/Interpreter.v
+index 568597ba..c36ca614 100644
+--- a/MenhirLib/Interpreter.v
++++ b/MenhirLib/Interpreter.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Grammar Validator_safe.
+@@ -82,6 +83,7 @@ Proof. by rewrite /cast -Eqdep_dec.eq_rect_eq_dec. Qed.
+ CoInductive buffer : Type :=
+   Buf_cons { buf_head : token; buf_tail : buffer }.
+ 
++Declare Scope buffer_scope.
+ Delimit Scope buffer_scope with buf.
+ Bind Scope buffer_scope with buffer.
+ 
+diff --git a/MenhirLib/Interpreter_complete.v b/MenhirLib/Interpreter_complete.v
+index ec69592b..51f2524b 100644
+--- a/MenhirLib/Interpreter_complete.v
++++ b/MenhirLib/Interpreter_complete.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Arith.
++From Coq Require Import List Arith.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Import Alphabet Grammar.
+ Require Automaton Interpreter Validator_complete.
+diff --git a/MenhirLib/Interpreter_correct.v b/MenhirLib/Interpreter_correct.v
+index 1325f610..083be5b7 100644
+--- a/MenhirLib/Interpreter_correct.v
++++ b/MenhirLib/Interpreter_correct.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax.
++From Coq Require Import List.
++Import ListNotations.
+ Require Import Alphabet.
+ Require Grammar Automaton Interpreter.
+ From Coq.ssr Require Import ssreflect.
+diff --git a/MenhirLib/Validator_complete.v b/MenhirLib/Validator_complete.v
+index ebb74500..9ba3e53c 100644
+--- a/MenhirLib/Validator_complete.v
++++ b/MenhirLib/Validator_complete.v
+@@ -13,6 +13,7 @@
+ 
+ From Coq Require Import List Syntax Derive.
+ From Coq.ssr Require Import ssreflect.
++Import ListNotations.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+ 
+diff --git a/MenhirLib/Validator_safe.v b/MenhirLib/Validator_safe.v
+index 628d2009..e7a54b47 100644
+--- a/MenhirLib/Validator_safe.v
++++ b/MenhirLib/Validator_safe.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax Derive.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0007-Use-ocamlfind-to-find-menhirLib.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0007-Use-ocamlfind-to-find-menhirLib.patch
@@ -1,0 +1,25 @@
+From 6a8204d46faa6776265ed7320b498f63b1e87bba Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 20:55:41 +0200
+Subject: [PATCH 7/9] Use ocamlfind to find menhirLib
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 6bd7ed0e..edf85dd4 100755
+--- a/configure
++++ b/configure
+@@ -582,7 +582,7 @@ case "$menhir_ver" in
+   20[0-9][0-9][0-9][0-9][0-9][0-9])
+       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
+           echo "version $menhir_ver -- good!"
+-          menhir_dir=$(menhir --suggest-menhirLib | tr -d '\r' | tr '\\' '/')
++          menhir_dir=$(ocamlfind -query menhirLib | tr -d '\r' | tr '\\' '/')
+           if test -z "$menhir_dir"; then
+               echo "Error: cannot determine the location of the Menhir API library."
+               echo "This can be due to an incorrect Menhir package."
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
@@ -1,0 +1,25 @@
+From 1feb12c82ec9c047256238d187c228b5464058ac Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Tue, 5 May 2020 17:10:06 +0200
+Subject: [PATCH 8/9] Use platform supplied menhirlib as suggested by jhjourdan
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 8c0be846..132a6cb5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ driver/Version.ml: VERSION
+ 
+ cparser/Parser.v: cparser/Parser.vy
+ 	@rm -f $@
+-	$(MENHIR) --coq --coq-lib-path compcert.MenhirLib --coq-no-version-check cparser/Parser.vy
++	$(MENHIR) --coq cparser/Parser.vy
+ 	@chmod a-w $@
+ 
+ depend: $(GENERATED) depend1
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
@@ -1,0 +1,51 @@
+From 172f55fd1e330a6eb9b06931b67c87ed1f1b1b94 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 21:08:37 +0200
+Subject: [PATCH 9/9] Don't build MenhirLib (platform version is used)
+
+---
+ Makefile | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 132a6cb5..56302b85 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,10 +23,10 @@ endif
+ 
+ DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
+   flocq/Core flocq/Prop flocq/Calc flocq/IEEE754 \
+-  exportclight MenhirLib cparser
++  exportclight cparser
+ 
+ RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight \
+-  MenhirLib cparser
++  cparser
+ 
+ COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
+ 
+@@ -109,12 +109,6 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+ 
+ PARSER=Cabs.v Parser.v
+ 
+-# MenhirLib
+-
+-MENHIRLIB=Alphabet.v Automaton.v Grammar.v Interpreter_complete.v \
+-  Interpreter_correct.v Interpreter.v Main.v Validator_complete.v \
+-  Validator_safe.v Validator_classes.v
+-
+ # Putting everything together (in driver/)
+ 
+ DRIVER=Compopts.v Compiler.v Complements.v
+@@ -122,7 +116,7 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ # All source files
+ 
+ FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+-  $(MENHIRLIB) $(PARSER)
++  $(PARSER)
+ 
+ # Generated source files
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0010-Added-open-source-build-to-makefile.patch
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/files/0010-Added-open-source-build-to-makefile.patch
@@ -1,0 +1,106 @@
+From 21548ed84fe998724206e3bf48b51e7d9bad5b5f Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 13:50:08 +0200
+Subject: [PATCH 10/10] Added open source build to makefile
+
+---
+ Makefile | 36 +++++++++++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 56302b85..7b48aec7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,10 +52,14 @@ FLOCQ=\
+   Relative.v Sterbenz.v Round_odd.v Double_rounding.v \
+   Binary.v Bits.v
+ 
++# Architecture files (in respective architecture folder)
++
++ARCHFILES=Archi.v
++
+ # General-purpose libraries (in lib/)
+ 
+ VLIB=Axioms.v Coqlib.v Intv.v Maps.v Heaps.v Lattice.v Ordered.v \
+-  Iteration.v Zbits.v Integers.v Archi.v IEEE754_extra.v Floats.v \
++  Iteration.v Zbits.v Integers.v IEEE754_extra.v Floats.v \
+   Parmov.v UnionFind.v Wfsimpl.v \
+   Postorder.v FSetAVLplus.v IntvSets.v Decidableplus.v BoolEqual.v
+ 
+@@ -96,6 +100,8 @@ BACKEND=\
+   Bounds.v Stacklayout.v Stacking.v Stackingproof.v \
+   Asm.v Asmgen.v Asmgenproof0.v Asmgenproof1.v Asmgenproof.v
+ 
++BACKEND_OPEN_SOURCE=Cminor.v
++  
+ # C front-end modules (in cfrontend/)
+ 
+ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+@@ -105,6 +111,8 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+   Cshmgen.v Cshmgenproof.v \
+   Csharpminor.v Cminorgen.v Cminorgenproof.v
+ 
++CFRONTEND_OPEN_SOURCE=Clight.v ClightBigstep.v Cop.v Csem.v Cstrategy.v Csyntax.v Ctypes.v Ctyping.v
++
+ # Parser
+ 
+ PARSER=Cabs.v Parser.v
+@@ -115,9 +123,17 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ 
+ # All source files
+ 
+-FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
++FILES=$(ARCHFILES) $(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+   $(PARSER)
+ 
++# All open source source files (in the order given in LICENSE)
++
++# ATTENTION: this also includes ./x86/Builtins1.vo - which is not open source but many files depend on it
++
++FILES_OPEN_SOURCE=$(VLIB) $(COMMON) $(CFRONTEND_OPEN_SOURCE) $(BACKEND_OPEN_SOURCE) $(PARSER) Clightdefs.v $(ARCHFILES) 
++
++# These files have non open dependencies: extractionMachdep.v, extraction.v
++
+ # Generated source files
+ 
+ GENERATED=\
+@@ -142,6 +158,8 @@ endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
++proof_open_source: $(FILES_OPEN_SOURCE:.v=.vo) compcert.config
++
+ # Turn off some warnings for compiling Flocq
+ flocq/%.vo: COQCOPTS+=-w -compatibility-notation
+ 
+@@ -170,7 +188,7 @@ runtime:
+ 
+ FORCE:
+ 
+-.PHONY: proof extraction runtime FORCE
++.PHONY: proof proof_open_source extraction runtime FORCE
+ 
+ documentation: $(FILES)
+ 	mkdir -p doc/html
+@@ -267,6 +285,18 @@ ifeq ($(INSTALL_COQDEV),true)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
++# ToDo: copy exactly the files in FILES_OPEN_SOURCE as soon as the issue with Builtins1 ins fixed
++install_open_source:
++ifeq ($(INSTALL_COQDEV),true)
++	install -d $(DESTDIR)$(COQDEVDIR)
++	for d in $(DIRS); do \
++          install -d $(DESTDIR)$(COQDEVDIR)/$$d && \
++          install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
++	done
++	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
++	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
++endif
+ 
+ clean:
+ 	rm -f $(patsubst %, %/*.vo*, $(DIRS))
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/opam
+++ b/released/packages/coq-compcert-64/coq-compcert-64.3.7+8.12~coq_platform~open_source/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+version: "3.7"
+build: [
+  ["./configure"
+  "amd64-linux" {os = "linux"}
+  "amd64-macosx" {os = "macos"}
+  "amd64-linux" {os = "win32"}
+  "-prefix" "%{prefix}%/variants/compcert64"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert64/compcert"
+  "-ignore-coq-version"]
+  [make "depend"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"} "proof_open_source"]
+]
+patches: [
+  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
+  "0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
+  "0003-Update-the-list-of-dual-licensed-files.patch"
+  "0004-Use-Coq-platform-supplied-Flocq.patch"
+  "0005-Import-ListNotations-explicitly.patch"
+  "0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch"
+  "0007-Use-ocamlfind-to-find-menhirLib.patch"
+  "0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
+  "0009-Don-t-build-MenhirLib-platform-version-is-used.patch"
+  "0010-Added-open-source-build-to-makefile.patch"
+]
+extra-files: [
+  ["0001-Install-compcert.config-file-along-the-Coq-developme.patch" "sha256=62e36964ed3d06a213caea8639be51641c25df3c4ea384e01ce57d015de698d3"]
+  ["0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch" "sha256=1af58e827aa24be60e115878b9f70f1bf715f83bb1b91da8e2a9d749f4195d29"]
+  ["0003-Update-the-list-of-dual-licensed-files.patch" "sha256=bf91c7d3e2177620296838658cafbeffdd50d8d1ef56649b56a35644410e1337"]
+  ["0004-Use-Coq-platform-supplied-Flocq.patch" "sha256=83261a1fae459c319c0288a543787d3abcadaa2cccb1c34543c9784fe645f942"]
+  ["0005-Import-ListNotations-explicitly.patch" "sha256=c4f29203e8dcaa17c76543ad77dabefdb555588567d4f6055cd53e19a9c81081"]
+  ["0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch" "sha256=3b7f59d4736d36878bbe3c0fed80e7db1ae75b9c8a5a9c90a57df2c1a4f4ae78"]
+  ["0007-Use-ocamlfind-to-find-menhirLib.patch" "sha256=df3f103977fa02bd339f6a8537da6bd4eaf1baa54c9675508e3bd16dbe11464e"]
+  ["0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch" "sha256=bcd2eb6eafb5a71fd0ee8ecf6f1b100b06723c636adb0ef2f915fa0ac3585c64"]
+  ["0009-Don-t-build-MenhirLib-platform-version-is-used.patch" "sha256=77835a85124eb1e8afefdcaf9eaa5beab64ed0fea22fceab78b7fd550778c857"]
+  ["0010-Added-open-source-build-to-makefile.patch" "sha256=0c30ba166c0687395eef15aa92dee66b02d46ee12417de74a69fc3b479ea3e4c"]
+]
+install: [
+  [make "install_open_source"]
+]
+depends: [
+  "coq" {>= "8.12" & < "8.13"}
+  "coq-flocq" {>= "3.2.1"}
+  "coq-menhirlib" {>= "20190626"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (64 bit, only open source files + using coq-platform)"
+description: "This package installs the 64 bit version of CompCert.
+For coexistence with the 32 bit version, the files are installed in:
+%{prefix}%/variants/compcert64/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert64/lib/compcert  (C library)
+%{lib}%/coq/user-contrib/compcert64  (Coq library)
+Please note that the coq module path is compcert and not compcert64,
+so the files cannot be directly Required as compcert64.
+Instead -Q or -R options must be used to bind the compcert64 folder
+to the module path compcert. This is more convenient if one development
+uses both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert64.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert64"
+  "date:2020-04-29"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.7.tar.gz"
+  checksum: "sha256=ceee1b2ed6c2576cb66eb7a0f2669dcf85e65c0fc68385f0781b0ca4edb87eb0"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
@@ -1,0 +1,81 @@
+From b7980c83620ca556b83b8c396ea7a2bc81810222 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Wed, 29 Apr 2020 15:40:13 +0200
+Subject: [PATCH 1/9] Install "compcert.config" file along the Coq development
+
+The file contains various parameters about the target processor and ABI,
+useful for VST and possibly other users of CompCert as a Coq library.
+
+It is in "var=val" syntax so that it can be included directly from
+a Makefile or a shell script.
+---
+ .gitignore |  1 +
+ Makefile   | 19 ++++++++++++++++++-
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/.gitignore b/.gitignore
+index da883cff..5ee5f7ad 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -30,6 +30,7 @@
+ /.depend
+ /.depend.extr
+ /compcert.ini
++/compcert.config
+ /x86/ConstpropOp.v
+ /x86/SelectOp.v
+ /x86/SelectLong.v
+diff --git a/Makefile b/Makefile
+index af069e3f..8c0be846 100644
+--- a/Makefile
++++ b/Makefile
+@@ -142,6 +142,9 @@ endif
+ ifeq ($(CLIGHTGEN),true)
+ 	$(MAKE) clightgen
+ endif
++ifeq ($(INSTALL_COQDEV),true)
++	$(MAKE) compcert.config
++endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
+@@ -219,6 +222,19 @@ compcert.ini: Makefile.config
+ 	 echo "response_file_style=$(RESPONSEFILE)";) \
+         > compcert.ini
+ 
++compcert.config: Makefile.config
++	(echo "# CompCert configuration parameters"; \
++        echo "COMPCERT_ARCH=$(ARCH)"; \
++        echo "COMPCERT_MODEL=$(MODEL)"; \
++        echo "COMPCERT_ABI=$(ABI)"; \
++        echo "COMPCERT_ENDIANNESS=$(ENDIANNESS)"; \
++        echo "COMPCERT_BITSIZE=$(BITSIZE)"; \
++        echo "COMPCERT_SYSTEM=$(SYSTEM)"; \
++        echo "COMPCERT_VERSION=$(BUILDVERSION)"; \
++        echo "COMPCERT_BUILDNR=$(BUILDNR)"; \
++        echo "COMPCERT_TAG=$(TAG)" \
++        ) > compcert.config
++
+ driver/Version.ml: VERSION
+ 	cat VERSION \
+ 	| sed -e 's|\(.*\)=\(.*\)|let \1 = \"\2\"|g' \
+@@ -253,6 +269,7 @@ ifeq ($(INSTALL_COQDEV),true)
+           install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
+ 	done
+ 	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
+@@ -262,7 +279,7 @@ clean:
+ 	rm -f $(patsubst %, %/.*.aux, $(DIRS))
+ 	rm -rf doc/html doc/*.glob
+ 	rm -f driver/Version.ml
+-	rm -f compcert.ini
++	rm -f compcert.ini compcert.config
+ 	rm -f extraction/STAMP extraction/*.ml extraction/*.mli .depend.extr
+ 	rm -f tools/ndfun tools/modorder tools/*.cm? tools/*.o
+ 	rm -f $(GENERATED) .depend
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
@@ -1,0 +1,60 @@
+From cea50ef9277668cb77ddf537fcff28b16988704e Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Sun, 3 May 2020 09:43:14 +0200
+Subject: [PATCH 2/9] Dual-license
+ aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
+
+The corresponding files in all other ports are dual-licensed
+(GPL + non-commercial), there is no reason it should be different for
+aarch64.
+---
+ aarch64/Archi.v             | 3 +++
+ aarch64/CBuiltins.ml        | 3 +++
+ aarch64/extractionMachdep.v | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index aef4ab77..24431cb2 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/CBuiltins.ml b/aarch64/CBuiltins.ml
+index fdc1372d..dfd5b768 100644
+--- a/aarch64/CBuiltins.ml
++++ b/aarch64/CBuiltins.ml
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/extractionMachdep.v b/aarch64/extractionMachdep.v
+index e82056e2..5f26dc28 100644
+--- a/aarch64/extractionMachdep.v
++++ b/aarch64/extractionMachdep.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0003-Update-the-list-of-dual-licensed-files.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0003-Update-the-list-of-dual-licensed-files.patch
@@ -1,0 +1,28 @@
+From 16878a61f7126b54567763787bc16fc7a83c45f6 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 10:51:47 +0200
+Subject: [PATCH 3/9] Update the list of dual-licensed files
+
+Closes: #351
+---
+ LICENSE | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE b/LICENSE
+index 5a7ae79f..61b84219 100644
+--- a/LICENSE
++++ b/LICENSE
+@@ -46,8 +46,8 @@ option) any later version:
+ 
+   all files in the exportclight/ directory
+ 
+-  the Archi.v, CBuiltins.ml, and extractionMachdep.v files
+-  in directories arm, powerpc, riscV, x86, x86_32, x86_64
++  the Archi.v, Builtins1.v, CBuiltins.ml, and extractionMachdep.v files
++  in directories aarch64, arm, powerpc, riscV, x86, x86_32, x86_64
+ 
+   extraction/extraction.v
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0004-Use-Coq-platform-supplied-Flocq.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0004-Use-Coq-platform-supplied-Flocq.patch
@@ -1,0 +1,123 @@
+From 4accc3dd195b098fab44c392c51d9b441b162140 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 16:25:19 +0200
+Subject: [PATCH 4/9] Use Coq platform supplied Flocq
+
+---
+ aarch64/Archi.v     | 2 +-
+ arm/Archi.v         | 2 +-
+ lib/Floats.v        | 2 +-
+ lib/IEEE754_extra.v | 2 +-
+ powerpc/Archi.v     | 2 +-
+ riscV/Archi.v       | 2 +-
+ x86_32/Archi.v      | 2 +-
+ x86_64/Archi.v      | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index 24431cb2..6c5655d8 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -16,7 +16,7 @@
+ (** Architecture-dependent parameters for AArch64 *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+diff --git a/arm/Archi.v b/arm/Archi.v
+index 16d6c71d..9b4cc96a 100644
+--- a/arm/Archi.v
++++ b/arm/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for ARM *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/lib/Floats.v b/lib/Floats.v
+index 13350dd0..ea9e220d 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -17,7 +17,7 @@
+ (** Formalization of floating-point numbers, using the Flocq library. *)
+ 
+ Require Import Coqlib Zbits Integers.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+diff --git a/lib/IEEE754_extra.v b/lib/IEEE754_extra.v
+index c23149be..d546c7d3 100644
+--- a/lib/IEEE754_extra.v
++++ b/lib/IEEE754_extra.v
+@@ -20,7 +20,7 @@
+ Require Import Psatz.
+ Require Import Bool.
+ Require Import Eqdep_dec.
+-(*From Flocq *)
++From Flocq
+ Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
+ 
+ Local Open Scope Z_scope.
+diff --git a/powerpc/Archi.v b/powerpc/Archi.v
+index 10f38391..5ada45f4 100644
+--- a/powerpc/Archi.v
++++ b/powerpc/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for PowerPC *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/riscV/Archi.v b/riscV/Archi.v
+index 61d129d0..4a929aac 100644
+--- a/riscV/Archi.v
++++ b/riscV/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for RISC-V *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Parameter ptr64 : bool.
+diff --git a/x86_32/Archi.v b/x86_32/Archi.v
+index e9d05c14..b5e4b638 100644
+--- a/x86_32/Archi.v
++++ b/x86_32/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 32-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/x86_64/Archi.v b/x86_64/Archi.v
+index 959d8dc1..59502b4a 100644
+--- a/x86_64/Archi.v
++++ b/x86_64/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 64-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0005-Import-ListNotations-explicitly.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0005-Import-ListNotations-explicitly.patch
@@ -1,0 +1,26 @@
+From 48d9cbd2dd476ccf59b9327040e86f41911ab484 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 12:04:38 +0200
+Subject: [PATCH 5/9] Import ListNotations explicitly
+
+So as not to depend on an implicit import from module Program.
+(See PR #352.)
+---
+ lib/Floats.v | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Floats.v b/lib/Floats.v
+index ea9e220d..25a55620 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -22,6 +22,7 @@ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+ Require Archi.
++Import ListNotations.
+ 
+ Close Scope R_scope.
+ Open Scope Z_scope.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
@@ -1,0 +1,121 @@
+From e2c86f5a76387c8642566ce2e35449e71566d772 Mon Sep 17 00:00:00 2001
+From: Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>
+Date: Mon, 4 May 2020 11:37:49 +0200
+Subject: [PATCH 6/9] Coq-MenhirLib: explicit import ListNotations (#354)
+
+import ListNotations wherever it is necessary so that we do not rely on it being exported by Program.  (See #352.)
+
+This is a backport from upstream: https://gitlab.inria.fr/fpottier/menhir/-/commit/53f94fa42c80ab1728383e9d2b19006180b14a78
+---
+ MenhirLib/Alphabet.v             | 3 ++-
+ MenhirLib/Grammar.v              | 3 ++-
+ MenhirLib/Interpreter.v          | 2 ++
+ MenhirLib/Interpreter_complete.v | 3 ++-
+ MenhirLib/Interpreter_correct.v  | 3 ++-
+ MenhirLib/Validator_complete.v   | 1 +
+ MenhirLib/Validator_safe.v       | 1 +
+ 7 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/MenhirLib/Alphabet.v b/MenhirLib/Alphabet.v
+index 29070e3d..530e3b4a 100644
+--- a/MenhirLib/Alphabet.v
++++ b/MenhirLib/Alphabet.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import Omega List Syntax Relations RelationClasses.
++From Coq Require Import Omega List Relations RelationClasses.
++Import ListNotations.
+ 
+ Local Obligation Tactic := intros.
+ 
+diff --git a/MenhirLib/Grammar.v b/MenhirLib/Grammar.v
+index a371318b..9be374e8 100644
+--- a/MenhirLib/Grammar.v
++++ b/MenhirLib/Grammar.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Orders.
++From Coq Require Import List Orders.
++Import ListNotations.
+ Require Import Alphabet.
+ 
+ (** The terminal non-terminal alphabets of the grammar. **)
+diff --git a/MenhirLib/Interpreter.v b/MenhirLib/Interpreter.v
+index 568597ba..c36ca614 100644
+--- a/MenhirLib/Interpreter.v
++++ b/MenhirLib/Interpreter.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Grammar Validator_safe.
+@@ -82,6 +83,7 @@ Proof. by rewrite /cast -Eqdep_dec.eq_rect_eq_dec. Qed.
+ CoInductive buffer : Type :=
+   Buf_cons { buf_head : token; buf_tail : buffer }.
+ 
++Declare Scope buffer_scope.
+ Delimit Scope buffer_scope with buf.
+ Bind Scope buffer_scope with buffer.
+ 
+diff --git a/MenhirLib/Interpreter_complete.v b/MenhirLib/Interpreter_complete.v
+index ec69592b..51f2524b 100644
+--- a/MenhirLib/Interpreter_complete.v
++++ b/MenhirLib/Interpreter_complete.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Arith.
++From Coq Require Import List Arith.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Import Alphabet Grammar.
+ Require Automaton Interpreter Validator_complete.
+diff --git a/MenhirLib/Interpreter_correct.v b/MenhirLib/Interpreter_correct.v
+index 1325f610..083be5b7 100644
+--- a/MenhirLib/Interpreter_correct.v
++++ b/MenhirLib/Interpreter_correct.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax.
++From Coq Require Import List.
++Import ListNotations.
+ Require Import Alphabet.
+ Require Grammar Automaton Interpreter.
+ From Coq.ssr Require Import ssreflect.
+diff --git a/MenhirLib/Validator_complete.v b/MenhirLib/Validator_complete.v
+index ebb74500..9ba3e53c 100644
+--- a/MenhirLib/Validator_complete.v
++++ b/MenhirLib/Validator_complete.v
+@@ -13,6 +13,7 @@
+ 
+ From Coq Require Import List Syntax Derive.
+ From Coq.ssr Require Import ssreflect.
++Import ListNotations.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+ 
+diff --git a/MenhirLib/Validator_safe.v b/MenhirLib/Validator_safe.v
+index 628d2009..e7a54b47 100644
+--- a/MenhirLib/Validator_safe.v
++++ b/MenhirLib/Validator_safe.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax Derive.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0007-Use-ocamlfind-to-find-menhirLib.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0007-Use-ocamlfind-to-find-menhirLib.patch
@@ -1,0 +1,25 @@
+From 6a8204d46faa6776265ed7320b498f63b1e87bba Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 20:55:41 +0200
+Subject: [PATCH 7/9] Use ocamlfind to find menhirLib
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 6bd7ed0e..edf85dd4 100755
+--- a/configure
++++ b/configure
+@@ -582,7 +582,7 @@ case "$menhir_ver" in
+   20[0-9][0-9][0-9][0-9][0-9][0-9])
+       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
+           echo "version $menhir_ver -- good!"
+-          menhir_dir=$(menhir --suggest-menhirLib | tr -d '\r' | tr '\\' '/')
++          menhir_dir=$(ocamlfind -query menhirLib | tr -d '\r' | tr '\\' '/')
+           if test -z "$menhir_dir"; then
+               echo "Error: cannot determine the location of the Menhir API library."
+               echo "This can be due to an incorrect Menhir package."
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
@@ -1,0 +1,25 @@
+From 1feb12c82ec9c047256238d187c228b5464058ac Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Tue, 5 May 2020 17:10:06 +0200
+Subject: [PATCH 8/9] Use platform supplied menhirlib as suggested by jhjourdan
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 8c0be846..132a6cb5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ driver/Version.ml: VERSION
+ 
+ cparser/Parser.v: cparser/Parser.vy
+ 	@rm -f $@
+-	$(MENHIR) --coq --coq-lib-path compcert.MenhirLib --coq-no-version-check cparser/Parser.vy
++	$(MENHIR) --coq cparser/Parser.vy
+ 	@chmod a-w $@
+ 
+ depend: $(GENERATED) depend1
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
@@ -1,0 +1,51 @@
+From 172f55fd1e330a6eb9b06931b67c87ed1f1b1b94 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 21:08:37 +0200
+Subject: [PATCH 9/9] Don't build MenhirLib (platform version is used)
+
+---
+ Makefile | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 132a6cb5..56302b85 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,10 +23,10 @@ endif
+ 
+ DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
+   flocq/Core flocq/Prop flocq/Calc flocq/IEEE754 \
+-  exportclight MenhirLib cparser
++  exportclight cparser
+ 
+ RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight \
+-  MenhirLib cparser
++  cparser
+ 
+ COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
+ 
+@@ -109,12 +109,6 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+ 
+ PARSER=Cabs.v Parser.v
+ 
+-# MenhirLib
+-
+-MENHIRLIB=Alphabet.v Automaton.v Grammar.v Interpreter_complete.v \
+-  Interpreter_correct.v Interpreter.v Main.v Validator_complete.v \
+-  Validator_safe.v Validator_classes.v
+-
+ # Putting everything together (in driver/)
+ 
+ DRIVER=Compopts.v Compiler.v Complements.v
+@@ -122,7 +116,7 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ # All source files
+ 
+ FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+-  $(MENHIRLIB) $(PARSER)
++  $(PARSER)
+ 
+ # Generated source files
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+version: "3.7"
+build: [
+  ["./configure"
+  "ia32-linux" {os = "linux"}
+  "ia32-macosx" {os = "macos"}
+  "ia32-cygwin" {os = "cygwin"}
+  "ia32-cygwin" {os = "win32"}
+  "-bindir" "%{bin}%"
+  "-libdir" "%{lib}%/compcert"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+patches: [
+  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
+  "0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
+  "0003-Update-the-list-of-dual-licensed-files.patch"
+  "0004-Use-Coq-platform-supplied-Flocq.patch"
+  "0005-Import-ListNotations-explicitly.patch"
+  "0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch"
+  "0007-Use-ocamlfind-to-find-menhirLib.patch"
+  "0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
+  "0009-Don-t-build-MenhirLib-platform-version-is-used.patch"
+]
+extra-files: [
+  ["0001-Install-compcert.config-file-along-the-Coq-developme.patch" "sha256=62e36964ed3d06a213caea8639be51641c25df3c4ea384e01ce57d015de698d3"]
+  ["0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch" "sha256=1af58e827aa24be60e115878b9f70f1bf715f83bb1b91da8e2a9d749f4195d29"]
+  ["0003-Update-the-list-of-dual-licensed-files.patch" "sha256=bf91c7d3e2177620296838658cafbeffdd50d8d1ef56649b56a35644410e1337"]
+  ["0004-Use-Coq-platform-supplied-Flocq.patch" "sha256=83261a1fae459c319c0288a543787d3abcadaa2cccb1c34543c9784fe645f942"]
+  ["0005-Import-ListNotations-explicitly.patch" "sha256=c4f29203e8dcaa17c76543ad77dabefdb555588567d4f6055cd53e19a9c81081"]
+  ["0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch" "sha256=3b7f59d4736d36878bbe3c0fed80e7db1ae75b9c8a5a9c90a57df2c1a4f4ae78"]
+  ["0007-Use-ocamlfind-to-find-menhirLib.patch" "sha256=df3f103977fa02bd339f6a8537da6bd4eaf1baa54c9675508e3bd16dbe11464e"]
+  ["0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch" "sha256=bcd2eb6eafb5a71fd0ee8ecf6f1b100b06723c636adb0ef2f915fa0ac3585c64"]
+  ["0009-Don-t-build-MenhirLib-platform-version-is-used.patch" "sha256=77835a85124eb1e8afefdcaf9eaa5beab64ed0fea22fceab78b7fd550778c857"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.12" & < "8.13"}
+  "coq-flocq" {>= "3.2.1"}
+  "coq-menhirlib" {>= "20190626"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (using coq-platform supplied version of Flocq)"
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2020-04-29"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.7.tar.gz"
+  checksum: "sha256=ceee1b2ed6c2576cb66eb7a0f2669dcf85e65c0fc68385f0781b0ca4edb87eb0"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0001-Install-compcert.config-file-along-the-Coq-developme.patch
@@ -1,0 +1,81 @@
+From b7980c83620ca556b83b8c396ea7a2bc81810222 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Wed, 29 Apr 2020 15:40:13 +0200
+Subject: [PATCH 1/9] Install "compcert.config" file along the Coq development
+
+The file contains various parameters about the target processor and ABI,
+useful for VST and possibly other users of CompCert as a Coq library.
+
+It is in "var=val" syntax so that it can be included directly from
+a Makefile or a shell script.
+---
+ .gitignore |  1 +
+ Makefile   | 19 ++++++++++++++++++-
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/.gitignore b/.gitignore
+index da883cff..5ee5f7ad 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -30,6 +30,7 @@
+ /.depend
+ /.depend.extr
+ /compcert.ini
++/compcert.config
+ /x86/ConstpropOp.v
+ /x86/SelectOp.v
+ /x86/SelectLong.v
+diff --git a/Makefile b/Makefile
+index af069e3f..8c0be846 100644
+--- a/Makefile
++++ b/Makefile
+@@ -142,6 +142,9 @@ endif
+ ifeq ($(CLIGHTGEN),true)
+ 	$(MAKE) clightgen
+ endif
++ifeq ($(INSTALL_COQDEV),true)
++	$(MAKE) compcert.config
++endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
+@@ -219,6 +222,19 @@ compcert.ini: Makefile.config
+ 	 echo "response_file_style=$(RESPONSEFILE)";) \
+         > compcert.ini
+ 
++compcert.config: Makefile.config
++	(echo "# CompCert configuration parameters"; \
++        echo "COMPCERT_ARCH=$(ARCH)"; \
++        echo "COMPCERT_MODEL=$(MODEL)"; \
++        echo "COMPCERT_ABI=$(ABI)"; \
++        echo "COMPCERT_ENDIANNESS=$(ENDIANNESS)"; \
++        echo "COMPCERT_BITSIZE=$(BITSIZE)"; \
++        echo "COMPCERT_SYSTEM=$(SYSTEM)"; \
++        echo "COMPCERT_VERSION=$(BUILDVERSION)"; \
++        echo "COMPCERT_BUILDNR=$(BUILDNR)"; \
++        echo "COMPCERT_TAG=$(TAG)" \
++        ) > compcert.config
++
+ driver/Version.ml: VERSION
+ 	cat VERSION \
+ 	| sed -e 's|\(.*\)=\(.*\)|let \1 = \"\2\"|g' \
+@@ -253,6 +269,7 @@ ifeq ($(INSTALL_COQDEV),true)
+           install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
+ 	done
+ 	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
+@@ -262,7 +279,7 @@ clean:
+ 	rm -f $(patsubst %, %/.*.aux, $(DIRS))
+ 	rm -rf doc/html doc/*.glob
+ 	rm -f driver/Version.ml
+-	rm -f compcert.ini
++	rm -f compcert.ini compcert.config
+ 	rm -f extraction/STAMP extraction/*.ml extraction/*.mli .depend.extr
+ 	rm -f tools/ndfun tools/modorder tools/*.cm? tools/*.o
+ 	rm -f $(GENERATED) .depend
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch
@@ -1,0 +1,60 @@
+From cea50ef9277668cb77ddf537fcff28b16988704e Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Sun, 3 May 2020 09:43:14 +0200
+Subject: [PATCH 2/9] Dual-license
+ aarch64/{Archi.v,Cbuiltins.ml,extractionMachdep.v}
+
+The corresponding files in all other ports are dual-licensed
+(GPL + non-commercial), there is no reason it should be different for
+aarch64.
+---
+ aarch64/Archi.v             | 3 +++
+ aarch64/CBuiltins.ml        | 3 +++
+ aarch64/extractionMachdep.v | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index aef4ab77..24431cb2 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/CBuiltins.ml b/aarch64/CBuiltins.ml
+index fdc1372d..dfd5b768 100644
+--- a/aarch64/CBuiltins.ml
++++ b/aarch64/CBuiltins.ml
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+diff --git a/aarch64/extractionMachdep.v b/aarch64/extractionMachdep.v
+index e82056e2..5f26dc28 100644
+--- a/aarch64/extractionMachdep.v
++++ b/aarch64/extractionMachdep.v
+@@ -6,6 +6,9 @@
+ (*                                                                     *)
+ (*  Copyright Institut National de Recherche en Informatique et en     *)
+ (*  Automatique.  All rights reserved.  This file is distributed       *)
++(*  under the terms of the GNU General Public License as published by  *)
++(*  the Free Software Foundation, either version 2 of the License, or  *)
++(*  (at your option) any later version.  This file is also distributed *)
+ (*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+ (*                                                                     *)
+ (* *********************************************************************)
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0003-Update-the-list-of-dual-licensed-files.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0003-Update-the-list-of-dual-licensed-files.patch
@@ -1,0 +1,28 @@
+From 16878a61f7126b54567763787bc16fc7a83c45f6 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 10:51:47 +0200
+Subject: [PATCH 3/9] Update the list of dual-licensed files
+
+Closes: #351
+---
+ LICENSE | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/LICENSE b/LICENSE
+index 5a7ae79f..61b84219 100644
+--- a/LICENSE
++++ b/LICENSE
+@@ -46,8 +46,8 @@ option) any later version:
+ 
+   all files in the exportclight/ directory
+ 
+-  the Archi.v, CBuiltins.ml, and extractionMachdep.v files
+-  in directories arm, powerpc, riscV, x86, x86_32, x86_64
++  the Archi.v, Builtins1.v, CBuiltins.ml, and extractionMachdep.v files
++  in directories aarch64, arm, powerpc, riscV, x86, x86_32, x86_64
+ 
+   extraction/extraction.v
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0004-Use-Coq-platform-supplied-Flocq.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0004-Use-Coq-platform-supplied-Flocq.patch
@@ -1,0 +1,123 @@
+From 4accc3dd195b098fab44c392c51d9b441b162140 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 16:25:19 +0200
+Subject: [PATCH 4/9] Use Coq platform supplied Flocq
+
+---
+ aarch64/Archi.v     | 2 +-
+ arm/Archi.v         | 2 +-
+ lib/Floats.v        | 2 +-
+ lib/IEEE754_extra.v | 2 +-
+ powerpc/Archi.v     | 2 +-
+ riscV/Archi.v       | 2 +-
+ x86_32/Archi.v      | 2 +-
+ x86_64/Archi.v      | 2 +-
+ 8 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/aarch64/Archi.v b/aarch64/Archi.v
+index 24431cb2..6c5655d8 100644
+--- a/aarch64/Archi.v
++++ b/aarch64/Archi.v
+@@ -16,7 +16,7 @@
+ (** Architecture-dependent parameters for AArch64 *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+diff --git a/arm/Archi.v b/arm/Archi.v
+index 16d6c71d..9b4cc96a 100644
+--- a/arm/Archi.v
++++ b/arm/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for ARM *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/lib/Floats.v b/lib/Floats.v
+index 13350dd0..ea9e220d 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -17,7 +17,7 @@
+ (** Formalization of floating-point numbers, using the Flocq library. *)
+ 
+ Require Import Coqlib Zbits Integers.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+diff --git a/lib/IEEE754_extra.v b/lib/IEEE754_extra.v
+index c23149be..d546c7d3 100644
+--- a/lib/IEEE754_extra.v
++++ b/lib/IEEE754_extra.v
+@@ -20,7 +20,7 @@
+ Require Import Psatz.
+ Require Import Bool.
+ Require Import Eqdep_dec.
+-(*From Flocq *)
++From Flocq
+ Require Import Core Digits Operations Round Bracket Sterbenz Binary Round_odd.
+ 
+ Local Open Scope Z_scope.
+diff --git a/powerpc/Archi.v b/powerpc/Archi.v
+index 10f38391..5ada45f4 100644
+--- a/powerpc/Archi.v
++++ b/powerpc/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for PowerPC *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/riscV/Archi.v b/riscV/Archi.v
+index 61d129d0..4a929aac 100644
+--- a/riscV/Archi.v
++++ b/riscV/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for RISC-V *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Parameter ptr64 : bool.
+diff --git a/x86_32/Archi.v b/x86_32/Archi.v
+index e9d05c14..b5e4b638 100644
+--- a/x86_32/Archi.v
++++ b/x86_32/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 32-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := false.
+diff --git a/x86_64/Archi.v b/x86_64/Archi.v
+index 959d8dc1..59502b4a 100644
+--- a/x86_64/Archi.v
++++ b/x86_64/Archi.v
+@@ -17,7 +17,7 @@
+ (** Architecture-dependent parameters for x86 in 64-bit mode *)
+ 
+ Require Import ZArith List.
+-(*From Flocq*)
++From Flocq
+ Require Import Binary Bits.
+ 
+ Definition ptr64 := true.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0005-Import-ListNotations-explicitly.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0005-Import-ListNotations-explicitly.patch
@@ -1,0 +1,26 @@
+From 48d9cbd2dd476ccf59b9327040e86f41911ab484 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Mon, 4 May 2020 12:04:38 +0200
+Subject: [PATCH 5/9] Import ListNotations explicitly
+
+So as not to depend on an implicit import from module Program.
+(See PR #352.)
+---
+ lib/Floats.v | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/Floats.v b/lib/Floats.v
+index ea9e220d..25a55620 100644
+--- a/lib/Floats.v
++++ b/lib/Floats.v
+@@ -22,6 +22,7 @@ Require Import Binary Bits Core.
+ Require Import IEEE754_extra.
+ Require Import Program.
+ Require Archi.
++Import ListNotations.
+ 
+ Close Scope R_scope.
+ Open Scope Z_scope.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch
@@ -1,0 +1,121 @@
+From e2c86f5a76387c8642566ce2e35449e71566d772 Mon Sep 17 00:00:00 2001
+From: Jacques-Henri Jourdan <jacques-henri.jourdan@normalesup.org>
+Date: Mon, 4 May 2020 11:37:49 +0200
+Subject: [PATCH 6/9] Coq-MenhirLib: explicit import ListNotations (#354)
+
+import ListNotations wherever it is necessary so that we do not rely on it being exported by Program.  (See #352.)
+
+This is a backport from upstream: https://gitlab.inria.fr/fpottier/menhir/-/commit/53f94fa42c80ab1728383e9d2b19006180b14a78
+---
+ MenhirLib/Alphabet.v             | 3 ++-
+ MenhirLib/Grammar.v              | 3 ++-
+ MenhirLib/Interpreter.v          | 2 ++
+ MenhirLib/Interpreter_complete.v | 3 ++-
+ MenhirLib/Interpreter_correct.v  | 3 ++-
+ MenhirLib/Validator_complete.v   | 1 +
+ MenhirLib/Validator_safe.v       | 1 +
+ 7 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/MenhirLib/Alphabet.v b/MenhirLib/Alphabet.v
+index 29070e3d..530e3b4a 100644
+--- a/MenhirLib/Alphabet.v
++++ b/MenhirLib/Alphabet.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import Omega List Syntax Relations RelationClasses.
++From Coq Require Import Omega List Relations RelationClasses.
++Import ListNotations.
+ 
+ Local Obligation Tactic := intros.
+ 
+diff --git a/MenhirLib/Grammar.v b/MenhirLib/Grammar.v
+index a371318b..9be374e8 100644
+--- a/MenhirLib/Grammar.v
++++ b/MenhirLib/Grammar.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Orders.
++From Coq Require Import List Orders.
++Import ListNotations.
+ Require Import Alphabet.
+ 
+ (** The terminal non-terminal alphabets of the grammar. **)
+diff --git a/MenhirLib/Interpreter.v b/MenhirLib/Interpreter.v
+index 568597ba..c36ca614 100644
+--- a/MenhirLib/Interpreter.v
++++ b/MenhirLib/Interpreter.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Grammar Validator_safe.
+@@ -82,6 +83,7 @@ Proof. by rewrite /cast -Eqdep_dec.eq_rect_eq_dec. Qed.
+ CoInductive buffer : Type :=
+   Buf_cons { buf_head : token; buf_tail : buffer }.
+ 
++Declare Scope buffer_scope.
+ Delimit Scope buffer_scope with buf.
+ Bind Scope buffer_scope with buffer.
+ 
+diff --git a/MenhirLib/Interpreter_complete.v b/MenhirLib/Interpreter_complete.v
+index ec69592b..51f2524b 100644
+--- a/MenhirLib/Interpreter_complete.v
++++ b/MenhirLib/Interpreter_complete.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax Arith.
++From Coq Require Import List Arith.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Import Alphabet Grammar.
+ Require Automaton Interpreter Validator_complete.
+diff --git a/MenhirLib/Interpreter_correct.v b/MenhirLib/Interpreter_correct.v
+index 1325f610..083be5b7 100644
+--- a/MenhirLib/Interpreter_correct.v
++++ b/MenhirLib/Interpreter_correct.v
+@@ -11,7 +11,8 @@
+ (*                                                                          *)
+ (****************************************************************************)
+ 
+-From Coq Require Import List Syntax.
++From Coq Require Import List.
++Import ListNotations.
+ Require Import Alphabet.
+ Require Grammar Automaton Interpreter.
+ From Coq.ssr Require Import ssreflect.
+diff --git a/MenhirLib/Validator_complete.v b/MenhirLib/Validator_complete.v
+index ebb74500..9ba3e53c 100644
+--- a/MenhirLib/Validator_complete.v
++++ b/MenhirLib/Validator_complete.v
+@@ -13,6 +13,7 @@
+ 
+ From Coq Require Import List Syntax Derive.
+ From Coq.ssr Require Import ssreflect.
++Import ListNotations.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+ 
+diff --git a/MenhirLib/Validator_safe.v b/MenhirLib/Validator_safe.v
+index 628d2009..e7a54b47 100644
+--- a/MenhirLib/Validator_safe.v
++++ b/MenhirLib/Validator_safe.v
+@@ -12,6 +12,7 @@
+ (****************************************************************************)
+ 
+ From Coq Require Import List Syntax Derive.
++Import ListNotations.
+ From Coq.ssr Require Import ssreflect.
+ Require Automaton.
+ Require Import Alphabet Validator_classes.
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0007-Use-ocamlfind-to-find-menhirLib.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0007-Use-ocamlfind-to-find-menhirLib.patch
@@ -1,0 +1,25 @@
+From 6a8204d46faa6776265ed7320b498f63b1e87bba Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 20:55:41 +0200
+Subject: [PATCH 7/9] Use ocamlfind to find menhirLib
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 6bd7ed0e..edf85dd4 100755
+--- a/configure
++++ b/configure
+@@ -582,7 +582,7 @@ case "$menhir_ver" in
+   20[0-9][0-9][0-9][0-9][0-9][0-9])
+       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
+           echo "version $menhir_ver -- good!"
+-          menhir_dir=$(menhir --suggest-menhirLib | tr -d '\r' | tr '\\' '/')
++          menhir_dir=$(ocamlfind -query menhirLib | tr -d '\r' | tr '\\' '/')
+           if test -z "$menhir_dir"; then
+               echo "Error: cannot determine the location of the Menhir API library."
+               echo "This can be due to an incorrect Menhir package."
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch
@@ -1,0 +1,25 @@
+From 1feb12c82ec9c047256238d187c228b5464058ac Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Tue, 5 May 2020 17:10:06 +0200
+Subject: [PATCH 8/9] Use platform supplied menhirlib as suggested by jhjourdan
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 8c0be846..132a6cb5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -242,7 +242,7 @@ driver/Version.ml: VERSION
+ 
+ cparser/Parser.v: cparser/Parser.vy
+ 	@rm -f $@
+-	$(MENHIR) --coq --coq-lib-path compcert.MenhirLib --coq-no-version-check cparser/Parser.vy
++	$(MENHIR) --coq cparser/Parser.vy
+ 	@chmod a-w $@
+ 
+ depend: $(GENERATED) depend1
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0009-Don-t-build-MenhirLib-platform-version-is-used.patch
@@ -1,0 +1,51 @@
+From 172f55fd1e330a6eb9b06931b67c87ed1f1b1b94 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 7 Jun 2020 21:08:37 +0200
+Subject: [PATCH 9/9] Don't build MenhirLib (platform version is used)
+
+---
+ Makefile | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 132a6cb5..56302b85 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,10 +23,10 @@ endif
+ 
+ DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
+   flocq/Core flocq/Prop flocq/Calc flocq/IEEE754 \
+-  exportclight MenhirLib cparser
++  exportclight cparser
+ 
+ RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight \
+-  MenhirLib cparser
++  cparser
+ 
+ COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
+ 
+@@ -109,12 +109,6 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+ 
+ PARSER=Cabs.v Parser.v
+ 
+-# MenhirLib
+-
+-MENHIRLIB=Alphabet.v Automaton.v Grammar.v Interpreter_complete.v \
+-  Interpreter_correct.v Interpreter.v Main.v Validator_complete.v \
+-  Validator_safe.v Validator_classes.v
+-
+ # Putting everything together (in driver/)
+ 
+ DRIVER=Compopts.v Compiler.v Complements.v
+@@ -122,7 +116,7 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ # All source files
+ 
+ FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+-  $(MENHIRLIB) $(PARSER)
++  $(PARSER)
+ 
+ # Generated source files
+ 
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0010-Added-open-source-build-to-makefile.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/files/0010-Added-open-source-build-to-makefile.patch
@@ -1,0 +1,106 @@
+From 21548ed84fe998724206e3bf48b51e7d9bad5b5f Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Thu, 30 Apr 2020 13:50:08 +0200
+Subject: [PATCH 10/10] Added open source build to makefile
+
+---
+ Makefile | 36 +++++++++++++++++++++++++++++++++---
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 56302b85..7b48aec7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,10 +52,14 @@ FLOCQ=\
+   Relative.v Sterbenz.v Round_odd.v Double_rounding.v \
+   Binary.v Bits.v
+ 
++# Architecture files (in respective architecture folder)
++
++ARCHFILES=Archi.v
++
+ # General-purpose libraries (in lib/)
+ 
+ VLIB=Axioms.v Coqlib.v Intv.v Maps.v Heaps.v Lattice.v Ordered.v \
+-  Iteration.v Zbits.v Integers.v Archi.v IEEE754_extra.v Floats.v \
++  Iteration.v Zbits.v Integers.v IEEE754_extra.v Floats.v \
+   Parmov.v UnionFind.v Wfsimpl.v \
+   Postorder.v FSetAVLplus.v IntvSets.v Decidableplus.v BoolEqual.v
+ 
+@@ -96,6 +100,8 @@ BACKEND=\
+   Bounds.v Stacklayout.v Stacking.v Stackingproof.v \
+   Asm.v Asmgen.v Asmgenproof0.v Asmgenproof1.v Asmgenproof.v
+ 
++BACKEND_OPEN_SOURCE=Cminor.v
++  
+ # C front-end modules (in cfrontend/)
+ 
+ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+@@ -105,6 +111,8 @@ CFRONTEND=Ctypes.v Cop.v Csyntax.v Csem.v Ctyping.v Cstrategy.v Cexec.v \
+   Cshmgen.v Cshmgenproof.v \
+   Csharpminor.v Cminorgen.v Cminorgenproof.v
+ 
++CFRONTEND_OPEN_SOURCE=Clight.v ClightBigstep.v Cop.v Csem.v Cstrategy.v Csyntax.v Ctypes.v Ctyping.v
++
+ # Parser
+ 
+ PARSER=Cabs.v Parser.v
+@@ -115,9 +123,17 @@ DRIVER=Compopts.v Compiler.v Complements.v
+ 
+ # All source files
+ 
+-FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
++FILES=$(ARCHFILES) $(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+   $(PARSER)
+ 
++# All open source source files (in the order given in LICENSE)
++
++# ATTENTION: this also includes ./x86/Builtins1.vo - which is not open source but many files depend on it
++
++FILES_OPEN_SOURCE=$(VLIB) $(COMMON) $(CFRONTEND_OPEN_SOURCE) $(BACKEND_OPEN_SOURCE) $(PARSER) Clightdefs.v $(ARCHFILES) 
++
++# These files have non open dependencies: extractionMachdep.v, extraction.v
++
+ # Generated source files
+ 
+ GENERATED=\
+@@ -142,6 +158,8 @@ endif
+ 
+ proof: $(FILES:.v=.vo)
+ 
++proof_open_source: $(FILES_OPEN_SOURCE:.v=.vo) compcert.config
++
+ # Turn off some warnings for compiling Flocq
+ flocq/%.vo: COQCOPTS+=-w -compatibility-notation
+ 
+@@ -170,7 +188,7 @@ runtime:
+ 
+ FORCE:
+ 
+-.PHONY: proof extraction runtime FORCE
++.PHONY: proof proof_open_source extraction runtime FORCE
+ 
+ documentation: $(FILES)
+ 	mkdir -p doc/html
+@@ -267,6 +285,18 @@ ifeq ($(INSTALL_COQDEV),true)
+ 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
+ endif
+ 
++# ToDo: copy exactly the files in FILES_OPEN_SOURCE as soon as the issue with Builtins1 ins fixed
++install_open_source:
++ifeq ($(INSTALL_COQDEV),true)
++	install -d $(DESTDIR)$(COQDEVDIR)
++	for d in $(DIRS); do \
++          install -d $(DESTDIR)$(COQDEVDIR)/$$d && \
++          install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
++	done
++	install -m 0644 ./VERSION $(DESTDIR)$(COQDEVDIR)
++	install -m 0644 ./compcert.config $(DESTDIR)$(COQDEVDIR)
++	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(DESTDIR)$(COQDEVDIR)/README
++endif
+ 
+ clean:
+ 	rm -f $(patsubst %, %/*.vo*, $(DIRS))
+-- 
+2.27.0
+

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+version: "3.7"
+build: [
+  ["./configure"
+  "ia32-linux" {os = "linux"}
+  "ia32-macosx" {os = "macos"}
+  "ia32-cygwin" {os = "cygwin"}
+  "ia32-cygwin" {os = "win32"}
+  "-bindir" "%{bin}%"
+  "-libdir" "%{lib}%/compcert"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "depend"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"} "proof_open_source"]
+]
+patches: [
+  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
+  "0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
+  "0003-Update-the-list-of-dual-licensed-files.patch"
+  "0004-Use-Coq-platform-supplied-Flocq.patch"
+  "0005-Import-ListNotations-explicitly.patch"
+  "0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch"
+  "0007-Use-ocamlfind-to-find-menhirLib.patch"
+  "0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
+  "0009-Don-t-build-MenhirLib-platform-version-is-used.patch"
+  "0010-Added-open-source-build-to-makefile.patch"
+]
+extra-files: [
+  ["0001-Install-compcert.config-file-along-the-Coq-developme.patch" "sha256=62e36964ed3d06a213caea8639be51641c25df3c4ea384e01ce57d015de698d3"]
+  ["0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch" "sha256=1af58e827aa24be60e115878b9f70f1bf715f83bb1b91da8e2a9d749f4195d29"]
+  ["0003-Update-the-list-of-dual-licensed-files.patch" "sha256=bf91c7d3e2177620296838658cafbeffdd50d8d1ef56649b56a35644410e1337"]
+  ["0004-Use-Coq-platform-supplied-Flocq.patch" "sha256=83261a1fae459c319c0288a543787d3abcadaa2cccb1c34543c9784fe645f942"]
+  ["0005-Import-ListNotations-explicitly.patch" "sha256=c4f29203e8dcaa17c76543ad77dabefdb555588567d4f6055cd53e19a9c81081"]
+  ["0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch" "sha256=3b7f59d4736d36878bbe3c0fed80e7db1ae75b9c8a5a9c90a57df2c1a4f4ae78"]
+  ["0007-Use-ocamlfind-to-find-menhirLib.patch" "sha256=df3f103977fa02bd339f6a8537da6bd4eaf1baa54c9675508e3bd16dbe11464e"]
+  ["0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch" "sha256=bcd2eb6eafb5a71fd0ee8ecf6f1b100b06723c636adb0ef2f915fa0ac3585c64"]
+  ["0009-Don-t-build-MenhirLib-platform-version-is-used.patch" "sha256=77835a85124eb1e8afefdcaf9eaa5beab64ed0fea22fceab78b7fd550778c857"]
+  ["0010-Added-open-source-build-to-makefile.patch" "sha256=0c30ba166c0687395eef15aa92dee66b02d46ee12417de74a69fc3b479ea3e4c"]
+]
+install: [
+  [make "install_open_source"]
+]
+depends: [
+  "coq" {>= "8.12" & < "8.13"}
+  "coq-flocq" {>= "3.2.1"}
+  "coq-menhirlib" {>= "20190626"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (only open source files + using coq-platform)"
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2020-04-29"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.7.tar.gz"
+  checksum: "sha256=ceee1b2ed6c2576cb66eb7a0f2669dcf85e65c0fc68385f0781b0ca4edb87eb0"
+}


### PR DESCRIPTION
This PR adds variants of CompCert 3.7 which are patched for Coq 8.12.

Besides two required compatibility patches from CompCert github, it also contains two patches for the makefile regarding using the platform supplied menhirlib. These are for platform compatibility.

The 32 bit non open source variant is identical to what is delivered in the Coq 8.12.0 Windows installer.

Note on the names: I changed the hyphens in the version names to underscores because hyphens in version names have a special meaning (see https://github.com/ocaml/opam/issues/4272)

Below is a comparison of the patch sets (note that the order for "Added-open-source-build-to-makefile" changed):

```
3.7~coq-platform~open-source:
  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
  "0007-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
  "0008-Update-the-list-of-dual-licensed-files.patch"
  "0010-Added-open-source-build-to-makefile.patch"
  "0011-Use-Coq-platform-supplied-Flocq.patch"
  "0012-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
```

```
3.7+8.12~coq_platform~open_source:
  "0001-Install-compcert.config-file-along-the-Coq-developme.patch"
  "0002-Dual-license-aarch64-Archi.v-Cbuiltins.ml-extraction.patch"
  "0003-Update-the-list-of-dual-licensed-files.patch"
  "0004-Use-Coq-platform-supplied-Flocq.patch"
  "0005-Import-ListNotations-explicitly.patch"
  "0006-Coq-MenhirLib-explicit-import-ListNotations-354.patch"
  "0007-Use-ocamlfind-to-find-menhirLib.patch"
  "0008-Use-platform-supplied-menhirlib-as-suggested-by-jhjo.patch"
  "0009-Don-t-build-MenhirLib-platform-version-is-used.patch"
  "0010-Added-open-source-build-to-makefile.patch"
```

@jhjourdan @xavierleroy : FYI