### PR TITLE
Fix dependencies of coq-switch.1.0.2

### DIFF
--- a/released/packages/coq-switch/coq-switch.1.0.2/opam
+++ b/released/packages/coq-switch/coq-switch.1.0.2/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.10.2"}
-  "coq-metacoq-template" {>= "1.0~alpha2+8.10"}
+  "coq-metacoq-template" {>= "1.0~alpha2+8.10" & < "1.0~beta1"}
 ]
 tags: [
   "category:Miscellaneous/Coq Extensions"


### PR DESCRIPTION
@vzaliva Example of error: https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.11.1/switch/1.0.2.html :
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-switch.1.0.2 coq.8.11.1
Return code
7936
Duration
9 s
Output
# Packages matching: installed
# Name               # Installed    # Synopsis
base-bigarray        base
base-threads         base
base-unix            base
conf-findutils       1              Virtual package relying on findutils
conf-m4              1              Virtual package relying on m4
coq                  8.11.1         Formal proof management system
coq-metacoq-template 1.0~beta1+8.11 A quoting and unquoting library for Coq in Coq
num                  1.3            The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                4.09.1         The OCaml compiler (virtual package)
ocaml-base-compiler  4.09.1         Official release 4.09.1
ocaml-config         1              OCaml Switch Configuration
ocamlfind            1.8.1          A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.1).
The following actions will be performed:
  - install coq-switch 1.0.2
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-switch.1.0.2: http]
[coq-switch.1.0.2] downloaded from https://github.com/vzaliva/coq-switch/archive/v1.0.2.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-switch: make]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-switch.1.0.2)
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-switch.1.0.2'
- COQDEP VFILES
- COQC theories/Switch.v
- File "./theories/Switch.v", line 18, characters 19-28:
- Error:
- In environment
- mkSwitchCases : string -> term -> term -> list term -> nat -> term
- type_name : string
- A_t : term
- P_t : term
- choices_t : list term
- n : nat
- ind_0 := fun n : kername => {| inductive_mind := n; inductive_ind := 0 |} :
- kername -> inductive
- The term "type_name" has type "string" while it is expected to have type
-  "kername".
- 
- make[2]: *** [Makefile.coq:678: theories/Switch.vo] Error 1
- make[1]: *** [Makefile.coq:327: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-switch.1.0.2'
- make: *** [Makefile:2: all] Error 2
[ERROR] The compilation of coq-switch failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
#=== ERROR while compiling coq-switch.1.0.2 ===================================#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-switch.1.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
# exit-code            2
# env-file             ~/.opam/log/coq-switch-31819-865888.env
# output-file          ~/.opam/log/coq-switch-31819-865888.out
### output ###
# [...]
# P_t : term
# choices_t : list term
# n : nat
# ind_0 := fun n : kername => {| inductive_mind := n; inductive_ind := 0 |} :
# kername -> inductive
# The term "type_name" has type "string" while it is expected to have type
#  "kername".
# 
# make[2]: *** [Makefile.coq:678: theories/Switch.vo] Error 1
# make[1]: *** [Makefile.coq:327: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-switch.1.0.2'
# make: *** [Makefile:2: all] Error 2
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-switch 1.0.2
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-switch.1.0.2 coq.8.11.1' failed.
```

I guess this is related to the latest release of metacoq.