### PR TITLE
require elpi 1.12.0

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
@@ -10,7 +10,7 @@ build: [ make "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 
 depends: [
-  "elpi"
+  "elpi" {>= "1.12.0" }
   "coq" {= "dev"}
 ]
 synopsis: "Elpi extension language for Coq"


### PR DESCRIPTION
The `coq-master` branch no longer compiles with `elpi-1.11.x` so the dev package should require the right version of `elpi` to avoid build failures (cf. https://github.com/coq-community/graph-theory/pull/6/checks?check_run_id=1485483778)

CC: @gares 