### PR TITLE
repair dev package for equations in extra-dev

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.dev/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.dev/opam
@@ -1,24 +1,37 @@
 opam-version: "2.0"
 authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Cyprien Mangin <cyprien.mangin@m4x.org>" ]
+dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
-dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-or-later"
+synopsis: "A function definition package for Coq"
+description: """
+Equations is a function definition plugin for Coq, that allows the
+definition of functions by dependent pattern-matching and well-founded,
+mutual or nested structural recursion and compiles them into core
+terms. It automatically derives the clauses equations, the graph of the
+function and its associated elimination principle.
+"""
+tags: [
+  "keyword:dependent pattern-matching"
+  "keyword:functional elimination"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Equations"
+]
 build: [
-  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  ["./configure.sh"]
   [make "-j%{jobs}%"]
 ]
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Equations"]
-depends: [
-  "ocaml"
-  "coq" {= "dev" }
+run-test: [
+  [make "test-suite"]
 ]
-synopsis: "A function definition package for Coq"
-flags: light-uninstall
+depends: [
+  "coq" {= "dev"}
+]
 url {
   src: "git+https://github.com/mattam82/Coq-Equations#master"
 }


### PR DESCRIPTION
This makes the `dev` package for equations match metadata/commands from the latest release, so we can test packages with Coq master that depend on equations.

@mattam82 is this something you might want to have upstream as well?