### PR TITLE
Fix Coq version for 8.12 and coq-menhirlib

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
@@ -14,7 +14,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.7" }
+  "coq" { >= "8.7" & < "8.12" }
 ]
 conflicts: [
   "menhir" { != "20190924" }

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200123/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200123/opam
@@ -15,7 +15,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.7" }
+  "coq" { >= "8.7" & < "8.12" }
 ]
 conflicts: [
   "menhir" { != "20200123" }

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200211/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200211/opam
@@ -15,7 +15,7 @@ install: [
   [make "-C" "coq-menhirlib" "install"]
 ]
 depends: [
-  "coq" { >= "8.7" }
+  "coq" { >= "8.7" & < "8.12" }
 ]
 conflicts: [
   "menhir" { != "20200211" }


### PR DESCRIPTION
@jhjourdan Due to Coq 8.12. The latest versions of Menhir work. Sample trace:
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-menhirlib.20200211 coq.8.12.0
Return code
7936
Duration
9 s
Output
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-threads        base
base-unix           base
conf-findutils      1           Virtual package relying on findutils
conf-m4             1           Virtual package relying on m4
coq                 8.12.0      Formal proof management system
num                 1.3         The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.10.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.10.0      Official release 4.10.0
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.8.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.12.0).
The following actions will be performed:
  - install coq-menhirlib 20200211
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-menhirlib.20200211: http]
[coq-menhirlib.20200211] downloaded from https://gitlab.inria.fr/fpottier/menhir/repository/20200211/archive.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-menhirlib: make coq-menhirlib]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-C" "coq-menhirlib" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211)
- make: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib'
- Compiling Alphabet...
- Compiling Version...
- File "/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib/src/Alphabet.v", line 181, characters 28-29:
- Error:
- Syntax error: [constr:operconstr level 200] expected after '(' (in [constr:operconstr]).
- 
- make[2]: *** [Makefile.coq:152: /home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib/src/Alphabet.vo] Error 1
- make[1]: *** [Makefile:10: all] Error 2
- make: *** [Makefile:6: all] Error 2
- make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib'
[ERROR] The compilation of coq-menhirlib failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -C coq-menhirlib -j4".
#=== ERROR while compiling coq-menhirlib.20200211 =============================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C coq-menhirlib -j4
# exit-code            2
# env-file             ~/.opam/log/coq-menhirlib-13453-0a5907.env
# output-file          ~/.opam/log/coq-menhirlib-13453-0a5907.out
### output ###
# make: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib'
# Compiling Alphabet...
# Compiling Version...
# File "/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib/src/Alphabet.v", line 181, characters 28-29:
# Error:
# Syntax error: [constr:operconstr level 200] expected after '(' (in [constr:operconstr]).
# 
# make[2]: *** [Makefile.coq:152: /home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib/src/Alphabet.vo] Error 1
# make[1]: *** [Makefile:10: all] Error 2
# make: *** [Makefile:6: all] Error 2
# make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.0/.opam-switch/build/coq-menhirlib.20200211/coq-menhirlib'
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-menhirlib 20200211
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-menhirlib.20200211 coq.8.12.0' failed.
```