### PR TITLE
Add coq-coqffi.1.0.0~beta2

### DIFF
--- a/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta2/opam
+++ b/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/coq-community/coqffi"
+dev-repo: "git+https://github.com/coq-community/coqffi.git"
+bug-reports: "https://github.com/coq-community/coqffi/issues"
+license: "MIT"
+
+synopsis: "Tool for generating Coq FFI bindings to OCaml libraries"
+description: """
+`coqffi` generates the necessary Coq boilerplate to use OCaml functions in a
+Coq development, and configures the Coq extraction mechanism accordingly."""
+
+build: [
+  ["./src-prepare.sh"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "4.12~" }
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.13~") | (= "dev")}
+  "cmdliner" {>= "1.0.4"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:foreign function interface"
+  "keyword:extraction"
+  "keyword:OCaml"
+  "logpath:CoqFFI"
+]
+authors: [
+  "Thomas Letan"
+  "Li-yao Xia"
+  "Yann Régis-Gianas"
+  "Yannick Zakowski"
+]
+url {
+  src: "https://github.com/coq-community/coqffi/archive/1.0.0-beta2.tar.gz"
+  checksum: "sha512=e1190d40bb163cc075d30c29d910b71b03c805f806ed9da2e6047de4b83da95cb6fc6622395d30c2920a17ef2df7cc2933f3702ee603681e908122d6eac18f8f"
+}


### PR DESCRIPTION
While writing the necessary documentation for my “call for betatesters”, I have found (and then fixed) two bugs. Hence the release of a `~beta2` version. Sorry about that!