### PR TITLE
Add opam packages for VST 2.7

### DIFF
--- a/released/packages/coq-vst-32/coq-vst-32.2.7/files/makefile.patch
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7/files/makefile.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2021-01-07 15:07:22.686505085 +0100
++++ b/Makefile	2021-01-07 15:07:17.654503280 +0100
+@@ -21,7 +21,7 @@
+ 
+ # Check Coq version
+ 
+-COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13
++COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0
+ 
+ COQV=$(shell $(COQC) -v)
+ ifneq ($(IGNORECOQVERSION),true)

--- a/released/packages/coq-vst-32/coq-vst-32.2.7/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "Sandrine Blazy"
+  "Qinxiang Cao"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Josiah Dodds"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Aquinas Hobor"
+  "Jean-Marie Madiot"
+  "William Mansky"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+build: [
+  [make "-j%{jobs}%" "BITSIZE=32"]
+]
+install: [
+  [make "install" "BITSIZE=32"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.11" & < "8.14"}
+  "coq-compcert-32" {(= "3.8") | (= "3.8~open-source")}
+  "coq-flocq" {>= "3.2.1"}
+]
+tags: [
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2020-12-20"
+]
+patches: ["makefile.patch"]
+extra-files: [ ["makefile.patch" "md5=a7242f51c9a723a23c9b3d7ffa062d31"] ]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz"
+  checksum: "sha256=970be13e71bdb013e2b9de64aecf1dda08228dd8ef3a1f6e4bb23ccd3a0896d3"
+}

--- a/released/packages/coq-vst/coq-vst.2.7/files/makefile.patch
+++ b/released/packages/coq-vst/coq-vst.2.7/files/makefile.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2021-01-07 15:07:22.686505085 +0100
++++ b/Makefile	2021-01-07 15:07:17.654503280 +0100
+@@ -21,7 +21,7 @@
+ 
+ # Check Coq version
+ 
+-COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13
++COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0
+ 
+ COQV=$(shell $(COQC) -v)
+ ifneq ($(IGNORECOQVERSION),true)

--- a/released/packages/coq-vst/coq-vst.2.7/opam
+++ b/released/packages/coq-vst/coq-vst.2.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "Sandrine Blazy"
+  "Qinxiang Cao"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Josiah Dodds"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Aquinas Hobor"
+  "Jean-Marie Madiot"
+  "William Mansky"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+build: [
+  [make "-j%{jobs}%" "BITSIZE=64"]
+]
+install: [
+  [make "install" "BITSIZE=64"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.11" & < "8.14"}
+  "coq-compcert" {(= "3.8") | (= "3.8~open-source")}
+  "coq-flocq" {>= "3.2.1"}
+]
+tags: [
+  "category:CS/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2020-12-20"
+]
+patches: ["makefile.patch"]
+extra-files: [ ["makefile.patch" "md5=a7242f51c9a723a23c9b3d7ffa062d31"] ]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz"
+  checksum: "sha256=970be13e71bdb013e2b9de64aecf1dda08228dd8ef3a1f6e4bb23ccd3a0896d3"
+}


### PR DESCRIPTION
This PR adds opam packages for VST version 2.7.

This is the version from the Coq Platform v8.13 branch.

Please don't confuse this PR with #1542 which is about dev packages for VST which currently has issues (incompatibility with master changes in CompCert - need to look into that).