### PR TITLE
sync Coq opam packages with ocaml repository

### DIFF
--- a/core-dev/packages/coq/coq.8.12+beta1/opam
+++ b/core-dev/packages/coq/coq.8.12+beta1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "coqdev@inria.fr"
 authors: "The Coq development team, INRIA, CNRS, and contributors."
-homepage: "https://coq.inria.fr"
+homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1-only"
@@ -18,7 +18,7 @@ and homotopy type theory) and teaching.
 """
 
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "4.12"}
   "ocamlfind" {build}
   "num"
   "conf-findutils" {build}
@@ -33,7 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coq/coq.8.12.dev/opam
+++ b/core-dev/packages/coq/coq.8.12.dev/opam
@@ -18,7 +18,7 @@ and homotopy type theory) and teaching.
 """
 
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "4.12"}
   "ocamlfind" {build}
   "num"
   "conf-findutils" {build}
@@ -33,7 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -33,7 +33,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]

--- a/core-dev/packages/coqide/coqide.8.12+beta1/opam
+++ b/core-dev/packages/coqide/coqide.8.12+beta1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "coqdev@inria.fr"
 authors: "The Coq development team, INRIA, CNRS, and contributors."
-homepage: "https://coq.inria.fr"
+homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 dev-repo: "git+https://github.com/coq/coq.git"
 license: "LGPL-2.1-only"
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.8.12.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.12.dev/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.dev/files/coqide.install
+++ b/core-dev/packages/coqide/coqide.dev/files/coqide.install
@@ -2,8 +2,8 @@ bin: [
   "bin/coqide"
 ]
 share_root: [
-  "ide/coq.lang" {"coq/coq.lang"}
-  "ide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
-  "ide/coq.png" {"coq/coq.png"}
-  "ide/coq_style.xml" {"coq/coq_style.xml"}
+  "ide/coqide/coq.lang" {"coq/coq.lang"}
+  "ide/coqide/coq-ssreflect.lang" {"coq/coq-ssreflect.lang"}
+  "ide/coqide/coq.png" {"coq/coq.png"}
+  "ide/coqide/coq_style.xml" {"coq/coq_style.xml"}
 ]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -27,7 +27,7 @@ build: [
     "-docdir" doc
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
-    "-flambda-opts" "-O3 -unbox-closures"
+    "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
   [make "-j%{jobs}%" "coqide-files"]
   [make "-j%{jobs}%" "coqide-opt"]

--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -41,7 +41,7 @@ install: [
 ]
 
 extra-files: [
-  ["coqide.install" "sha512=0c59f0c3cf3453e92c02b29aceb31090020410d2b0dd2856172cd19b1b2b58b2a1d46047fb08a9c1d4767d87934c73ae6adfcb4204b1ea6a55a85ba75b2b812d"]
+  ["coqide.install" "sha512=3eba9f94c7cc2a4b9b4fc8be549d7e5b3125315360cc85fb1001ba25d2eb5fb174c358ba3295036dda44197ec068e18c0b2f3b341aaa77b73fdb75d1e7d5c27f"]
 ]
 
 url {


### PR DESCRIPTION
I usually use the packages here as template for the next release, assuming that this is where we keep the latest opam file (as the one in the repo is for experimental dune support). So let's make sure they are in sync.