### PR TITLE
Make coq.dev honor coq-native

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -34,7 +34,7 @@ build: [
     "-libdir" "%{lib}%/coq"
     "-datadir" "%{share}%/coq"
     "-coqide" "no"
-    "-native-compiler" {os = "macos"} "no" {os = "macos"}
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
   [make "-j%{jobs}%"]
   [make "-j%{jobs}%" "byte"]


### PR DESCRIPTION
Only coq.8.13.dev was fixed, but not coq.dev which is important for benchmarks and ci