### PR TITLE
Fix coq-vst.2.6 for Coq 8.11.X

### DIFF
--- a/released/packages/coq-vst-64/coq-vst-64.2.6/opam
+++ b/released/packages/coq-vst-64/coq-vst-64.2.6/opam
@@ -29,7 +29,7 @@ install: [
 depends: [
   "ocaml"
   "coq" {>= "8.11" & < "8.13"}
-  "coq-compcert-64" {(= "3.7~coq_platform~open_source") | (= "3.7~coq_platform") | (= "3.7+8.12~coq_platform~open_source") | (= "3.7+8.12~coq_platform")}
+  "coq-compcert-64" {(= "3.7~coq-platform~open-source") | (= "3.7~coq-platform") | (= "3.7+8.12~coq_platform~open_source") | (= "3.7+8.12~coq_platform")}
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [

--- a/released/packages/coq-vst/coq-vst.2.6/opam
+++ b/released/packages/coq-vst/coq-vst.2.6/opam
@@ -29,7 +29,7 @@ install: [
 depends: [
   "ocaml"
   "coq" {>= "8.11" & < "8.13"}
-  "coq-compcert" {(= "3.7~coq_platform~open_source") | (= "3.7~coq_platform") | (= "3.7+8.12~coq_platform~open_source") | (= "3.7+8.12~coq_platform")}
+  "coq-compcert" {(= "3.7~coq-platform~open-source") | (= "3.7~coq-platform") | (= "3.7+8.12~coq_platform~open_source") | (= "3.7+8.12~coq_platform")}
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [


### PR DESCRIPTION
This PR fixes the CompCert version names for Coq 8.11.X.
This is tested with a Coq platform 8.11.2 prototype.