### PR TITLE
Fix deps of coq-metacoq-translations.1.0~beta1+8.11

### DIFF
--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.11/opam
@@ -20,6 +20,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.11" & < "8.12~"}
+  "conf-python-3" {build}
   "conf-time" {build}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.12/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta1+8.12/opam
@@ -20,6 +20,7 @@ install: [
 depends: [
   "ocaml" {>= "4.07.1"}
   "coq" {>= "8.12" & < "8.13~"}
+  "conf-python-3" {build}
   "conf-time" {build}
   "coq-metacoq-template" {= version}
   "coq-metacoq-checker" {= version}


### PR DESCRIPTION
It seems that metacoq-translations 1.0~beta1+8.11 requires Python3. @mattam82  https://coq-bench.github.io/clean/Linux-x86_64-4.10.1-2.0.6/released/8.11.2/metacoq-translations/1.0~beta1%2B8.11.html
```
Command
opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-metacoq-translations.1.0~beta1+8.11 coq.8.11.2
Return code
7936
Duration
1 m 41 s
Output
# Packages matching: installed
# Name               # Installed    # Synopsis
base-bigarray        base
base-threads         base
base-unix            base
conf-findutils       1              Virtual package relying on findutils
conf-m4              1              Virtual package relying on m4
conf-time            1              Virtual package relying on the "time" command
conf-which           1              Virtual package relying on which
coq                  8.11.2         Formal proof management system
coq-equations        1.2.3+8.11     A function definition package for Coq
coq-metacoq-checker  1.0~beta1+8.11 Specification of Coq's type theory and reference checker implementation
coq-metacoq-template 1.0~beta1+8.11 A quoting and unquoting library for Coq in Coq
num                  1.3            The legacy Num library for arbitrary-precision integer and rational arithmetic
ocaml                4.10.1         The OCaml compiler (virtual package)
ocaml-base-compiler  4.10.1         Official release 4.10.1
ocaml-config         1              OCaml Switch Configuration
ocamlfind            1.8.1          A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.11.2).
The following actions will be performed:
  - install coq-metacoq-translations 1.0~beta1+8.11
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[coq-metacoq-translations.1.0~beta1+8.11] found in cache
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-metacoq-translations: sh]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "sh" "./configure.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11)
- make -C template-coq mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/template-coq'
- rm -f Makefile.coq
- rm -f Makefile.plugin
- rm -f Makefile.template
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/template-coq'
- make -C pcuic mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/pcuic'
- rm -f metacoq-config
- rm -f Makefile.plugin _PluginProject
- rm -f Makefile.pcuic _CoqProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/pcuic'
- make -C safechecker mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/safechecker'
- rm -f metacoq-config
- rm -f Makefile.plugin _PluginProject
- rm -f Makefile.safechecker _CoqProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/safechecker'
- make -C erasure mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/erasure'
- rm -f Makefile.plugin
- rm -f Makefile.erasure
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/erasure'
- make -C checker mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/checker'
- rm -f Makefile.coq Makefile.plugin _CoqProject _PluginProject
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/checker'
- make -C examples mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/examples'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/examples'
- make -C test-suite mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/test-suite'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/test-suite'
- make -C translations mrproper
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
- rm -f Makefile.coq
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
- ./configure.sh: 19: [: unexpected operator
- Building MetaCoq globally (default)
Processing  1/2: [coq-metacoq-translations: make translations]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" "-C" "translations" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11)
- make: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
- cat metacoq-config > _CoqProject 
- cat _CoqProject.in >> _CoqProject
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq pretty-timed
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
- COQDEP VFILES
- COQC sigma.v
- COQC MiniHoTT.v
- COQC MiniHoTT_paths.v
- COQC translation_utils.v
- File "./MiniHoTT.v", line 37, characters 0-198:
- Warning: Notation "exists _ .. _ , _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT.v", line 41, characters 0-64:
- Warning: Notation "{ _ : _ & _ }" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT_paths.v", line 41, characters 0-198:
- Warning: Notation "exists _ .. _ , _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT_paths.v", line 45, characters 0-64:
- Warning: Notation "{ _ : _ & _ }" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT.v", line 96, characters 0-37:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope equiv_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT.v", line 98, characters 0-35:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope path_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT.v", line 99, characters 0-45:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope fibration_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT.v", line 100, characters 0-37:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope trunc_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT.v", line 136, characters 0-21:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "./MiniHoTT.v", line 139, characters 0-52:
- Warning: Notation "_ = _ :> _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT.v", line 140, characters 0-45:
- Warning: Notation "_ = _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT_paths.v", line 100, characters 0-37:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope equiv_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT_paths.v", line 102, characters 0-35:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope path_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT_paths.v", line 103, characters 0-45:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope fibration_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT_paths.v", line 104, characters 0-37:
- Warning: Declaring a scope implicitly is deprecated; use in advance an
- explicit "Declare Scope trunc_scope.". [undeclared-scope,deprecated]
- File "./MiniHoTT_paths.v", line 140, characters 0-21:
- Warning: Adding and removing hints in the core database implicitly is
- deprecated. Please specify a hint database.
- [implicit-core-hint-db,deprecated]
- File "./MiniHoTT_paths.v", line 143, characters 0-52:
- Warning: Notation "_ = _ :> _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./MiniHoTT_paths.v", line 144, characters 0-45:
- Warning: Notation "_ = _" was already used in scope type_scope.
- [notation-overridden,parsing]
- sigma (real: 6.29, user: 1.08, sys: 0.22, mem: 495872 ko)
- translation_utils (real: 10.37, user: 2.13, sys: 0.18, mem: 540600 ko)
- COQC param_cheap_packed.v
- COQC param_binary.v
- MiniHoTT_paths (real: 14.85, user: 3.25, sys: 0.11, mem: 351960 ko)
- COQC standard_model.v
- MiniHoTT (real: 17.20, user: 3.48, sys: 0.13, mem: 352748 ko)
- COQC param_original.v
- Coq.Init.Datatypes.nat has been translated.
- Coq.Init.Datatypes.list has been translated.
- listᵗ : forall A : TYPE, list A.1 -> Type
-      : forall A : TYPE, list A.1 -> Type
- nilᵗ : forall A : TYPE, listᵗ A []
-      : forall A : TYPE, listᵗ A []
- consᵗ
- :
- forall (A : TYPE) (x : El A) (lH : ∃ l : list A.1, listᵗ A l),
- listᵗ A (x.1 :: lH.1)
-      : forall (A : TYPE) (x : El A) (lH : ∃ l : list A.1, listᵗ A l),
-        listᵗ A (x.1 :: lH.1)
- Coq.Init.Datatypes.nat has been translated.
- Coq.Init.Datatypes.bool has been translated.
- param_cheap_packed (real: 11.14, user: 1.81, sys: 0.29, mem: 538352 ko)
- COQC param_generous_packed.v
- check_guarded: true
- check_positive:
[...] truncated
aCoq.Translations.param_generous_packed.808 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.809 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.810 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.811 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.812 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.813 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.814 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.815 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.816 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.817 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.818 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.819 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.820 was added to the context.
- Fresh universe MetaCoq.Translations.param_generous_packed.821 was added to the context.
- "MetaCoq.Translations.MiniHoTT.Equiv has been translated."
- "equiv has been translated as equivᵗ"
- param_generous_packed (real: 32.93, user: 8.82, sys: 0.35, mem: 757036 ko)
- "~~~~~~~~~~~~~~~~~~"
- "Translating Coq.Init.Logic.eq"
- "Coq.Init.Logic.eq was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.paths"
- "MetaCoq.Translations.MiniHoTT.paths was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.Sect"
- "MetaCoq.Translations.MiniHoTT.Sect was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.idpath"
- "MetaCoq.Translations.MiniHoTT.idpath was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.paths_ind"
- "MetaCoq.Translations.MiniHoTT.paths_ind was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.transport"
- "MetaCoq.Translations.MiniHoTT.transport was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.ap"
- "MetaCoq.Translations.MiniHoTT.ap was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.IsEquiv"
- "MetaCoq.Translations.MiniHoTT.IsEquiv was already translated"
- "Translating MetaCoq.Translations.param_original.Axioms.coe"
- "MetaCoq.Translations.param_original.Axioms.coe was already translated"
- "Translating MetaCoq.Translations.param_original.Axioms.Univalence'"
- "MetaCoq.Translations.param_original.Axioms.Univalence' was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.Equiv"
- "MetaCoq.Translations.MiniHoTT.Equiv was already translated"
- "Translating MetaCoq.Translations.MiniHoTT.equiv_fun"
- "equiv_fun has been translated as equiv_funᵗ"
- "Translating MetaCoq.Translations.MiniHoTT.isequiv_idmap"
- "isequiv_idmap has been translated as isequiv_idmapᵗ"
- "Translating MetaCoq.Translations.times_bool_fun.wUnivalence"
- "wUnivalence has been translated as wUnivalenceᵗ"
- "Translating MetaCoq.Translations.MiniHoTT.equiv_idmap"
- "equiv_idmap has been translated as equiv_idmapᵗ"
- "Translating MetaCoq.Translations.param_original.Axioms.equiv_paths"
- "equiv_paths has been translated as equiv_pathsᵗ"
- "Translating MetaCoq.Translations.param_original.Axioms.Univalence"
- "Univalence has been translated as Univalenceᵗ"
- "Translating MetaCoq.Translations.param_original.Axioms.UU'"
- "UU' has been translated as UU'ᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun.647 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.648 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.649 was added to the context.
- "isequiv_idmap has been translated as isequiv_idmapᵗ"
- param_original (real: 56.87, user: 17.07, sys: 0.32, mem: 692224 ko)
- Fresh universe MetaCoq.Translations.times_bool_fun.651 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.652 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.653 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.654 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.655 was added to the context.
- "equiv_idmap has been translated as equiv_idmapᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun.657 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.658 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.659 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.660 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.661 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.662 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.663 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.664 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun.665 was added to the context.
- "UA has been translated as UAᵗ"
- "notUA has been translated as notUAᵗ"
- times_bool_fun (real: 58.55, user: 23.67, sys: 0.41, mem: 850456 ko)
- COQC times_bool_fun2.v
- File "./times_bool_fun2.v", line 4, characters 0-83:
- Warning: Notation "exists _ .. _ , _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./times_bool_fun2.v", line 4, characters 0-83:
- Warning: Notation "{ _ : _ & _ }" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./times_bool_fun2.v", line 4, characters 0-83:
- Warning: Notation "_ = _ :> _" was already used in scope type_scope.
- [notation-overridden,parsing]
- File "./times_bool_fun2.v", line 4, characters 0-83:
- Warning: Notation "_ = _" was already used in scope type_scope.
- [notation-overridden,parsing]
- "paths has been translated as pathsᵗ"
- "idpath has been translated as idpathᵗ"
- "paths_ind has been translated as paths_indᵗ"
- "transport has been translated as transportᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun2.277 was added to the context.
- "sigT has been translated as sigTᵗ"
- "projT1 has been translated as projT1ᵗ"
- "projT2 has been translated as projT2ᵗ"
- "existT has been translated as existTᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun2.389 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.390 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.391 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.392 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.393 was added to the context.
- "isequiv has been translated as isequivᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun2.395 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.396 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.397 was added to the context.
- "equiv has been translated as equivᵗ"
- "eq has been translated as eqᵗ"
- "inverse has been translated as inverseᵗ"
- Fresh universe MetaCoq.Translations.times_bool_fun2.430 was added to the context.
- Fresh universe MetaCoq.Translations.times_bool_fun2.431 was added to the context.
- "contr has been translated as contrᵗ"
- "weakFunext has been translated as weakFunextᵗ"
- times_bool_fun2 (real: 10.31, user: 8.02, sys: 0.28, mem: 572736 ko)
- /usr/bin/env: 'python3': No such file or directory
- make[2]: *** [Makefile.coq:344: print-pretty-timed] Error 127
- make[1]: *** [Makefile.coq:363: pretty-timed] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
- make: *** [Makefile:2: all] Error 2
- make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
[ERROR] The compilation of coq-metacoq-translations failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4 -C translations".
#=== ERROR while compiling coq-metacoq-translations.1.0~beta1+8.11 ============#
# context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.1 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4 -C translations
# exit-code            2
# env-file             ~/.opam/log/coq-metacoq-translations-21744-6d07ae.env
# output-file          ~/.opam/log/coq-metacoq-translations-21744-6d07ae.out
### output ###
# [...]
# "inverse has been translated as inverseᵗ"
# Fresh universe MetaCoq.Translations.times_bool_fun2.430 was added to the context.
# Fresh universe MetaCoq.Translations.times_bool_fun2.431 was added to the context.
# "contr has been translated as contrᵗ"
# "weakFunext has been translated as weakFunextᵗ"
# times_bool_fun2 (real: 10.31, user: 8.02, sys: 0.28, mem: 572736 ko)
# /usr/bin/env: 'python3': No such file or directory
# make[2]: *** [Makefile.coq:344: print-pretty-timed] Error 127
# make[1]: *** [Makefile.coq:363: pretty-timed] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
# make: *** [Makefile:2: all] Error 2
# make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-metacoq-translations.1.0~beta1+8.11/translations'
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-metacoq-translations 1.0~beta1+8.11
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-metacoq-translations.1.0~beta1+8.11 coq.8.11.2' failed.
The middle of the output is truncated (maximum 20000 characters)
```