### PR TITLE
Update dependencies of coq-prosa.dev

### DIFF
--- a/extra-dev/packages/coq-prosa/coq-prosa.dev/opam
+++ b/extra-dev/packages/coq-prosa/coq-prosa.dev/opam
@@ -12,8 +12,8 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {((>= "8.9" & < "8.12~") | = "dev")}
-  "coq-mathcomp-ssreflect" {((>= "1.9" & < "1.11~") | = "dev")}
+  "coq" {((>= "8.11" & < "8.13~") | = "dev")}
+  "coq-mathcomp-ssreflect" {((>= "1.10" & < "1.12~") | = "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
There is also a coq-prosa in released not compatible with Coq >= 8.11, this would require a release upstream (WIP)