### PR TITLE
Add (new) dev package for coq-unicoq

### DIFF
--- a/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
+++ b/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Beta Ziliani <beta@mpi-sws.org>" ]
+dev-repo: "git+https://github.com/unicoq/unicoq.git"
+homepage: "https://github.com/unicoq/unicoq"
+bug-reports: "https://github.com/unicoq/unicoq/issues"
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12.0" | = "dev"}
+]
+synopsis: "An enhanced unification algorithm for Coq"
+tags: [
+  "logpath:Unicoq"
+]
+url {
+  src: "git+https://github.com/unicoq/unicoq.git#master"
+}


### PR DESCRIPTION
This PR adds a dev/master opam package for Unicoq - it didn't have a dev package as yet.

@mattam82  : FYI : this is required for the master branch of the Coq Platform.