### PR TITLE
Add coq-metacoq-*.1.0~beta2 packages (and ci-skip redudant tests)

### DIFF
--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.11/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "erasure"]
+]
+install: [
+  [make "-C" "erasure" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Erasure module provides a complete specification of Coq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+# url {
+#   src: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+#   checksum: "md5=e81b8ecabef788a10337a39b095d54f3"
+# }
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.11/opam
@@ -46,5 +46,5 @@ thesis.
 # }
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.12/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "erasure"]
+]
+install: [
+  [make "-C" "erasure" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.12~"}
+  "coq" { >= "8.12~" & < "8.13~" }
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Erasure module provides a complete specification of Coq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.12/opam
@@ -42,5 +42,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.13/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "erasure"]
+]
+install: [
+  [make "-C" "erasure" "install"]
+]
+depends: [
+  "coq" {>= "8.13" & < "8.14~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+]
+synopsis: "Implementation and verification of an erasure procedure for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Erasure module provides a complete specification of Coq's so-called
+\"extraction\" procedure, starting from the PCUIC calculus and targeting
+untyped call-by-value lambda-calculus.
+
+The `erasure` function translates types and proofs in well-typed terms
+into a dummy `tBox` constructor, following closely P. Letouzey's PhD
+thesis.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}

--- a/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-erasure/coq-metacoq-erasure.1.0~beta2+8.13/opam
@@ -41,5 +41,5 @@ thesis.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.11/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "pcuic"]
+]
+install: [
+  [make "-C" "pcuic" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-equations" {>= "1.2.3"}
+  "coq-metacoq-template" {= version}
+]
+synopsis: "A type system equivalent to Coq's and its metatheory"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The PCUIC module provides a cleaned-up specification of Coq's typing algorithm along
+with a certified typechecker for it. This module includes the standard metatheory of
+PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
+"""
+# url {
+#   src: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+#   checksum: "md5=e81b8ecabef788a10337a39b095d54f3"
+# }
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.11/opam
@@ -41,5 +41,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 # }
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.12/opam
@@ -37,5 +37,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.12/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "pcuic"]
+]
+install: [
+  [make "-C" "pcuic" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.12~"}
+  "coq" { >= "8.12~" & < "8.13~" }
+  "coq-equations" {= "1.2.3+8.12" }
+  "coq-metacoq-template" {= version}
+]
+synopsis: "A type system equivalent to Coq's and its metatheory"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The PCUIC module provides a cleaned-up specification of Coq's typing algorithm along
+with a certified typechecker for it. This module includes the standard metatheory of
+PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
@@ -36,5 +36,5 @@ PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "pcuic"]
+]
+install: [
+  [make "-C" "pcuic" "install"]
+]
+depends: [
+  "coq" {>= "8.13" & < "8.14~"}
+  "coq-equations" { >= "1.2.3" }
+  "coq-metacoq-template" {= version}
+]
+synopsis: "A type system equivalent to Coq's and its metatheory"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The PCUIC module provides a cleaned-up specification of Coq's typing algorithm along
+with a certified typechecker for it. This module includes the standard metatheory of
+PCUIC: Weakening, Substitution, Confluence and Subject Reduction are proven here.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.11/opam
@@ -40,5 +40,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 # }
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "safechecker"]
+]
+install: [
+  [make "-C" "safechecker" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+]
+synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The SafeChecker modules provides a correct implementation of
+weak-head reduction, conversion and typechecking of Coq definitions and global environments.
+"""
+# url {
+#   src: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+#   checksum: "md5=e81b8ecabef788a10337a39b095d54f3"
+# }
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.12/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "safechecker"]
+]
+install: [
+  [make "-C" "safechecker" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.12~"}
+  "coq" { >= "8.12~" & < "8.13~" }
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+]
+synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The SafeChecker modules provides a correct implementation of
+weak-head reduction, conversion and typechecking of Coq definitions and global environments.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.12/opam
@@ -36,5 +36,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.13/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "safechecker"]
+]
+install: [
+  [make "-C" "safechecker" "install"]
+]
+depends: [
+  "coq" {>= "8.13" & < "8.14~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+]
+synopsis: "Implementation and verification of safe conversion and typechecking algorithms for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The SafeChecker modules provides a correct implementation of
+weak-head reduction, conversion and typechecking of Coq definitions and global environments.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}

--- a/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-safechecker/coq-metacoq-safechecker.1.0~beta2+8.13/opam
@@ -35,5 +35,5 @@ weak-head reduction, conversion and typechecking of Coq definitions and global e
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.11/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "template-coq"]
+]
+install: [
+  [make "-C" "template-coq" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-equations" { >= "1.2.3" }
+]
+synopsis: "A quoting and unquoting library for Coq in Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+Template Coq is a quoting library for Coq. It takes Coq terms and
+constructs a representation of their syntax tree as a Coq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Coq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaCoq/MTac.
+"""
+# url {
+#   src: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+#   checksum: "md5=e81b8ecabef788a10337a39b095d54f3"
+# }
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.11/opam
@@ -49,5 +49,5 @@ Template Coq includes:
 # }
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.12/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.12"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "template-coq"]
+]
+install: [
+  [make "-C" "template-coq" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" { >= "8.12~"  & < "8.13~" }
+  "coq-equations" { >= "1.2.3" }
+]
+synopsis: "A quoting and unquoting library for Coq in Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+Template Coq is a quoting library for Coq. It takes Coq terms and
+constructs a representation of their syntax tree as a Coq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Coq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaCoq/MTac.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.12/opam
@@ -45,5 +45,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.13/opam
@@ -45,5 +45,5 @@ Template Coq includes:
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.0~beta2+8.13/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.13"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "template-coq"]
+]
+install: [
+  [make "-C" "template-coq" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.13" & < "8.14~"}
+  "coq-equations" { >= "1.2.3" }
+]
+synopsis: "A quoting and unquoting library for Coq in Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+Template Coq is a quoting library for Coq. It takes Coq terms and
+constructs a representation of their syntax tree as a Coq inductive data
+type. The representation is based on the kernel's term representation.
+
+In addition to a complete reification and denotation of CIC terms,
+Template Coq includes:
+
+- Reification of the environment structures, for constant and inductive declarations.
+- Denotation of terms and global declarations
+- A monad for manipulating global declarations, calling the type
+  checker, and inserting them in the global environment, in the style of
+  MetaCoq/MTac.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.11/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j%{jobs}%" "-C" "translations"]
+]
+install: [
+  [make "-C" "translations" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+]
+synopsis: "Translations built on top of MetaCoq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Translations modules provides implementation of standard translations 
+from type theory to type theory, e.g. parametricity and the `cross-bool` 
+translation that invalidates functional extensionality.
+"""
+# url {
+#   src: "https://github.com/MetaCoq/metacoq/archive/v2.1-beta3.tar.gz"
+#   checksum: "md5=e81b8ecabef788a10337a39b095d54f3"
+# }
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.11/opam
@@ -36,5 +36,5 @@ translation that invalidates functional extensionality.
 # }
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.12/opam
@@ -32,5 +32,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.12/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "translations"]
+]
+install: [
+  [make "-C" "translations" "install"]
+]
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.12~"}
+  "coq" { >= "8.12~" & < "8.13~" }
+  "coq-metacoq-template" {= version}
+]
+synopsis: "Translations built on top of MetaCoq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Translations modules provides implementation of standard translations 
+from type theory to type theory, e.g. parametricity and the `cross-bool` 
+translation that invalidates functional extensionality.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.13/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+build: [
+  ["sh" "./configure.sh"]
+  [make "-j" "%{jobs}%" "-C" "translations"]
+]
+install: [
+  [make "-C" "translations" "install"]
+]
+depends: [
+  "coq-metacoq-template" {= version}
+]
+synopsis: "Translations built on top of MetaCoq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The Translations modules provides implementation of standard translations 
+from type theory to type theory, e.g. parametricity and the `cross-bool` 
+translation that invalidates functional extensionality.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}

