### PR TITLE
Resync coq/coqide dev packages with (safer, slower) release settings

### DIFF
--- a/core-dev/packages/coq/coq.8.12.dev/opam
+++ b/core-dev/packages/coq/coq.8.12.dev/opam
@@ -33,7 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coq/coq.8.12.dev/opam
+++ b/core-dev/packages/coq/coq.8.12.dev/opam
@@ -33,6 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    # These settings are used as templates for release packages
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -33,7 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -33,6 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
+    # These settings are used as templates for release packages
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]

--- a/core-dev/packages/coqide/coqide.8.12.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.12.dev/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.8.12.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.12.dev/opam
@@ -27,6 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
+    # These settings are used as templates for release packages
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -27,6 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
+    # These settings are used as templates for release packages
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]


### PR DESCRIPTION
These opam packages are currently used as templates for releases.
See discussion at ocaml/opam-repository#16908,
https://github.com/ocaml/opam-repository/pull/16876#issuecomment-665598798
and
https://github.com/coq/coq/issues/11178#issuecomment-665589620.

Only done for 8.12 and dev, which will be used in the future.

The resulting packages are safer and slower (for flambda users); fixing that
will require a more proper fix (such as ocaml/opam-repository#16887).