### PR TITLE
Adjust menhirlib opam files to Cygwin MinGW builds

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190924/files/0001-Adjust-make-to-cygwin-mingw-cross-builds.patch
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190924/files/0001-Adjust-make-to-cygwin-mingw-cross-builds.patch
@@ -1,0 +1,66 @@
+From 670b368c226f52a2f660810083dbc13f0554dbd3 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 26 Jul 2020 21:33:15 +0200
+Subject: [PATCH] Adjust make to cygwin mingw cross builds
+
+---
+ coq-menhirlib/src/Makefile     |  4 ++--
+ coq-menhirlib/src/Makefile.coq | 13 ++-----------
+ 2 files changed, 4 insertions(+), 13 deletions(-)
+
+diff --git a/coq-menhirlib/src/Makefile b/coq-menhirlib/src/Makefile
+index bb04f20f..2003662b 100644
+--- a/coq-menhirlib/src/Makefile
++++ b/coq-menhirlib/src/Makefile
+@@ -1,6 +1,6 @@
+ PWD := $(shell pwd)
+ 
+-COQINCLUDE := -R $(PWD) MenhirLib \
++COQINCLUDE := -R . MenhirLib \
+ 
+ export
+ 
+@@ -24,7 +24,7 @@ clean:
+ # A nonempty value can be used to perform a dummy installation
+ # in a different location.
+ 
+-CONTRIB := $(shell $(COQBIN)coqc -where)/user-contrib
++CONTRIB := $(shell $(COQBIN)coqc -where  | tr -d '\r' | tr '\\' '/')/user-contrib
+ TARGET  := $(DESTDIR)$(CONTRIB)/MenhirLib
+ 
+ install: all
+diff --git a/coq-menhirlib/src/Makefile.coq b/coq-menhirlib/src/Makefile.coq
+index c530fa91..f272c8ee 100644
+--- a/coq-menhirlib/src/Makefile.coq
++++ b/coq-menhirlib/src/Makefile.coq
+@@ -11,7 +11,7 @@ SHELL := /usr/bin/env bash
+ #
+ #
+ # This Makefile relies on the following variables:
+-# ROOTDIR    (default: `pwd`)
++# ROOTDIR    (default: .)
+ # COQBIN     (default: empty)
+ # COQINCLUDE (default: empty)
+ # VV         (default: *.v)
+@@ -22,17 +22,8 @@ SHELL := /usr/bin/env bash
+ # VERBOSE    (default: undefined)
+ #            (if defined, commands are displayed)
+ 
+-# We usually refer to the .v files using relative paths (such as Foo.v)
+-# but [coqdep -R] produces dependencies that refer to absolute paths
+-# (such as /bar/Foo.v). This confuses [make], which does not recognize
+-# that these files are the same. As a result, [make] does not respect
+-# the dependencies.
+-
+-# We fix this by using ABSOLUTE PATHS EVERYWHERE. The paths used in targets,
+-# in -R options, etc., must be absolute paths.
+-
+ ifndef ROOTDIR
+-	ROOTDIR := $(shell pwd)
++	ROOTDIR := .
+ endif
+ 
+ ifndef VV
+-- 
+2.27.0
+

--- a/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
@@ -10,6 +10,12 @@ bug-reports: "jacques-henri.jourdan@lri.fr"
 build: [
   [make "-C" "coq-menhirlib" "-j%{jobs}%"]
 ]
+patches: [
+  "0001-Adjust-make-to-cygwin-mingw-cross-builds.patch"
+]
+extra-files: [
+  ["0001-Adjust-make-to-cygwin-mingw-cross-builds.patch" "sha512=785e48a7d78cdc5a822adad057d69caa232cf9a62dd2402d3b3f0cd768c6d1417c74460e5866f80d8cd2c1edcc8b24b8f8432f916a291daef251bbb75b21ecdd"]
+]
 install: [
   [make "-C" "coq-menhirlib" "install"]
 ]

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200624/files/0001-Adjust-make-to-cygwin-mingw-cross-builds.patch
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200624/files/0001-Adjust-make-to-cygwin-mingw-cross-builds.patch
@@ -1,0 +1,56 @@
+From 3a66583a4f4bcbf728f9509675c2bcc9735c1174 Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Sun, 26 Jul 2020 21:33:15 +0200
+Subject: [PATCH] Adjust make to cygwin mingw cross builds
+
+---
+ coq-menhirlib/src/Makefile     | 4 ++--
+ coq-menhirlib/src/Makefile.coq | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/coq-menhirlib/src/Makefile b/coq-menhirlib/src/Makefile
+index 426e5d50..28ab0adb 100644
+--- a/coq-menhirlib/src/Makefile
++++ b/coq-menhirlib/src/Makefile
+@@ -1,6 +1,6 @@
+ PWD := $(shell pwd)
+ 
+-COQINCLUDE := -R $(PWD) MenhirLib \
++COQINCLUDE := -R . MenhirLib \
+ 
+ export COQINCLUDE
+ 
+@@ -22,7 +22,7 @@ clean:
+ # A nonempty value can be used to perform a dummy installation
+ # in a different location.
+ 
+-CONTRIB = $(shell $(COQBIN)coqc -where)/user-contrib
++CONTRIB = $(shell $(COQBIN)coqc -where  | tr -d '\r' | tr '\\' '/')/user-contrib
+ TARGET  = $(DESTDIR)$(CONTRIB)/MenhirLib
+ 
+ install: all
+diff --git a/coq-menhirlib/src/Makefile.coq b/coq-menhirlib/src/Makefile.coq
+index c530fa91..b1543069 100644
+--- a/coq-menhirlib/src/Makefile.coq
++++ b/coq-menhirlib/src/Makefile.coq
+@@ -11,7 +11,7 @@ SHELL := /usr/bin/env bash
+ #
+ #
+ # This Makefile relies on the following variables:
+-# ROOTDIR    (default: `pwd`)
++# ROOTDIR    (default: .)
+ # COQBIN     (default: empty)
+ # COQINCLUDE (default: empty)
+ # VV         (default: *.v)
+@@ -32,7 +32,7 @@ SHELL := /usr/bin/env bash
+ # in -R options, etc., must be absolute paths.
+ 
+ ifndef ROOTDIR
+-	ROOTDIR := $(shell pwd)
++	ROOTDIR := .
+ endif
+ 
+ ifndef VV
+-- 
+2.27.0
+

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
@@ -11,6 +11,12 @@ license: "LGPL-3.0-or-later"
 build: [
   [make "-C" "coq-menhirlib" "-j%{jobs}%"]
 ]
+patches: [
+  "0001-Adjust-make-to-cygwin-mingw-cross-builds.patch"
+]
+extra-files: [
+  ["0001-Adjust-make-to-cygwin-mingw-cross-builds.patch" "sha512=9cbff58064e5eea3607932fdd5cc183e879c01cafc9443273fb1a58f3e3e5af553112b32c1d596ca17a902d2538f42a45bce60b611c77b1e0640b87632f2b56c"]
+]
 install: [
   [make "-C" "coq-menhirlib" "install"]
 ]


### PR DESCRIPTION
The menhirlib make files unnecessarily use absolute paths. This does not work in Cygwin MinGW cross builds, where Cygwin and MinGW executables are mixed. Since these have different ideas of absolute path names, one has to use relative paths.

The patch is tested on Cygwin/MinGW, Linux and Mac (as port of the Coq platform since a while).