### PR TITLE
Add coq-coqffi.1.0.0~beta3

### DIFF
--- a/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta3/opam
+++ b/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thomas.letan@ssi.gouv.fr"
+
+homepage: "https://github.com/coq-community/coqffi"
+dev-repo: "git+https://github.com/coq-community/coqffi.git"
+bug-reports: "https://github.com/coq-community/coqffi/issues"
+license: "MIT"
+
+synopsis: "Tool for generating Coq FFI bindings to OCaml libraries"
+description: """
+`coqffi` generates the necessary Coq boilerplate to use OCaml functions in a
+Coq development, and configures the Coq extraction mechanism accordingly."""
+
+build: [
+  ["./src-prepare.sh"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "4.12~" }
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.13~") | (= "dev")}
+  "cmdliner" {>= "1.0.4"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:foreign function interface"
+  "keyword:extraction"
+  "keyword:OCaml"
+  "logpath:CoqFFI"
+]
+authors: [
+  "Thomas Letan"
+  "Li-yao Xia"
+  "Yann Régis-Gianas"
+  "Yannick Zakowski"
+]
+url {
+  src: "https://github.com/coq-community/coqffi/archive/1.0.0-beta3.tar.gz"
+  checksum: "sha512=5d0a924eac883591b8bf85296b1351fa57f99839500fb05fa423dffc08b6107bf5682c4e4bb4a1911657cc48ff6780bdcb6c5d65ee58641a5345bc1559125908"
+}


### PR DESCRIPTION
This third beta introduces way more features than anticipated. If everything goes as planned, there should be one last beta to fix any remaining bugs, and then `coq-coqffi.1.0.0` will finally be a thing :tada:.