### PR TITLE
Mark coq-mathcomp-ssreflect.1.12.0 compatible with upcoming Coq 8.13

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.12.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.12.0/opam
@@ -8,7 +8,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.10" & < "8.13~") | (= "dev"))} ]
+depends: [ "coq" { ((>= "8.10" & < "8.14~") | (= "dev"))} ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
Coq 8.13+beta1 is not yet released, but I propose to update this package from now on (Cc @CohenCyril @affeldt-aist @chdoc)

small accompanying test:

```
$ docker run --rm -it coqorg/coq:8.13 bash -c \
  "opam install --ignore-constraints-on=coq coq-mathcomp-ssreflect.1.12.0 && opam list"

The following actions will be performed:
  - install coq-mathcomp-ssreflect 1.12.0

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[coq-mathcomp-ssreflect.1.12.0] downloaded from https://github.com/math-comp/math-comp/archive/mathcomp-1.12.0.tar.gz

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> installed coq-mathcomp-ssreflect.1.12.0
Done.
# Packages matching: installed
# Name                   # Installed # Synopsis
base-bigarray            base
base-num                 base        Num library distributed with the OCaml compiler
base-threads             base
base-unix                base
conf-findutils           1           Virtual package relying on findutils
conf-gmp                 2           Virtual package relying on a GMP lib system installation
conf-m4                  1           Virtual package relying on m4
conf-perl                1           Virtual package relying on perl
coq                      8.13.dev    pinned to version 8.13.dev at git+https://github.com/coq/coq#e974541
coq-bignums              8.13+beta1  Bignums, the Coq library of arbitrary large numbers
coq-mathcomp-ssreflect   1.12.0      Small Scale Reflection
dune                     2.5.1       pinned to version 2.5.1
num                      0           pinned to version 0
ocaml                    4.05.0      The OCaml compiler (virtual package)
ocaml-base-compiler      4.05.0      Official 4.05.0 release
ocaml-config             1           OCaml Switch Configuration
ocaml-secondary-compiler 4.08.1-1    OCaml 4.08.1 Secondary Switch Compiler
ocamlfind                1.8.1       pinned to version 1.8.1
ocamlfind-secondary      1.8.1       ocamlfind support for ocaml-secondary-compiler
opam-depext              1.1.5       install OS distribution packages
zarith                   1.10        pinned to version 1.10
```