### PR TITLE
metacoq-translations 1.0~beta1 depends on the time command during build

### DIFF
--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
@@ -20,6 +20,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.11" & < "8.12~"}
+  "conf-time" {build}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}
 ]

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.12/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.12/opam
@@ -20,6 +20,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.12" & < "8.13~"}
+  "conf-time" {build}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}
 ]


### PR DESCRIPTION
Due to the following in the Makefile, the build for metacoq-translations depends on the `time` command:
```make
all: Makefile.coq
        $(MAKE) -f Makefile.coq pretty-timed
```
This adds the corresponding `conf-time` build dependency.