### PR TITLE
Add new/updated dev package for coq-vst and coq-vst-32

### DIFF
--- a/extra-dev/packages/coq-vst-32/coq-vst-32.dev/opam
+++ b/extra-dev/packages/coq-vst-32/coq-vst-32.dev/opam
@@ -21,16 +21,16 @@ dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
 build: [
-  [make "-j%{jobs}%" "IGNORECOQVERSION=true" "BITSIZE=64"]
+  [make "-j%{jobs}%" "IGNORECOQVERSION=true" "BITSIZE=32"]
 ]
 install: [
-  [make "install" "IGNORECOQVERSION=true" "BITSIZE=64"]
+  [make "install" "IGNORECOQVERSION=true" "BITSIZE=32"]
 ]
 depends: [
   "ocaml"
   "coq" {>= "8.11" | = "dev"}
   # Note: the dev version of VST requires clightgen, so no open source
-  "coq-compcert" {= "3.8" | = "dev"}
+  "coq-compcert-32" {= "3.8" | = "dev"}
   "coq-flocq" {>= "3.2.1" | = "dev"}
 ]
 tags: [


### PR DESCRIPTION
This PR adds an updated dev package for coq-vst and a new dev package for coq-vst-32

Please note that VST currently does not compile with CompCert master, so depending on what CI selects, this will not pass CI. Still this is what a Coq VST dev package should be and it does compile with CompCert 3.8, so it should be merged anyway.

@AndrewAppel, @liyishuai : FYI: this is required for the Coq Platform master branch.