### PR TITLE
Fix Coq version for coq-coqprime

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.3/opam
@@ -15,7 +15,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqprime"]
 depends: [
   "ocaml"
-  "coq" {>= "8.8~"}
+  "coq" {>= "8.8~" & < "8.12"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.4/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.4/opam
@@ -14,7 +14,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Coqprime"]
 depends: [
   "ocaml"
-  "coq" {>= "8.10~"}
+  "coq" {>= "8.10~" & < "8.12"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"

--- a/released/packages/coq-coqprime/coq-coqprime.1.0.5/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.5/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.10~"}
+  "coq" {>= "8.10~" & < "8.12"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
@thery Also some issues with Coq 8.12. Install trace for the 1.0.3 version:
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-coqprime.1.0.3 coq.8.12.0
Return code
7936
Duration
12 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.12.0      Formal proof management system
coq-bignums         8.12.0      Bignums, the Coq library of arbitrary large numbers
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.10.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.10.0      Official release 4.10.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.12.0).
The following actions will be performed:
  - install coq-coqprime 1.0.3
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-coqprime.1.0.3: http]
[coq-coqprime.1.0.3] downloaded from https://github.com/thery/coqprime/archive/v8.8.zip
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-coqprime: ./configure.sh]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-coqprime.1.0.3)
Processing  1/2: [coq-coqprime: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-coqprime.1.0.3)
- COQDEP VFILES
- COQC src/Coqprime/Tactic/Tactic.v
- COQC src/Coqprime/N/NatAux.v
- COQC src/Coqprime/Z/ZCmisc.v
- COQC src/Coqprime/Z/Zmod.v
- COQC src/Coqprime/Z/Ppow.v
- File "./src/Coqprime/Z/Ppow.v", line 24, characters 5-22:
- Error: Found no subterm matching "2 * Z.pos ?M1461" in the current goal.
- 
- make[1]: *** [Makefile:715: src/Coqprime/Z/Ppow.vo] Error 1
- make[1]: *** Waiting for unfinished jobs....
- COQC src/Coqprime/num/Bits.v
- File "./src/Coqprime/Z/ZCmisc.v", line 65, characters 1-13:
- Error: No such hypothesis: H1
- 
- make[1]: *** [Makefile:715: src/Coqprime/Z/ZCmisc.vo] Error 1
- File "./src/Coqprime/num/Bits.v", line 16, characters 0-3:
- Error: No head constant to reduce.
- 
- make[1]: *** [Makefile:715: src/Coqprime/num/Bits.vo] Error 1
- make: *** [Makefile:339: all] Error 2
[ERROR] The compilation of coq-coqprime failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-coqprime.1.0.3 =================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-coqprime.1.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-coqprime-23371-e4db2f.env
# output-file          ~/.opam/log/coq-coqprime-23371-e4db2f.out
### output ###
# [...]
# make[1]: *** [Makefile:715: src/Coqprime/Z/Ppow.vo] Error 1
# make[1]: *** Waiting for unfinished jobs....
# COQC src/Coqprime/num/Bits.v
# File "./src/Coqprime/Z/ZCmisc.v", line 65, characters 1-13:
# Error: No such hypothesis: H1
# 
# make[1]: *** [Makefile:715: src/Coqprime/Z/ZCmisc.vo] Error 1
# File "./src/Coqprime/num/Bits.v", line 16, characters 0-3:
# Error: No head constant to reduce.
# 
# make[1]: *** [Makefile:715: src/Coqprime/num/Bits.vo] Error 1
# make: *** [Makefile:339: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-coqprime 1.0.3
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-coqprime.1.0.3 coq.8.12.0' failed.
```