### PR TITLE
graph-theory and comp-dec-modal releases work on 8.13

### DIFF
--- a/released/packages/coq-comp-dec-modal/coq-comp-dec-modal.1.0/opam
+++ b/released/packages/coq-comp-dec-modal/coq-comp-dec-modal.1.0/opam
@@ -28,8 +28,8 @@ of said algorithm.
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.12~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.9" & < "1.13~") | (= "dev")}
 ]
 
 tags: [

--- a/released/packages/coq-graph-theory/coq-graph-theory.0.8/opam
+++ b/released/packages/coq-graph-theory/coq-graph-theory.0.8/opam
@@ -19,7 +19,7 @@ isomorphism)."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.11" & < "8.13~"}
+  "coq" {>= "8.11" & < "8.14~"}
   "coq-mathcomp-ssreflect" {>= "1.10" & < "1.13~"}
   "coq-mathcomp-finmap" 
   "coq-hierarchy-builder" { >= "0.10" }


### PR DESCRIPTION
cc: @chdoc 