### PR TITLE
Fix Coq version for coq-geometric-algebra.0.8.11

### DIFF
--- a/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
+++ b/released/packages/coq-geometric-algebra/coq-geometric-algebra.0.8.11/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.11~"}
+  "coq" {>= "8.11~" & < "8.12"}
 ]
 synopsis: "Grassman Cayley and Clifford formalisations"
 tags: [


### PR DESCRIPTION
@thery This fix the Coq version as it seems incompatible with Coq 8.12.
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-geometric-algebra.0.8.11 coq.8.12.0
Return code
7936
Duration
11 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.12.0      Formal proof management system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.10.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.10.0      Official release 4.10.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.12.0).
The following actions will be performed:
  - install coq-geometric-algebra 0.8.11
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-geometric-algebra.0.8.11: http]
[coq-geometric-algebra.0.8.11] downloaded from https://github.com/thery/GeometricAlgebra/archive/v8,11.zip
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-geometric-algebra: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-geometric-algebra.0.8.11)
- /home/bench/.opam/ocaml-base-compiler.4.10.0/bin//coq_makefile -f _CoqProject -o Makefile.coq
- COQDEP VFILES
- COQC Aux.v
- COQC Field.v
- File "./Field.v", line 344, characters 0-17:
- Error:
- In environment
- p : fparams
- Hp : fparamsProp
- z1, z2 : Z
- HH : forall z1 z2 : Z,
-      (0 <= z1)%Z -> (0 <= z2)%Z -> Z_to_K (z1 + z2) = Z_to_K z1 + Z_to_K z2
- HH1 : forall z1 z2 : Z,
-       (0 <= z1 <= z2)%Z -> Z_to_K (z2 - z1) = Z_to_K z2 + - Z_to_K z1
- Unable to unify "Z.abs_nat ?M1610 <= Z.abs_nat ?M1611" with
-  "Z_to_K (z1 + z2) = Z_to_K z1 + Z_to_K z2".
- 
- make[1]: *** [Makefile.coq:716: Field.vo] Error 1
- make: *** [Makefile.coq:339: all] Error 2
[ERROR] The compilation of coq-geometric-algebra failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-geometric-algebra.0.8.11 =======================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-geometric-algebra.0.8.11
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-geometric-algebra-27211-865888.env
# output-file          ~/.opam/log/coq-geometric-algebra-27211-865888.out
### output ###
# [...]
# p : fparams
# Hp : fparamsProp
# z1, z2 : Z
# HH : forall z1 z2 : Z,
#      (0 <= z1)%Z -> (0 <= z2)%Z -> Z_to_K (z1 + z2) = Z_to_K z1 + Z_to_K z2
# HH1 : forall z1 z2 : Z,
#       (0 <= z1 <= z2)%Z -> Z_to_K (z2 - z1) = Z_to_K z2 + - Z_to_K z1
# Unable to unify "Z.abs_nat ?M1610 <= Z.abs_nat ?M1611" with
#  "Z_to_K (z1 + z2) = Z_to_K z1 + Z_to_K z2".
# 
# make[1]: *** [Makefile.coq:716: Field.vo] Error 1
# make: *** [Makefile.coq:339: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-geometric-algebra 0.8.11
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-geometric-algebra.0.8.11 coq.8.12.0' failed.
```