### PR TITLE
CompCert: update/fix opam packages for 3.8

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.8/files/0001-Configure-the-correct-archiver-to-build-runtime-libc.patch
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.8/files/0001-Configure-the-correct-archiver-to-build-runtime-libc.patch
@@ -1,0 +1,80 @@
+From ca2ebae012d6cdcc19d0a01f54f3dad614de8e68 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Thu, 24 Dec 2020 16:28:01 +0100
+Subject: [PATCH 01/16] Configure the correct archiver to build
+ runtime/libcompcert.a
+
+- Use `${toolprefix}ar` instead of `ar` so as to match the choice
+  of C compiler (as proposed by Michael Soegtrop in PR #380)
+
+- Use the Diab archiver `dar` if configured for powerpc-eabi-diab
+
+Closes: #380
+---
+ configure        | 8 +++++++-
+ runtime/Makefile | 2 +-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 1620ad4b..a4b257fc 100755
+--- a/configure
++++ b/configure
+@@ -211,7 +211,7 @@ casmruntime=""
+ clinker_needs_no_pie=true
+ clinker_options=""
+ cprepro_options=""
+-
++archiver="${toolprefix}ar rcs"
+ 
+ #
+ # ARM Target Configuration
+@@ -275,6 +275,7 @@ if test "$arch" = "powerpc"; then
+         clinker="${toolprefix}dcc"
+         cprepro="${toolprefix}dcc"
+         cprepro_options="-E -D__GNUC__"
++        archiver="${toolprefix}dar -q"
+         libmath="-lm"
+         system="diab"
+         responsefile="diab"
+@@ -666,6 +667,7 @@ CLINKER=$clinker
+ CLINKER_OPTIONS=$clinker_options
+ CPREPRO=$cprepro
+ CPREPRO_OPTIONS=$cprepro_options
++ARCHIVER=$archiver
+ ENDIANNESS=$endianness
+ HAS_RUNTIME_LIB=$has_runtime_lib
+ HAS_STANDARD_HEADERS=$has_standard_headers
+@@ -750,6 +752,9 @@ CASMRUNTIME=gcc -c
+ # Linker
+ CLINKER=gcc
+ 
++# Archiver to build .a libraries
++ARCHIVER=ar rcs
++
+ # Math library. Set to empty under MacOS X
+ LIBMATH=-lm
+ 
+@@ -839,6 +844,7 @@ CompCert configuration:
+     Assembler for runtime lib..... $casmruntime
+     Linker........................ $clinker
+     Linker needs '-no-pie'........ $clinker_needs_no_pie
++    Archiver...................... $archiver
+     Math library.................. $libmath
+     Build command to use.......... $make
+     Menhir API library............ $menhir_dir
+diff --git a/runtime/Makefile b/runtime/Makefile
+index 6777995d..beb105a6 100644
+--- a/runtime/Makefile
++++ b/runtime/Makefile
+@@ -48,7 +48,7 @@ endif
+ 
+ $(LIB): $(OBJS)
+ 	rm -f $(LIB)
+-	ar rcs $(LIB) $(OBJS)
++	$(ARCHIVER) $(LIB) $(OBJS)
+ 
+ %.o: %.s
+ 	$(CASMRUNTIME) -o $@ $^
+-- 
+2.29.2
+

--- a/released/packages/coq-compcert-32/coq-compcert-32.3.8/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.8/opam
@@ -6,10 +6,17 @@ dev-repo: "git+https://github.com/AbsInt/CompCert.git"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
 available: os != "macos"
+patches: [ "0001-Configure-the-correct-archiver-to-build-runtime-libc.patch" ]
 build: [
-  ["./configure" "ia32-linux" {os = "linux"}
+  ["./configure"
+  "ia32-linux" {os = "linux"}
   "ia32-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
   "ia32-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 32 bit CompCert on 64 bit MinGW with cygwin build host
+  "-toolprefix"     {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  "i686-pc-cygwin-" {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  # The 32 bit CompCert is a variant which is installed in a non standard folder
   "-prefix" "%{prefix}%/variants/compcert32"
   "-install-coqdev"
   "-clightgen"
@@ -48,7 +55,7 @@ tags: [
   "keyword:C"
   "keyword:compiler"
   "logpath:compcert32"
-  "date:2020-12-05"
+  "date:2020-12-21"
 ]
 url {
   src: "https://github.com/AbsInt/CompCert/archive/v3.8.tar.gz"

--- a/released/packages/coq-compcert/coq-compcert.3.8/files/0001-Configure-the-correct-archiver-to-build-runtime-libc.patch
+++ b/released/packages/coq-compcert/coq-compcert.3.8/files/0001-Configure-the-correct-archiver-to-build-runtime-libc.patch
@@ -1,0 +1,80 @@
+From ca2ebae012d6cdcc19d0a01f54f3dad614de8e68 Mon Sep 17 00:00:00 2001
+From: Xavier Leroy <xavier.leroy@college-de-france.fr>
+Date: Thu, 24 Dec 2020 16:28:01 +0100
+Subject: [PATCH 01/16] Configure the correct archiver to build
+ runtime/libcompcert.a
+
+- Use `${toolprefix}ar` instead of `ar` so as to match the choice
+  of C compiler (as proposed by Michael Soegtrop in PR #380)
+
+- Use the Diab archiver `dar` if configured for powerpc-eabi-diab
+
+Closes: #380
+---
+ configure        | 8 +++++++-
+ runtime/Makefile | 2 +-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 1620ad4b..a4b257fc 100755
+--- a/configure
++++ b/configure
+@@ -211,7 +211,7 @@ casmruntime=""
+ clinker_needs_no_pie=true
+ clinker_options=""
+ cprepro_options=""
+-
++archiver="${toolprefix}ar rcs"
+ 
+ #
+ # ARM Target Configuration
+@@ -275,6 +275,7 @@ if test "$arch" = "powerpc"; then
+         clinker="${toolprefix}dcc"
+         cprepro="${toolprefix}dcc"
+         cprepro_options="-E -D__GNUC__"
++        archiver="${toolprefix}dar -q"
+         libmath="-lm"
+         system="diab"
+         responsefile="diab"
+@@ -666,6 +667,7 @@ CLINKER=$clinker
+ CLINKER_OPTIONS=$clinker_options
+ CPREPRO=$cprepro
+ CPREPRO_OPTIONS=$cprepro_options
++ARCHIVER=$archiver
+ ENDIANNESS=$endianness
+ HAS_RUNTIME_LIB=$has_runtime_lib
+ HAS_STANDARD_HEADERS=$has_standard_headers
+@@ -750,6 +752,9 @@ CASMRUNTIME=gcc -c
+ # Linker
+ CLINKER=gcc
+ 
++# Archiver to build .a libraries
++ARCHIVER=ar rcs
++
+ # Math library. Set to empty under MacOS X
+ LIBMATH=-lm
+ 
+@@ -839,6 +844,7 @@ CompCert configuration:
+     Assembler for runtime lib..... $casmruntime
+     Linker........................ $clinker
+     Linker needs '-no-pie'........ $clinker_needs_no_pie
++    Archiver...................... $archiver
+     Math library.................. $libmath
+     Build command to use.......... $make
+     Menhir API library............ $menhir_dir
+diff --git a/runtime/Makefile b/runtime/Makefile
+index 6777995d..beb105a6 100644
+--- a/runtime/Makefile
++++ b/runtime/Makefile
+@@ -48,7 +48,7 @@ endif
+ 
+ $(LIB): $(OBJS)
+ 	rm -f $(LIB)
+-	ar rcs $(LIB) $(OBJS)
++	$(ARCHIVER) $(LIB) $(OBJS)
+ 
+ %.o: %.s
+ 	$(CASMRUNTIME) -o $@ $^
+-- 
+2.29.2
+

--- a/released/packages/coq-compcert/coq-compcert.3.8/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.8/opam
@@ -5,13 +5,18 @@ homepage: "http://compcert.inria.fr/"
 dev-repo: "git+https://github.com/AbsInt/CompCert.git"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 license: "INRIA Non-Commercial License Agreement"
+patches: [ "0001-Configure-the-correct-archiver-to-build-runtime-libc.patch" ]
 build: [
-  ["./configure" "amd64-linux" {os = "linux"}
+  ["./configure"
+  "amd64-linux" {os = "linux"}
   "amd64-macosx" {os = "macos"}
   "amd64-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
   "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
-  "-bindir" "%{bin}%"
-  "-libdir" "%{lib}%/compcert"
+  # This is for building a 64 bit CompCert on 32 bit MinGW with cygwin build host
+  "-toolprefix"        {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "x86_64-pc-cygwin-"  {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "-prefix" "%{prefix}%"
   "-install-coqdev"
   "-clightgen"
   "-use-external-Flocq"
@@ -37,7 +42,7 @@ tags: [
   "keyword:C"
   "keyword:compiler"
   "logpath:compcert"
-  "date:2020-12-05"
+  "date:2020-12-21"
 ]
 url {
   src: "https://github.com/AbsInt/CompCert/archive/v3.8.tar.gz"


### PR DESCRIPTION
- enable cross build of CompCert 3.8 64 bit (on 32 bit systems)
- add Xavier's fix for the archiver toolprefix