### PR TITLE
Fix Coq version for coq-poltac.0.8.11

### DIFF
--- a/released/packages/coq-poltac/coq-poltac.0.8.11/opam
+++ b/released/packages/coq-poltac/coq-poltac.0.8.11/opam
@@ -11,7 +11,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.11~"}
+  "coq" {>= "8.11~" & < "8.12"}
 ]
 synopsis:
   "A set of tactics to deal with inequalities in Coq over N, Z and R:"


### PR DESCRIPTION
@thery Similarly, fix the Coq version as this seems not compatible with Coq 8.12.
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-poltac.0.8.11 coq.8.12.0
Return code
7936
Duration
16 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.12.0      Formal proof management system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.10.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.10.0      Official release 4.10.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.12.0).
The following actions will be performed:
  - install coq-poltac 0.8.11
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-poltac.0.8.11: http]
[coq-poltac.0.8.11] downloaded from https://github.com/thery/PolTac/archive/v8.11.zip
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  2/2: [coq-poltac: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "install" "make" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-poltac.0.8.11)
- /home/bench/.opam/ocaml-base-compiler.4.10.0/bin/coq_makefile -f _CoqProject -o Makefile.coq
- COQDEP VFILES
- COQC NatAux.v
- COQC NatGroundTac.v
- COQC NatSignTac.v
- COQC NAux.v
- COQC NGroundTac.v
- COQC NSignTac.v
- COQC ZAux.v
- File "./ZAux.v", line 72, characters 0-42:
- Error: No such goal.
- 
- make[1]: *** [Makefile.coq:716: ZAux.vo] Error 1
- make: *** [Makefile.coq:339: all] Error 2
[ERROR] The installation of coq-poltac failed at "make".
#=== ERROR while installing coq-poltac.0.8.11 =================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-poltac.0.8.11
# command              ~/.opam/opam-init/hooks/sandbox.sh install make
# exit-code            2
# env-file             ~/.opam/log/coq-poltac-19474-865888.env
# output-file          ~/.opam/log/coq-poltac-19474-865888.out
### output ###
# [...]
# COQC NatAux.v
# COQC NatGroundTac.v
# COQC NatSignTac.v
# COQC NAux.v
# COQC NGroundTac.v
# COQC NSignTac.v
# COQC ZAux.v
# File "./ZAux.v", line 72, characters 0-42:
# Error: No such goal.
# 
# make[1]: *** [Makefile.coq:716: ZAux.vo] Error 1
# make: *** [Makefile.coq:339: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - install coq-poltac 0.8.11
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-poltac.0.8.11 coq.8.12.0' failed.
```