--- a/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-translations/coq-metacoq-translations.1.0~beta2+8.13/opam
@@ -30,5 +30,5 @@ translation that invalidates functional extensionality.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.11/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.07.1"}
+  "coq" {>= "8.11" & < "8.12~"}
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+  "coq-metacoq-erasure" {= version}
+  "coq-metacoq-translations" {= version}
+]
+synopsis: "A meta-programming framework for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The meta-package includes the template-coq library, unverified checker for Coq,
+PCUIC development including a verified translation from Coq to PCUIC, 
+safe checker and erasure for PCUIC and example translations. 
+
+See individual packages for more detailed descriptions.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
+  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+}

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.11/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.11/opam
@@ -35,5 +35,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.11.tar.gz"
-  checksum: "sha256=8ed0fd3942f12c7f48499fe367f31bbe60dc27fff3a22eeb9c4d4009d783a902"
+  checksum: "sha256=35d4a30bb19e6710fc03d178a2c8a17bc964bfbfd9236d1c59a0e77a30c425df"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.12/opam
@@ -35,5 +35,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
-  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+  checksum: "sha256=108582a6f11ed511a5a94f2b302359f8d648168cba893169009def7c19e08778"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.12/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.12/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.07.1" & < "4.12~"}
+  "coq" { >= "8.12~" & < "8.13~" }
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+  "coq-metacoq-erasure" {= version}
+  "coq-metacoq-translations" {= version}
+]
+synopsis: "A meta-programming framework for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The meta-package includes the template-coq library, unverified checker for Coq,
+PCUIC development including a verified translation from Coq to PCUIC, 
+safe checker and erasure for PCUIC and example translations. 
+
+See individual packages for more detailed descriptions.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.12.tar.gz"
+  checksum: "sha256=52e5cb50bdbf439ebd157ca4da2425805891f231b82eb9282e2869a8502012b7"
+}

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.13/opam
@@ -33,5 +33,5 @@ See individual packages for more detailed descriptions.
 """
 url {
   src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
-  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+  checksum: "sha256=15e1cfde70e6c4dbf33bff1a77266ac5c0c3e280586ef059e0cdec07bee814f2"
 }

--- a/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq/coq-metacoq.1.0~beta2+8.13/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://metacoq.github.io/metacoq"
+dev-repo: "git+https://github.com/MetaCoq/metacoq.git#coq-8.11"
+bug-reports: "https://github.com/MetaCoq/metacoq/issues"
+authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
+          "Simon Boulier <simon.boulier@inria.fr>"
+          "Cyril Cohen <cyril.cohen@inria.fr>"
+          "Yannick Forster <forster@ps.uni-saarland.de>"
+          "Fabian Kunze <fkunze@fakusb.de>"
+          "Gregory Malecha <gmalecha@gmail.com>"
+          "Matthieu Sozeau <matthieu.sozeau@inria.fr>"
+          "Nicolas Tabareau <nicolas.tabareau@inria.fr>"
+          "Théo Winterhalter <theo.winterhalter@inria.fr>"
+]
+license: "MIT"
+depends: [
+  "coq-metacoq-template" {= version}
+  "coq-metacoq-pcuic" {= version}
+  "coq-metacoq-safechecker" {= version}
+  "coq-metacoq-erasure" {= version}
+  "coq-metacoq-translations" {= version}
+]
+synopsis: "A meta-programming framework for Coq"
+description: """
+MetaCoq is a meta-programming framework for Coq.
+
+The meta-package includes the template-coq library, unverified checker for Coq,
+PCUIC development including a verified translation from Coq to PCUIC, 
+safe checker and erasure for PCUIC and example translations. 
+
+See individual packages for more detailed descriptions.
+"""
+url {
+  src: "https://github.com/MetaCoq/metacoq/archive/v1.0-beta2-8.13.tar.gz"
+  checksum: "sha256=4d2d2e5eaa9dba2f903961f036852b55925b3c267ec7eaa0ddb2bf44ac9c016f"
+}


### PR DESCRIPTION
ci-skip: coq-metacoq-erasure.1.0~beta2+8.11 coq-metacoq-erasure.1.0~beta2+8.12 coq-metacoq-erasure.1.0~beta2+8.13 coq-metacoq-pcuic.1.0~beta2+8.11 coq-metacoq-pcuic.1.0~beta2+8.12 coq-metacoq-pcuic.1.0~beta2+8.13 coq-metacoq-safechecker.1.0~beta2+8.11 coq-metacoq-safechecker.1.0~beta2+8.12 coq-metacoq-safechecker.1.0~beta2+8.13 coq-metacoq-template.1.0~beta2+8.11 coq-metacoq-template.1.0~beta2+8.12 coq-metacoq-template.1.0~beta2+8.13 coq-metacoq-translations.1.0~beta2+8.11 coq-metacoq-translations.1.0~beta2+8.12 coq-metacoq-translations.1.0~beta2+8.13
