### PR TITLE
Update FreeSpec packages location

### DIFF
--- a/extra-dev/packages/coq-freespec-core/coq-freespec-core.dev/opam
+++ b/extra-dev/packages/coq-freespec-core/coq-freespec-core.dev/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+maintainer: "Thomas Letan <lthms@soap.coffee>"
 
-homepage: "https://github.com/ANSSI-FR/FreeSpec"
-dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
-bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
-doc: "https://ANSSI-FR.github.io/FreeSpec"
+homepage: "https://github.com/lthms/FreeSpec"
+dev-repo: "git+https://github.com/lthms/FreeSpec.git"
+bug-reports: "https://github.com/lthms/FreeSpec.git/issues"
+doc: "https://lthms.github.io/FreeSpec"
 license: "GPL-3.0-or-later"
 
 synopsis: "A framework for implementing and certifying impure computations in Coq"
@@ -42,5 +42,5 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#"
+  src: "git+https://github.com/lthms/FreeSpec.git#"
 }

--- a/extra-dev/packages/coq-freespec-exec/coq-freespec-exec.dev/opam
+++ b/extra-dev/packages/coq-freespec-exec/coq-freespec-exec.dev/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+maintainer: "Thomas Letan <lthms@soap.coffee>"
 
-homepage: "https://github.com/ANSSI-FR/FreeSpec"
-dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
-bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
-doc: "https://ANSSI-FR.github.io/FreeSpec"
+homepage: "https://github.com/lthms/FreeSpec"
+dev-repo: "git+https://github.com/lthms/FreeSpec.git"
+bug-reports: "https://github.com/lthms/FreeSpec.git/issues"
+doc: "https://lthms.github.io/FreeSpec"
 license: "GPL-3.0-or-later"
 
 synopsis: "A framework for implementing and certifying impure computations in Coq"
@@ -40,5 +40,5 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#master"
+  src: "git+https://github.com/lthms/FreeSpec.git#master"
 }

--- a/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
+++ b/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
-maintainer: "Thomas Letan <thomas.letan@ssi.gouv.fr"
+maintainer: "Thomas Letan <lthms@soap.coffee>"
 
-homepage: "https://github.com/ANSSI-FR/FreeSpec"
-dev-repo: "git+https://github.com/ANSSI-FR/FreeSpec.git"
-bug-reports: "https://github.com/ANSSI-FR/FreeSpec.git/issues"
-doc: "https://ANSSI-FR.github.io/FreeSpec"
+homepage: "https://github.com/lthms/FreeSpec"
+dev-repo: "git+https://github.com/lthms/FreeSpec.git"
+bug-reports: "https://github.com/lthms/FreeSpec.git/issues"
+doc: "https://lthms.github.io/FreeSpec"
 license: "GPL-3.0-or-later"
 
 synopsis: "A framework for implementing and certifying impure computations in Coq"
@@ -40,5 +40,5 @@ authors: [
 ]
 
 url {
-  src: "git+https://github.com/ANSSI-FR/FreeSpec.git#master"
+  src: "git+https://github.com/lthms/FreeSpec.git#master"
 }


### PR DESCRIPTION
The FreeSpec repository is no longer hosted by the ANSSI organization.
Because we have transferred ownership, rather than deleting/recreating
a new repository, GitHub has set up a redirection, but said
redirection could be revoked at any time.