### PR TITLE
Added opam packages for CompCert 3.8

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.8/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.8/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "ia32-linux" {os = "linux"}
+  "ia32-macosx" {os = "macos"}
+  "ia32-cygwin" {os = "cygwin"}
+  "ia32-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  "-prefix" "%{prefix}%/variants/compcert32"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert32/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.7.0" & < "8.14"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (32 bit)"
+description: "This package installs the 32 bit version of CompCert.
+For coexistence with the 64 bit version, the files are installed in:
+%{prefix}%/variants/compcert32/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert32/lib/compcert  (C library)
+%{lib}%/coq-variant/compcert32/compcert (Coq library)
+Please note that the coq module path is compcert and not compcert32,
+so the files cannot be directly Required as compcert32.
+Instead -Q or -R options must be used to bind the compcert32 folder
+to the module path compcert. This is more convenient if one development
+supports both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert32.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert32"
+  "date:2020-12-05"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.8.tar.gz"
+  checksum: "sha512=ba669eb2098eb80ba393404f45b814113cf9e1d9497b074f7158c8e3857fdfdf72a95c7b177b1342689cf802efd7e0004356a89bb010cbbf496fca8a4f9fbda7"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.8/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure" "amd64-linux" {os = "linux"}
+  "amd64-macosx" {os = "macos"}
+  "amd64-cygwin" {os = "cygwin"}
+  "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  "-bindir" "%{bin}%"
+  "-libdir" "%{lib}%/compcert"
+  "-install-coqdev"
+  "-clightgen"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.7.0" & < "8.14"}
+  "menhir" {>= "20190626"}
+  "ocaml" {>= "4.05.0"}
+]
+synopsis: "The CompCert C compiler (64 bit)"
+tags: [
+  "category:CS/Semantics and Compilation/Compilation"
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2020-12-05"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.8.tar.gz"
+  checksum: "sha512=ba669eb2098eb80ba393404f45b814113cf9e1d9497b074f7158c8e3857fdfdf72a95c7b177b1342689cf802efd7e0004356a89bb010cbbf496fca8a4f9fbda7"
+}


### PR DESCRIPTION
This PR adds opam packages for CompCert 3.8

The packages are tested to be compatible with Coq platform (use platform supplied Flocq and MenhirLib), so there will be no separate coq-platform variant of the packages as for 3.7, but there will be an open source variant (in a separate PR).

Also please note that Xavier requested that from 3.8 on CompCert 64 shall be the default package and 32 bit shall be the variant package. So there is a new "compcert-32" package and "compcert-64" is deprecated now. One can of cause discuss to have both a compcert-32 and a compcert-64 variant package and a default package beeing identical to the latter except for the install location (lib/coq/user-contrib/compcert vs. lib/coq-variant/compcert-64/compcert).

@xavierleroy, @jhjourdan : FYI.