### PR TITLE
Package coq-menhirlib.20201122

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20201122/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201122/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20201122" }
+]
+tags: [
+  "date:2020-11-22"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20201122/archive.tar.gz"
+  checksum: [
+    "md5=9ad6a5f88aab6ec677b970e0d9de1763"
+    "sha512=9174e74cfb2336c5008c7461411ba79190e673d310da99117e363f60782bcf9a4bb26a04f6448cf6f3ed7888aa2b5b04d38c32e6d86594accfaadbbb72528068"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20201122`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.2