### PR TITLE
Trim starting spaces from categories and keywords

### DIFF
--- a/scripts/archive2web
+++ b/scripts/archive2web
@@ -95,7 +95,7 @@ function pluraly(s,n,...)
 end
 
 function print_pkg(name,info,print)
-	print [[ <tr class="package"><td> ]]
+	print [[<tr class="package"><td>]]
 	if info.homepage ~= "" then print(('<a href="%s">'):format(info.homepage or "#")) end
 	print (([[<h3 class="name">%s</h3>]]):format(name))
 	if info.homepage ~= "" then print "</a>" end
@@ -140,8 +140,7 @@ function print_pkg(name,info,print)
 	end
 	print [[</div>]]
 	print [[</div>]]
-	print [[</div>]]
-	print [[ </td></tr> ]]
+	print "</td></tr>\n"
 end
 
 template = io.open(templ):read('*a')

--- a/scripts/archive2web
+++ b/scripts/archive2web
@@ -60,9 +60,9 @@ function do_one_root(suite)
   	local dates = info.dates or {}
   	local categories = info.categories or {}
   	for tag in tags:gmatch('(%b"")') do
-  		add_uniq(categories, tag:match('"category:([^"]*)"'))
-  		add_uniq(keywords, tag:match('"keyword:([^"]*)"'))
-  		add_uniq(dates, tag:match('"date:([^"]*)"'))
+		add_uniq(categories, tag:match('"category: *([^"]*)"'))
+		add_uniq(keywords, tag:match('"keyword: *([^"]*)"'))
+		add_uniq(dates, tag:match('"date: *([^"]*)"'))
   	end
   	info.categories = categories
   	info.keywords = keywords


### PR DESCRIPTION
Some packages write tags as `"keyword: foo"` instead of `"keyword:foo"`, which causes the creation of two separate tags. Rather than fixing all the broken packages, this pull request makes the script a bit more robust to spaces.

It also removes an extraneous `</div>` along the way and make the output more readable.