### PR TITLE
release of mathcomp-analysis-0.3.4

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.4/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+version: "dev"
+
+homepage: "https://github.com/math-comp/analysis"
+dev-repo: "git+https://github.com/math-comp/analysis.git"
+bug-reports: "https://github.com/math-comp/analysis/issues"
+license: "CECILL-C"
+
+synopsis: "An analysis library for mathematical components"
+description: """
+This repository contains an experimental library for real analysis for
+the Coq proof-assistant and using the Mathematical Components library."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" { (>= "8.11" & < "8.13~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-fingroup" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-algebra" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-solvable" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-field" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-finmap" { (>= "1.5.0" & < "1.6~") }
+  "coq-hierarchy-builder" { (>= "0.10.0" & < "0.11~") }
+]
+
+tags: [
+  "keyword:analysis"
+  "keyword:topology"
+  "keyword:real numbers"
+  "logpath:mathcomp.analysis"
+]
+authors: [
+  "Reynald Affeldt"
+  "Cyril Cohen"
+  "Marie Kerjean"
+  "Assia Mahboubi"
+  "Damien Rouhling"
+  "Kazuhiko Sakaguchi"
+  "Pierre-Yves Strub"
+]
+url {
+  http: "https://github.com/math-comp/analysis/archive/0.3.4.tar.gz"
+  checksum: "sha512=d17ccb9accfc2812accf3c289c89c559421823e3e96d8478d00f8d8c3518aef540674836da82f708410901e9447cc1ea654fd5c45a65f90f776b8e94f9015a41"
+}


### PR DESCRIPTION
- compatibility with mathcomp 1.11 but not with mathcomp 1.12
- introduce dependency w.r.t. coq-hierarchy-builder