### PR TITLE
infotheo 0.2 requires analysis 0.3.2

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.2/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.2/opam
@@ -27,7 +27,7 @@ install: [
 depends: [
   "coq" {>= "8.11" & < "8.13~"}
   "coq-mathcomp-field" {>= "1.11" & < "1.12~"}
-  "coq-mathcomp-analysis"   {>= "0.3.2" & < "0.4~"}
+  "coq-mathcomp-analysis"   {>= "0.3.2" & < "0.3.3~"}
 ]
 synopsis: "Infotheo"
 description: """


### PR DESCRIPTION
It seems that the latest version of mathcomp-analysis prevents compilation of infotheo 0.2.