### PR TITLE
Add new/updated dev packages for some mathcomp components

### DIFF
--- a/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "coq-mathcomp-bigenough"
+version: "1.0.0"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+
+homepage: "https://github.com/math-comp/bigenough"
+bug-reports: "https://github.com/math-comp/bigenough/issues"
+license: "CeCILL-B"
+dev-repo: "git+https://github.com/math-comp/bigenough"
+
+build: [ make "-j" "%{jobs}%" ]
+install: [ make "install" ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/bigenough'" ]
+depends: [
+  "ocaml"
+  "coq-mathcomp-ssreflect" {(>= "1.6" | = "dev")}
+]
+tags: [ "keyword:bigenough" "keyword:asymptotic reasonning" "keyword:small scale reflection" "keyword:mathematical components" ]
+authors: [ "Cyril Cohen <cyril.cohen@inria.fr>" ]
+synopsis: "A small library to do epsilon - N reasonning"
+description: """
+The package contains a package to reasoning with big enough objects
+(mostly natural numbers). This package is essentially for backward
+compatibility purposes as `bigenough` will be subsumed by the near
+tactics. The formalization is based on the Mathematical Components
+library."""
+url {
+  src: "git+https://github.com/math-comp/bigenough.git#master"
+}

--- a/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.dev/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "coq-mathcomp-bigenough"
-version: "1.0.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "https://github.com/math-comp/bigenough"
@@ -10,7 +8,6 @@ dev-repo: "git+https://github.com/math-comp/bigenough"
 
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/bigenough'" ]
 depends: [
   "ocaml"
   "coq-mathcomp-ssreflect" {(>= "1.6" | = "dev")}

--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -1,29 +1,37 @@
 opam-version: "2.0"
-version: "dev"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "https://github.com/math-comp/finmap"
-bug-reports: "https://github.com/math-comp/finmap/issues"
 dev-repo: "git+https://github.com/math-comp/finmap.git"
+bug-reports: "https://github.com/math-comp/finmap/issues"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/finmap'" ]
-depends: [
-  "coq" { (>= "8.7" & < "8.13~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11" & < "1.12~") | (= "dev") }
-  "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~") }
-]
-tags: [ "keyword:finmap" "keyword:finset" "keyword:multiset" "keyword:order"]
-authors: [ "Cyril Cohen <cyril.cohen@inria.fr>" ]
-synopsis: "Finite sets, finite maps, finitely supported functions, orders"
+synopsis: "Finite sets, finite maps, finitely supported functions"
 description: """
 This library is an extension of mathematical component in order to
 support finite sets and finite maps on choicetypes (rather that finite
 types). This includes support for functions with finite support and
 multisets. The library also contains a generic order and set libary,
 which will be used to subsume notations for finite sets, eventually."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.13~") | (= "dev") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") | (= "dev") }
+]
+
+tags: [
+  "keyword:finmap"
+  "keyword:finset"
+  "keyword:multiset"
+  "logpath:mathcomp.finmap"
+]
+authors: [
+  "Cyril Cohen"
+  "Kazuhiko Sakaguchi"
+]
 url {
   src: "git+https://github.com/math-comp/finmap.git#master"
 }

--- a/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
@@ -1,30 +1,36 @@
 opam-version: "2.0"
-name: "coq-mathcomp-real-closed"
-maintainer: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
 homepage: "https://github.com/math-comp/real-closed"
-bug-reports: "https://github.com/math-comp/real-closed/issues"
 dev-repo: "git+https://github.com/math-comp/real-closed.git"
+bug-reports: "https://github.com/math-comp/real-closed/issues"
 license: "CeCILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
-install: [ make "install" ]
-depends: [
-  "coq" { (>= "8.7" & < "8.10~") }
-  "coq-mathcomp-field" { (>= "1.8.0" & < "1.9.0~") }
-  "coq-mathcomp-bigenough"   {(>= "1.0.0" & < "1.1.0~")}
-]
-
-tags: [ "keyword:real closed field" "keyword:small scale reflection" "keyword:mathematical components" "date:2019-05-23" "logpath:mathcomp"]
-authors: [ "Cyril Cohen <>" "Assia Mahboubi <>" ]
 synopsis: "Mathematical Components Library on real closed fields"
 description: """
 This library contains definitions and theorems about real closed
 fields, with a construction of the real closure and the algebraic
-closure (including a proof of the fundamental theorem of algebra). It
-also contains a proof of decidability of the first order theory of
-real closed field, through quantifier elimination.
-"""
+closure (including a proof of the fundamental theorem of
+algebra). It also contains a proof of decidability of the first
+order theory of real closed field, through quantifier elimination."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") | (= "dev")  }
+]
+tags: [
+  "keyword:real closed field"
+  "logpath:mathcomp.real_closed"
+]
+authors: [
+  "Cyril Cohen"
+  "Assia Mahboubi"
+]
 url {
   src: "git+https://github.com/math-comp/real-closed.git"
 }


### PR DESCRIPTION
This PR adds dev packages for a few mathcomp components.

One was missing and the other ones didn't build (at least not in the Coq platform environment) and they looked very different from the latest release versions, so I updated these packages to be close to the latest release versions (of cause still referencing master).

FYI: @gares