### PR TITLE
Add conf-jq to fiat-crypto build-depends

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -10,9 +10,9 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "coq-without-bedrock2" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "coq-without-bedrock2" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -16,6 +16,7 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "BINDIR=%{bin}%" "install-without-bedro
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
+  "conf-jq" {build}
   "coq" {>= "8.9~"}
   "coq-coqprime"
   "coq-rewriter"


### PR DESCRIPTION
After https://github.com/mit-plv/fiat-crypto/pull/864 is merged,
fiat-crypto will be using jq to build some files.