### PR TITLE
Fix remake for XCode 12 on Mac

### DIFF
--- a/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/files/remake.patch
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 3a6af80..47d5be8 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -786,7 +786,7 @@ struct log
+ 	}
+ };
+ 
+-static log debug;
++static struct log debug;
+ 
+ struct log_auto_close
+ {

--- a/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/opam
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/opam
@@ -4,6 +4,9 @@ homepage: "http://coquelicot.saclay.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/coquelicot/coquelicot.git"
 bug-reports: "https://gitlab.inria.fr/coquelicot/coquelicot/issues"
 license: "LGPL-3.0-or-later"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]

--- a/released/packages/coq-flocq/coq-flocq.3.3.1/files/remake.patch
+++ b/released/packages/coq-flocq/coq-flocq.3.3.1/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 56a3c2f..e7bcbcd 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -800,7 +800,7 @@ struct log
+ 	}
+ };
+ 
+-static log debug;
++static struct log debug;
+ 
+ struct log_auto_close
+ {

--- a/released/packages/coq-flocq/coq-flocq.3.3.1/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.3.1/opam
@@ -4,6 +4,9 @@ homepage: "http://flocq.gforge.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/flocq/flocq.git"
 bug-reports: "https://gitlab.inria.fr/flocq/flocq/issues"
 license: "LGPL-3.0-or-later"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/files/remake.patch
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 3a6af80..47d5be8 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -786,7 +786,7 @@ struct log
+ 	}
+ };
+ 
+-static log debug;
++static struct log debug;
+ 
+ struct log_auto_close
+ {

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/opam
@@ -4,6 +4,9 @@ homepage: "http://gappa.gforge.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
 bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL-3.0-or-later"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]

--- a/released/packages/coq-interval/coq-interval.4.0.0/files/remake.patch
+++ b/released/packages/coq-interval/coq-interval.4.0.0/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 3a6af80..47d5be8 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -786,7 +786,7 @@ struct log
+ 	}
+ };
+ 
+-static log debug;
++static struct log debug;
+ 
+ struct log_auto_close
+ {

--- a/released/packages/coq-interval/coq-interval.4.0.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.0.0/opam
@@ -4,6 +4,9 @@ homepage: "http://coq-interval.gforge.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/coqinterval/interval.git"
 bug-reports: "https://gitlab.inria.fr/coqinterval/interval/issues"
 license: "CeCILL-C"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]


### PR DESCRIPTION
After the update to XCode 12 on Mac the build tool remake does not compile anymore.

This patches remake to fix this. The patch works on all platforms.

This has been discussed by email with @coq/windows-build-maintainers 

The version of the opam packages does not change since there is no change in the installed coq packages.