### PR TITLE
paco: requires 8.10

### DIFF
--- a/extra-dev/packages/coq-paco/coq-paco.dev/opam
+++ b/extra-dev/packages/coq-paco/coq-paco.dev/opam
@@ -19,7 +19,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {(>= "8.5.dev")}
+  "coq" {(>= "8.10")}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [

--- a/released/packages/coq-paco/coq-paco.4.0.3/opam
+++ b/released/packages/coq-paco/coq-paco.4.0.3/opam
@@ -15,7 +15,7 @@ license: "BSD-3-Clause"
 build: [make "-C" "src" "all" "-j%{jobs}%"]
 install: [make "-C" "src" "-f" "Makefile.coq" "install"]
 depends: [
-  "coq" {>= "8.9" & < "8.13~"}
+  "coq" {>= "8.10" & < "8.13~"}
 ]
 tags: [
   "date:2020-12-30"


### PR DESCRIPTION
since snu-sf/paco@e0a71f016bf6a6ce82dfd4ca8d4a53de7dd2442d uses `Declare Scope`