### PR TITLE
Fix dependencies for coq-switch.1.0.4

### DIFF
--- a/released/packages/coq-switch/coq-switch.1.0.4/opam
+++ b/released/packages/coq-switch/coq-switch.1.0.4/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.12.0"}
-  "coq-metacoq-template" {>= "1.0~beta1+8.12"}
+  "coq-metacoq-template" {>= "1.0~beta1+8.12" & < "1.0~beta2+8.12"}
 ]
 tags: [
   "category:Miscellaneous/Coq Extensions"


### PR DESCRIPTION
@vzaliva Fixing the dependencies of coq-switch.1.0.4 as there is this error with the latest version of `coq-metacoq-template`:
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-switch.1.0.4 coq.8.12.1
Return code
    7936
Duration
    10 s
Output

    # Packages matching: installed
    # Name               # Installed    # Synopsis
    base-bigarray        base
    base-threads         base
    base-unix            base
    conf-findutils       1              Virtual package relying on findutils
    conf-m4              1              Virtual package relying on m4
    coq                  8.12.1         Formal proof management system
    coq-equations        1.2.3+8.12     A function definition package for Coq
    coq-metacoq-template 1.0~beta2+8.12 A quoting and unquoting library for Coq in Coq
    num                  1.4            The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                4.10.1         The OCaml compiler (virtual package)
    ocaml-base-compiler  4.10.1         Official release 4.10.1
    ocaml-config         1              OCaml Switch Configuration
    ocamlfind            1.8.1          A library manager for OCaml
    [NOTE] Package coq is already installed (current version is 8.12.1).
    The following actions will be performed:
      - install coq-switch 1.0.4
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-switch.1.0.4: http]
    [coq-switch.1.0.4] downloaded from https://github.com/vzaliva/coq-switch/archive/v1.0.4.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-switch: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-switch.1.0.4)
    - coq_makefile -f _CoqProject -o Makefile.coq
    - make -f Makefile.coq
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-switch.1.0.4'
    - COQDEP VFILES
    - COQC theories/Switch.v
    - File "./theories/Switch.v", line 25, characters 15-26:
    - Error:
    - In environment
    - mkSwitchCases : kername -> term -> term -> list term -> nat -> term
    - type_name : kername
    - A_t : term
    - P_t : term
    - choices_t : list term
    - n : nat
    - ind_0 := fun n : kername => {| inductive_mind := n; inductive_ind := 0 |} :
    - kername -> inductive
    - T_i := ind_0 type_name : inductive
    - bool_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "bool") : inductive
    - opt_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "option") : inductive
    - x : term
    - xs : list term
    - The term "(bool_i, 0)" has type "inductive × nat"
    - while it is expected to have type "(inductive × nat) × relevance".
    - 
    - make[2]: *** [Makefile.coq:716: theories/Switch.vo] Error 1
    - make[1]: *** [Makefile.coq:339: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-switch.1.0.4'
    - make: *** [Makefile:2: all] Error 2
    [ERROR] The compilation of coq-switch failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-switch.1.0.4 ===================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-switch.1.0.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-switch-22182-865888.env
    # output-file          ~/.opam/log/coq-switch-22182-865888.out
    ### output ###
    # [...]
    # T_i := ind_0 type_name : inductive
    # bool_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "bool") : inductive
    # opt_i := ind_0 (MPfile ["Datatypes"; "Init"; "Coq"], "option") : inductive
    # x : term
    # xs : list term
    # The term "(bool_i, 0)" has type "inductive × nat"
    # while it is expected to have type "(inductive × nat) × relevance".
    # 
    # make[2]: *** [Makefile.coq:716: theories/Switch.vo] Error 1
    # make[1]: *** [Makefile.coq:339: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-switch.1.0.4'
    # make: *** [Makefile:2: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-switch 1.0.4
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-switch.1.0.4 coq.8.12.1' failed.
```