### PR TITLE
Fix coq-freespec-ffi.dev dependencies

### DIFF
--- a/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
+++ b/extra-dev/packages/coq-freespec-ffi/coq-freespec-ffi.dev/opam
@@ -24,8 +24,8 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {>= "8.12" & < "8.13~"}
   "coq-freespec-core" {= "dev"}
-  "coq-coqffi" {= "1.0.0~beta2"}
-  "coq-simple-io" {<= "1.3.0"}
+  "coq-coqffi" {= "1.0.0~beta2" | = "dev"}
+  "coq-simple-io" {>= "1.0" & < "2.0~"}
 ]
 
 tags: [


### PR DESCRIPTION
The dependencies specs of the `coq-freespec-ffi.dev` were too strong. This patch fixes the issue.