### PR TITLE
Add lens 1.0.1+8.{11,12} (for metacoq 1.0~beta1+8.{11,12})

### DIFF
--- a/released/packages/coq-lens/coq-lens.1.0.1+8.11/opam
+++ b/released/packages/coq-lens/coq-lens.1.0.1+8.11/opam
@@ -20,8 +20,8 @@ depends: [
   "coq-metacoq-template" { = "1.0~beta1+8.11" }
 ]
 tags: [
-  "logpath: Lens"
-  "date: 2020-03-29"
+  "logpath:Lens"
+  "date: 2020-11-18"
 ]
 url {
   src: "https://github.com/bedrocksystems/coq-lens/archive/v1.0.1.tar.gz"

--- a/released/packages/coq-lens/coq-lens.1.0.1+8.11/opam
+++ b/released/packages/coq-lens/coq-lens.1.0.1+8.11/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Generation of lenses for record datatypes"
+maintainer: "gregory@bedrocksystems.com"
+authors: [
+  "Gregory Malecha <gregory@bedrocksystems.com>"
+]
+homepage: "https://github.com/bedrocksystems/coq-lens"
+dev-repo: "git://github.com/bedrocksystems/coq-lens.git"
+bug-reports: "https://github.com/bedrocksystems/coq-lens/issues"
+license: "LGPL2.1+BedRock"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" { = "1.0~beta1+8.11" }
+]
+tags: [
+  "logpath: Lens"
+  "date: 2020-03-29"
+]
+url {
+  src: "https://github.com/bedrocksystems/coq-lens/archive/v1.0.1.tar.gz"
+  checksum: "sha256=c1092aa89e885dd4abe1abc0605474440e8a763569be0accbbf6af4b129b3a91"
+}

--- a/released/packages/coq-lens/coq-lens.1.0.1+8.12/opam
+++ b/released/packages/coq-lens/coq-lens.1.0.1+8.12/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Generation of lenses for record datatypes"
+maintainer: "gregory@bedrocksystems.com"
+authors: [
+  "Gregory Malecha <gregory@bedrocksystems.com>"
+]
+homepage: "https://github.com/bedrocksystems/coq-lens"
+dev-repo: "git://github.com/bedrocksystems/coq-lens.git"
+bug-reports: "https://github.com/bedrocksystems/coq-lens/issues"
+license: "LGPL2.1+BedRock"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12" & < "8.13~"}
+  "coq-metacoq-template" { = "1.0~beta1+8.12" }
+]
+tags: [
+  "logpath: Lens"
+  "date: 2020-03-29"
+]
+url {
+  src: "https://github.com/bedrocksystems/coq-lens/archive/v1.0.1.tar.gz"
+  checksum: "sha256=c1092aa89e885dd4abe1abc0605474440e8a763569be0accbbf6af4b129b3a91"
+}

--- a/released/packages/coq-lens/coq-lens.1.0.1+8.12/opam
+++ b/released/packages/coq-lens/coq-lens.1.0.1+8.12/opam
@@ -20,8 +20,8 @@ depends: [
   "coq-metacoq-template" { = "1.0~beta1+8.12" }
 ]
 tags: [
-  "logpath: Lens"
-  "date: 2020-03-29"
+  "logpath:Lens"
+  "date: 2020-11-18"
 ]
 url {
   src: "https://github.com/bedrocksystems/coq-lens/archive/v1.0.1.tar.gz"


### PR DESCRIPTION
- Add packages for new coq-lens release https://github.com/bedrocksystems/coq-lens/releases/tag/v1.0.1
- Add support for Coq 8.12
- Since a dependency has different release names for Coq 8.11 and 8.12, we do the same.