### PR TITLE
Package coq-menhirlib.20201216

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20201216/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201216/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20201216" }
+]
+tags: [
+  "date:2020-12-16"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20201216/archive.tar.gz"
+  checksum: [
+    "md5=f27f8f5dedd316eff4c02d9130fced49"
+    "sha512=50f86fb2f55184f43c4be9c572ada4feb2208eb350ef64b2651351934a1b48a0b7e98c8c752c3c22e95676c5a0f38b0e638b3f845e53ecff1740dad95b50918c"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20201216`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.2