### PR TITLE
Fix Coq version for coq-tactician-dummy.1.0~beta1

### DIFF
--- a/released/packages/coq-tactician-dummy/coq-tactician-dummy.1.0~beta1/opam
+++ b/released/packages/coq-tactician-dummy/coq-tactician-dummy.1.0~beta1/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/coq-tactician/coq-tactician-dummy/issues"
 maintainer: "Lasse Blaauwbroek <lasse@blaauwbroek.eu>"
 authors: "Lasse Blaauwbroek <lasse@blaauwbroek.eu"
 depends: [
-  "coq"
+  "coq" {>= "8.6.1"}
   "dune" {>= "2.5"}
 ]
 build: [


### PR DESCRIPTION
It seems that this package fails with the following error for Coq versions prior to 8.6.1 (not entirely sure, may be related to the OCaml version too): @LasseBlaauwbroek 
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-tactician-dummy.1.0~beta1 coq.8.6
Return code
    7936
Duration
    8 s
Output

    # Packages matching: installed
    # Name                   # Installed # Synopsis
    base-bigarray            base
    base-num                 base        Num library distributed with the OCaml compiler
    base-threads             base
    base-unix                base
    camlp5                   7.13        Preprocessor-pretty-printer of OCaml
    conf-findutils           1           Virtual package relying on findutils
    conf-m4                  1           Virtual package relying on m4
    coq                      8.6         Formal proof management system
    dune                     2.7.1       Fast, portable, and opinionated build system
    num                      0           The Num library for arbitrary-precision integer and rational arithmetic
    ocaml                    4.03.0      The OCaml compiler (virtual package)
    ocaml-base-compiler      4.03.0      Official 4.03.0 release
    ocaml-config             1           OCaml Switch Configuration
    ocaml-secondary-compiler 4.08.1-1    OCaml 4.08.1 Secondary Switch Compiler
    ocamlfind                1.8.1       A library manager for OCaml
    ocamlfind-secondary      1.8.1       ocamlfind support for ocaml-secondary-compiler
    [NOTE] Package coq is already installed (current version is 8.6).
    The following actions will be performed:
      - install coq-tactician-dummy 1.0~beta1
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-tactician-dummy.1.0~beta1: http]
    [coq-tactician-dummy.1.0~beta1] downloaded from https://github.com/coq-tactician/coq-tactician-dummy/archive/1.0-beta1.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-tactician-dummy: dune build]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "dune" "build" "--release" "-j" "4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-tactician-dummy.1.0~beta1)
    -       coqdep theories/Ltac1Dummy.v.d
    - *** Warning: in file Ltac1Dummy.v, declared ML module ltac_plugin has not been found!
    - *** Warning: in file Ltac1Dummy.v, declared ML module ltac_plugin has not been found!
    -         coqc theories/.Ltac1Dummy.aux,theories/Ltac1Dummy.{glob,vo} (exit 1)
    - (cd _build/default && /home/bench/.opam/ocaml-base-compiler.4.03.0/bin/coqc -q -noinit -R theories Tactician theories/Ltac1Dummy.v)
    - File "./theories/Ltac1Dummy.v", line 1, characters 0-32:
    - Error:
    - File not found on loadpath : ltac_plugin.cmxs
    - Loadpath: /home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-tactician-dummy.1.0~beta1/_build/default:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/quote:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/funind:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/setoid_ring:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/firstorder:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/romega:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/omega:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/derive:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/syntax:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/micromega:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/nsatz:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/fourier:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/extraction:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/decl_mode:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/cc:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/btauto:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/ssrmatching:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/rtauto:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/toploop
    [ERROR] The compilation of coq-tactician-dummy failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build dune build --release -j 4".
    #=== ERROR while compiling coq-tactician-dummy.1.0~beta1 ======================#
    # context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-tactician-dummy.1.0~beta1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build --release -j 4
    # exit-code            1
    # env-file             ~/.opam/log/coq-tactician-dummy-11754-d0f245.env
    # output-file          ~/.opam/log/coq-tactician-dummy-11754-d0f245.out
    ### output ###
    #       coqdep theories/Ltac1Dummy.v.d
    # *** Warning: in file Ltac1Dummy.v, declared ML module ltac_plugin has not been found!
    # *** Warning: in file Ltac1Dummy.v, declared ML module ltac_plugin has not been found!
    #         coqc theories/.Ltac1Dummy.aux,theories/Ltac1Dummy.{glob,vo} (exit 1)
    # (cd _build/default && /home/bench/.opam/ocaml-base-compiler.4.03.0/bin/coqc -q -noinit -R theories Tactician theories/Ltac1Dummy.v)
    # File "./theories/Ltac1Dummy.v", line 1, characters 0-32:
    # Error:
    # File not found on loadpath : ltac_plugin.cmxs
    # Loadpath: /home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-tactician-dummy.1.0~beta1/_build/default:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/quote:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/funind:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/setoid_ring:/home/bench/.opam/ocaml-base-compiler.4.03.0/lib/coq/plugins/firstor[...]
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-tactician-dummy 1.0~beta1
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-tactician-dummy.1.0~beta1 coq.8.6' failed.
```