### PR TITLE
Add latest version of UniCoq and Mtac2

### DIFF
--- a/released/packages/coq-mtac2/coq-mtac2.1.3+8.12/opam
+++ b/released/packages/coq-mtac2/coq-mtac2.1.3+8.12/opam
@@ -18,6 +18,10 @@ depends: [
   "coq-unicoq" {>= "1.5" & < "2~"}
 ]
 synopsis: "Mtac2: Typed Tactics for Coq"
+tags: [
+  "logpath:Mtac2"
+  "date:2020-08-19"
+]
 url {
   src: "https://github.com/Mtac2/Mtac2/archive/v1.3-coq8.12.tar.gz"
   checksum: "sha512=6d17c5916cacf24d10a55bc0c84d31cb3e8f3d7458586d98f4734f0d7bb9b8d2be88ada15537aaada478a9f844692f5d271f8b7e721743c70272fa44ffd47ac8"

--- a/released/packages/coq-mtac2/coq-mtac2.1.3+8.12/opam
+++ b/released/packages/coq-mtac2/coq-mtac2.1.3+8.12/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "beta.ziliani@gmail.com"
+homepage: "https://github.com/Mtac2/Mtac2"
+dev-repo: "git+https://github.com/Mtac2/Mtac2.git"
+bug-reports: "https://github.com/Mtac2/Mtac2/issues"
+authors: ["Beta Ziliani <beta.ziliani@gmail.com>" "Jan-Oliver Kaiser <janno@mpi-sws.org>" "Robbert Krebbers <mail@robbertkrebbers.nl>" "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>" "Derek Dreyer <dreyer@mpi-sws.org>"]
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12.0" & < "8.13~"}
+  "coq-unicoq" {>= "1.5" & < "2~"}
+]
+synopsis: "Mtac2: Typed Tactics for Coq"
+url {
+  src: "https://github.com/Mtac2/Mtac2/archive/v1.3-coq8.12.tar.gz"
+  checksum: "sha512=6d17c5916cacf24d10a55bc0c84d31cb3e8f3d7458586d98f4734f0d7bb9b8d2be88ada15537aaada478a9f844692f5d271f8b7e721743c70272fa44ffd47ac8"
+}

--- a/released/packages/coq-unicoq/coq-unicoq.1.5+8.12/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.5+8.12/opam
@@ -17,6 +17,10 @@ depends: [
   "coq" {>= "8.12.0" & < "8.13~"}
 ]
 synopsis: "An enhanced unification algorithm for Coq"
+tags: [
+  "logpath:Unicoq"
+  "date:2020-08-12"
+]
 url {
   src: "https://github.com/unicoq/unicoq/archive/v1.5-8.12.tar.gz"
   checksum: "sha512=c2326af1972ddf0f34e6f2c81426882a332729a3d7f8a9c6cbffb23f85fa5b61d747adfa1cd149c05640e2c329945ab7405620eb80c9c3f6744aaf01f3ee8c1f"

--- a/released/packages/coq-unicoq/coq-unicoq.1.5+8.12/opam
+++ b/released/packages/coq-unicoq/coq-unicoq.1.5+8.12/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Beta Ziliani <beta@mpi-sws.org>" ]
+dev-repo: "git+https://github.com/unicoq/unicoq.git"
+homepage: "https://github.com/unicoq/unicoq"
+bug-reports: "https://github.com/unicoq/unicoq/issues"
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12.0" & < "8.13~"}
+]
+synopsis: "An enhanced unification algorithm for Coq"
+url {
+  src: "https://github.com/unicoq/unicoq/archive/v1.5-8.12.tar.gz"
+  checksum: "sha512=c2326af1972ddf0f34e6f2c81426882a332729a3d7f8a9c6cbffb23f85fa5b61d747adfa1cd149c05640e2c329945ab7405620eb80c9c3f6744aaf01f3ee8c1f"
+}


### PR DESCRIPTION
This command adds opam packages for the latest version of UniCoq and Mtac2.

This are plain unmodified tag versions.