### PR TITLE
Package coq-coqeal.dev

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.dev/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.dev/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "CoqEAL - The Coq Effective Algebra Library"
+description: """\
+This libary contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
+- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
+- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof."""
+maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
+authors: [
+  "Guillaume Cano"
+  "Cyril Cohen"
+  "Maxime Dénès"
+  "Anders Mörtberg"
+  "Damien Rouhling"
+  "Vincent Siles"
+]
+license: "MIT"
+tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms"
+  "keyword:effective algebra"
+  "keyword:elementary divisor rings"
+  "keyword:Smith normal form"
+  "keyword:mathematical components"
+  "keyword:Bareiss"
+  "keyword:Karatsuba"
+  "keyword:refinements"
+  "logpath:CoqEAL"
+]
+homepage: "https://github.com/CoqEAL/coqeal"
+bug-reports: "https://github.com/CoqEAL/coqeal/issues"
+depends: [
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq-bignums"
+  "coq-paramcoq" {(>= "1.1.1") | (= "dev")}
+  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
+  "coq-mathcomp-algebra" {((>= "1.11.0" & < "1.13~") | = "dev")}
+]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+dev-repo: "git+https://github.com/CoqEAL/coqeal.git"
+url {
+  src: "https://github.com/coqeal/coqeal/archive/1.0.5.tar.gz"
+  checksum: [
+    "md5=8e44571f4f4c21ba4673cb797a6ff40e"
+    "sha512=f397d6a441c8d63894e88d8bbfe2aac4b633d94d013692629fd8558e540a4334fc4c9e5d9ac111152043b47f9200f8aa8b85e9c314b37faca95e9ffd8d78598a"
+  ]
+}


### PR DESCRIPTION
### `coq-coqeal.dev`
CoqEAL - The Coq Effective Algebra Library
This libary contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof.



---
* Homepage: https://github.com/CoqEAL/coqeal
* Source repo: git+https://github.com/CoqEAL/coqeal.git
* Bug tracker: https://github.com/CoqEAL/coqeal/issues

---
:camel: Pull-request generated by opam-publish v2.0.3