### PR TITLE
Upgrade bound on `zarith`

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind" {build}
   "num"
   "conf-findutils" {build}
-  "zarith" { >= "1.9.1" }
+  "zarith" { >= "1.10" }
 ]
 build: [
   [


### PR DESCRIPTION
Apparently `coq.dev` now fails without `1.10`.
See e.g. https://travis-ci.org/github/Mtac2/Mtac2/builds/729658147#L664. Reported by @beta-ziliani on Zulip.