### PR TITLE
coq-hott opam package for coq 8.12.0

### DIFF
--- a/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.10.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.11.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.12.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.12.dev/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+homepage: "http://homotopytypetheory.org/"
+bug-reports: "https://github.com/HoTT/HoTT/issues"
+license: "BSD-2-Clause"
+build: [
+  ["bash" "-c" "./autogen.sh -skip-submodules || :"]
+  ["./configure" "COQBIN=%{bin}%" "--prefix=%{prefix}%"]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-autoconf" {build}
+  "ocaml"
+  "ocamlfind" {build}
+  "coq" {>= "8.12" & < "8.13~"}
+]
+authors: ["The Coq-HoTT Development Team"]
+dev-repo: "git+https://github.com/HoTT/HoTT.git"
+synopsis: "The Homotopy Type Theory library"
+tags: [ "logpath:HoTT" ]
+url {
+  src: "git+https://github.com/HoTT/HoTT.git#V8.12"
+}

--- a/extra-dev/packages/coq-hott/coq-hott.8.12.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.12.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.7.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.8.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.8.9.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>"
+maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"

--- a/extra-dev/packages/coq-hott/coq-hott.dev/opam
+++ b/extra-dev/packages/coq-hott/coq-hott.dev/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>"
+maintainer: [ "Jason Gross <jgross@mit.edu>" "Ali Caglayan <alizter@gmail.com>" ]
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 license: "BSD-2-Clause"


### PR DESCRIPTION
I've added an 8.12 package for the HoTT library. I've also added myself as a maintainer of the existing packages.

@JasonGross