### PR TITLE
Updated VST 2.6 to allow Coq 8.12.2

### DIFF
--- a/released/packages/coq-vst-64/coq-vst-64.2.6/files/makefile.patch
+++ b/released/packages/coq-vst-64/coq-vst-64.2.6/files/makefile.patch
@@ -7,7 +7,7 @@ index 2445971f..492e44ff 100755
  # Check Coq version
  
 -COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0
-+COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0 or-else 8.12.1
++COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0 or-else 8.12.1 or-else 8.12.2
  
  COQV=$(shell $(COQC) -v)
  ifneq ($(IGNORECOQVERSION),true)

--- a/released/packages/coq-vst/coq-vst.2.6/files/makefile.patch
+++ b/released/packages/coq-vst/coq-vst.2.6/files/makefile.patch
@@ -7,7 +7,7 @@ index 2445971f..492e44ff 100755
  # Check Coq version
  
 -COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0
-+COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0 or-else 8.12.1
++COQVERSION= 8.11.0 or-else 8.11.1 or-else 8.11.2 or-else 8.12+beta1 or-else 8.12.0 or-else 8.12.1 or-else 8.12.2
  
  COQV=$(shell $(COQC) -v)
  ifneq ($(IGNORECOQVERSION),true)


### PR DESCRIPTION
This PR is a minor patch to the VST 2.6 packages so that Coq 8.12.2 is allowed (the VST makefile explicitly names all allowed Coq versions)