### PR TITLE
macOS 11: fix for remake (Coq platform 8.12 package versions)

### DIFF
--- a/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/files/remake.patch
+++ b/released/packages/coq-coquelicot/coq-coquelicot.3.1.0/files/remake.patch
@@ -1,7 +1,16 @@
 diff --git a/remake.cpp b/remake.cpp
-index 3a6af80..47d5be8 100644
+index 3a6af80..d5ac424 100644
 --- a/remake.cpp
 +++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 
 @@ -786,7 +786,7 @@ struct log
  	}
  };

--- a/released/packages/coq-flocq/coq-flocq.3.3.1/files/remake.patch
+++ b/released/packages/coq-flocq/coq-flocq.3.3.1/files/remake.patch
@@ -1,8 +1,17 @@
 diff --git a/remake.cpp b/remake.cpp
-index 56a3c2f..e7bcbcd 100644
+index 3a6af80..d5ac424 100644
 --- a/remake.cpp
 +++ b/remake.cpp
-@@ -800,7 +800,7 @@ struct log
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 
+@@ -786,7 +786,7 @@ struct log
  	}
  };
  

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/files/remake.patch
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/files/remake.patch
@@ -1,7 +1,16 @@
 diff --git a/remake.cpp b/remake.cpp
-index 3a6af80..47d5be8 100644
+index 3a6af80..d5ac424 100644
 --- a/remake.cpp
 +++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 
 @@ -786,7 +786,7 @@ struct log
  	}
  };

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/opam
@@ -17,7 +17,6 @@ depends: [
   "ocaml"
   "coq" {>= "8.8.1" & < "8.13~"}
   "coq-flocq" {>= "3.0"}
-  "gappa" {>= "1.3.5"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml"
   "coq" {>= "8.8.1" & < "8.13~"}
   "coq-flocq" {>= "3.0"}
+  "gappa" {>= "1.3.5"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-gappa/coq-gappa.1.4.5/files/remake.patch
+++ b/released/packages/coq-gappa/coq-gappa.1.4.5/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 3a6af80..d5ac424 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 

--- a/released/packages/coq-gappa/coq-gappa.1.4.5/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.5/opam
@@ -4,6 +4,9 @@ homepage: "http://gappa.gforge.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
 bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL-3.0-or-later"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]

--- a/released/packages/coq-interval/coq-interval.4.0.0/files/remake.patch
+++ b/released/packages/coq-interval/coq-interval.4.0.0/files/remake.patch
@@ -1,7 +1,16 @@
 diff --git a/remake.cpp b/remake.cpp
-index 3a6af80..47d5be8 100644
+index 3a6af80..d5ac424 100644
 --- a/remake.cpp
 +++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 
 @@ -786,7 +786,7 @@ struct log
  	}
  };

--- a/released/packages/coq-interval/coq-interval.4.1.0/files/remake.patch
+++ b/released/packages/coq-interval/coq-interval.4.1.0/files/remake.patch
@@ -1,0 +1,13 @@
+diff --git a/remake.cpp b/remake.cpp
+index 3a6af80..d5ac424 100644
+--- a/remake.cpp
++++ b/remake.cpp
+@@ -450,7 +450,7 @@ enum { INVALID_SOCKET = -1 };
+ extern char **environ;
+ #endif
+ 
+-#if defined(WINDOWS) || defined(MACOSX)
++# if (defined(WINDOWS) || defined(MACOSX)) && ! defined(MSG_NOSIGNAL)
+ enum { MSG_NOSIGNAL = 0 };
+ #endif
+ 

--- a/released/packages/coq-interval/coq-interval.4.1.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.1.0/opam
@@ -4,6 +4,9 @@ homepage: "http://coq-interval.gforge.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/coqinterval/interval.git"
 bug-reports: "https://gitlab.inria.fr/coqinterval/interval/issues"
 license: "CeCILL-C"
+patches: [
+  "remake.patch"
+]
 build: [
   ["autoconf"] {dev}
   ["./configure"]


### PR DESCRIPTION
This PR fixes an issue with remake on macOS 11 / XCode 12.
It also fixes a missing dependency for coq-gappa.

There are also newer versions of some packages affected which will be fixed in a separate PR for Coq platform 8.13 package versions (for testability reasons).

@silene : FYI