### PR TITLE
metacoq 1.0~beta1+8.11 packages

### DIFF
--- a/released/packages/coq-metacoq-checker/coq-metacoq-checker.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-checker/coq-metacoq-checker.1.0~beta1+8.11/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "checker"]
+]
+install: [
+  [make "-C" "checker" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-equations" { >= "1.2.3" }
+  "coq-metacoq-template" {= version}
+]
+synopsis: "Specification of Coq's type theory and reference checker implementation"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Checker module provides a complete specification of Coq's typing and conversion
+relation along with a reference type-checker that is extracted to a pluging.
+
+This provides a command: `MetaCoq Check [global_reference]` that can be used
+to typecheck a Coq definition using the verified type-checker.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta1+8.11/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "erasure"]
+]
+install: [
+  [make "-C" "erasure" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-checker" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Erasure module provides a complete specification of Coq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta1+8.11/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "pcuic"]
+]
+install: [
+  [make "-C" "pcuic" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-equations" {>= "1.2.3"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-checker" {= version}
+]
+synopsis: "A type system equivalent to Coq's and its metatheory"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The PCUIC module provides a cleaned-up specification of Coq's typing algorithm along
+with a certified typechecker for it. This module includes the standard metatheory of
+PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta1+8.11/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "safechecker"]
+]
+install: [
+  [make "-C" "safechecker" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-checker" {= version}
+  "coq-metacoq-pcuic" {= version}
+]
+synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The SafeChecker modules provides a correct implementation of
+weak-head reduction, conversion and typechecking of Coq definitions and global environments.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta1+8.11/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "template-coq"]
+]
+install: [
+  [make "-C" "template-coq" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.10"}
+  "coq" {>= "8.11" & < "8.12~"}
+]
+synopsis: "A quoting and unquoting library for Coq in Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+Template Coq is a quoting library for Coq. It takes Coq terms and
+constructs a representation of their syntax tree as a Coq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Coq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaCoq/MTac.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "translations"]
+]
+install: [
+  [make "-C" "translations" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-checker" {= version}
+]
+synopsis: "Translations built on top of MetaCoq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Translations modules provides implementation of standard translations 
+from type theory to type theory, e.g. parametricity and the `cross-bool` 
+translation that invalidates functional extensionality.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta1+8.11/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-checker" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+  "coq-metacoq-erasure" {= version}
+  "coq-metacoq-translations" {= version}
+]
+synopsis: "A meta-programming framework for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The meta-package includes the template-coq library, unverified checker for Coq,
+PCUIC development including a verified translation from Coq to PCUIC, 
+safe checker and erasure for PCUIC and example translations. 
+
+See individual packages for more detailed descriptions.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta1-8.11.tar.gz"
+  checksum: "sha256=1644c5bd9d02385c802535c6c46dbcaf279afcecd4ffb3da5fae08618c628c75"
+}


### PR DESCRIPTION
ci-skip: coq-metacoq-checker.1.0~beta1+8.11 coq-metacoq-template.1.0~beta1+8.11 coq-metacoq-pcuic.1.0~beta1+8.11 coq-metacoq-safechecker.1.0~beta1+8.11 coq-metacoq-erasure.1.0~beta1+8.11 coq-metacoq-translations.1.0~beta1+8.11

Tested with ocaml 4.10.1. @vzaliva does that work for you ? I'll make 8.12 packages too