### PR TITLE
Add FreeSpec packages to extra-dev

### DIFF
--- a/extra-dev/packages/coq-freespec-core/coq-freespec-core.dev/opam
+++ b/extra-dev/packages/coq-freespec-core/coq-freespec-core.dev/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/ANSSI-FR/FreeSpec"
+dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
+bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
+doc: "https://ANSSI-FR.github.io/FreeSpec"
+license: "GPL-3.0-or-later"
+
+synopsis: "A framework for implementing and certifying impure computations in Coq"
+description: """
+FreeSpec is a framework for the Coq proof assistant which allows to
+implement and specify impure computations. This is the core of the
+framework: it provides the foundation of the formalism, based on the
+freer monad, the reasoning theory and tactics to automate the
+reasoning.
+"""
+
+build: [
+  ["patch" "-p1" "-i" "patches/opam-builds.patch"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"
+  "dune" {>= "2.5"}
+  "coq" {>= "8.12" & < "8.13~"}
+  "coq-ext-lib" {>= "0.11.2"}
+]
+
+tags: [
+  "keyword:effect"
+  "keyword:freer"
+  "keyword:program logic"
+  "category:Mathematics/Category Theory"
+  "logpath:FreeSpec.Core"
+]
+
+authors: [
+  "Thomas Letan"
+  "Yann Régis-Gianas"
+]
+
+url {
+  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#"
+}

--- a/extra-dev/packages/coq-freespec-exec/coq-freespec-exec.dev/opam
+++ b/extra-dev/packages/coq-freespec-exec/coq-freespec-exec.dev/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/ANSSI-FR/FreeSpec"
+dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
+bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
+doc: "https://ANSSI-FR.github.io/FreeSpec"
+license: "GPL-3.0-or-later"
+
+synopsis: "A framework for implementing and certifying impure computations in Coq"
+description: """
+FreeSpec is a framework for the Coq proof assistant which allows to
+implement and specify impure computations. This is the “exec” plugin,
+which allows from executing impure computations from with Coq thanks
+to a dedicated vernacular command.
+"""
+
+build: [
+  ["patch" "-p1" "-i" "patches/opam-builds.patch"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"
+  "dune" {>= "2.5"}
+  "coq" {>= "8.12" & < "8.13~"}
+  "coq-freespec-core" {= "dev"}
+  "coq-freespec-ffi" {= "dev"}
+]
+
+tags: [
+  "keyword:plugin"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:FreeSpec.Exec"
+]
+
+authors: [
+  "Thomas Letan"
+  "Yann Régis-Gianas"
+]
+
+url {
+  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#master"
+}

--- a/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
+++ b/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/ANSSI-FR/FreeSpec"
+dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
+bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
+doc: "https://ANSSI-FR.github.io/FreeSpec"
+license: "GPL-3.0-or-later"
+
+synopsis: "A framework for implementing and certifying impure computations in Coq"
+description: """
+FreeSpec is a framework for the Coq proof assistant which allows to
+implement and specify impure computations. It can be used with coqffi
+to write certified software.
+"""
+
+build: [
+  ["patch" "-p1" "-i" "patches/opam-builds.patch"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"
+  "dune" {>= "2.5"}
+  "coq" {>= "8.12" & < "8.13~"}
+  "coq-freespec-core" {= "dev"}
+  "coq-coqffi" {= "1.0.0~beta2"}
+  "coq-simple-io" {<= "1.3.0"}
+]
+
+tags: [
+  "keyword:foreign function interface"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:FreeSpec.Exec"
+]
+
+authors: [
+  "Thomas Letan"
+  "Yann Régis-Gianas"
+]
+
+url {
+  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#master"
+}


### PR DESCRIPTION
This is a draft PR to add the three packages in the `FreeSpec` repository in `extra-dev`.  I create this early on to discuss the Category of these packages. I haven’t found one that seems suitable in the list currently used in `released`. Does adding `CS/Program Logic` sounds fine to you?