### PR TITLE
Add coq-coqffi.1.0.0~beta1

### DIFF
--- a/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta1/opam
+++ b/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/coq-community/coqffi"
+dev-repo: "git+https://github.com/coq-community/coqffi.git"
+bug-reports: "https://github.com/coq-community/coqffi/issues"
+license: "MIT"
+
+synopsis: "Tool for generating Coq FFI bindings to OCaml libraries"
+description: """
+`coqffi` generates the necessary Coq boilerplate to use OCaml functions in a
+Coq development, and configures the Coq extraction mechanism accordingly."""
+
+build: [
+  ["./src-prepare.sh"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "4.12~" }
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.13~") | (= "dev")}
+  "cmdliner" {>= "1.0.4"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:foreign function interface"
+  "keyword:extraction"
+  "keyword:OCaml"
+  "logpath:CoqFFI"
+]
+authors: [
+  "Thomas Letan"
+  "Li-yao Xia"
+  "Yann Régis-Gianas"
+  "Yannick Zakowski"
+]
+url {
+  src: "https://github.com/coq-community/coqffi/archive/1.0.0-beta1.tar.gz"
+  checksum: "sha512=7c64e4cd75a81dd3508b044f807236a1cfc3d8dba8ac9c75ba0033e774886bca863bc53e51c148b7a6854d0a7bc3bd9f0808fe649356f18ff6ecb2634b8ac7d7"
+}


### PR DESCRIPTION
This is the first beta of [`coq-coqffi`](https://github.com/coq-community/coqffi). I think we should be able to release the “true” `1.0.0` really soon, but the main idea behind this beta is to do a “call for testers.”