### PR TITLE
Add (new) dev package for coq-mtac2

### DIFF
--- a/extra-dev/packages/coq-mtac2/coq-mtac2.dev/opam
+++ b/extra-dev/packages/coq-mtac2/coq-mtac2.dev/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "beta.ziliani@gmail.com"
+homepage: "https://github.com/Mtac2/Mtac2"
+dev-repo: "git+https://github.com/Mtac2/Mtac2.git"
+bug-reports: "https://github.com/Mtac2/Mtac2/issues"
+authors: ["Beta Ziliani <beta.ziliani@gmail.com>" "Jan-Oliver Kaiser <janno@mpi-sws.org>" "Robbert Krebbers <mail@robbertkrebbers.nl>" "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>" "Derek Dreyer <dreyer@mpi-sws.org>"]
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12.0" | = "dev"}
+  "coq-unicoq" {>= "1.5" | = "dev"}
+]
+synopsis: "Mtac2: Typed Tactics for Coq"
+tags: [
+  "logpath:Mtac2"
+]
+url {
+  src: "git+https://github.com/Mtac2/Mtac2.git#master"
+}

--- a/extra-dev/packages/coq-mtac2/coq-mtac2.dev/opam
+++ b/extra-dev/packages/coq-mtac2/coq-mtac2.dev/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12.0" | = "dev"}
+  "coq" {>= "8.13" | = "dev"}
   "coq-unicoq" {>= "1.5" | = "dev"}
 ]
 synopsis: "Mtac2: Typed Tactics for Coq"


### PR DESCRIPTION
This PR adds a dev/master opam package for Mtac2 - it didn't have a dev package as yet.

@beta-ziliani : FYI : this is required for the master branch of the Coq Platform.