### PR TITLE
Update bounds of coq-bbv.dev

### DIFF
--- a/extra-dev/packages/coq-bbv/coq-bbv.dev/opam
+++ b/extra-dev/packages/coq-bbv/coq-bbv.dev/opam
@@ -27,7 +27,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.9" & < "8.12~"}
+  "coq" {((>= "8.9" & < "8.13~") | = "dev")}
 ]
 synopsis: "An implementation of bitvectors in Coq."
 url {


### PR DESCRIPTION
Current master https://github.com/mit-plv/bbv/commit/3d3275d7c110db7d9dd04c07c35c49fb2799c798 successfully compiles with coq 8.9 through 8.12 and with dev using the coqorg/coq:dev docker image.