### PR TITLE
Update Coq version for coq-vst.2.7

### DIFF
--- a/released/packages/coq-vst/coq-vst.2.7/opam
+++ b/released/packages/coq-vst/coq-vst.2.7/opam
@@ -28,7 +28,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.11" & < "8.14"}
+  "coq" {>= "8.12" & < "8.14"}
   "coq-compcert" {(= "3.8") | (= "3.8~open-source")}
   "coq-flocq" {>= "3.2.1"}
 ]


### PR DESCRIPTION
@MSoegtropIMC It seems that `coq-vst.2.7` requires Coq version 8.12:
https://coq-bench.github.io/clean/Linux-x86_64-4.10.1-2.0.6/released/8.11.2/vst/2.7.html
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-vst.2.7 coq.8.11.2
Return code
    7936
Duration
    11 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-g++            1.0         Virtual package relying on the g++ compiler (for C++)
    conf-m4             1           Virtual package relying on m4
    coq                 8.11.2      Formal proof management system
    coq-compcert        3.8         The CompCert C compiler (64 bit)
    coq-flocq           3.4.0       A formalization of floating-point arithmetic for the Coq system
    coq-menhirlib       20201216    A support library for verified Coq parsers produced by Menhir
    dune                2.8.2       Fast, portable, and opinionated build system
    menhir              20201216    An LR(1) parser generator
    menhirLib           20201216    Runtime support library for parsers generated by Menhir
    menhirSdk           20201216    Compile-time library for auxiliary tools related to Menhir
    num                 1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml               4.10.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.10.1      Official release 4.10.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.8.1       A library manager for OCaml
    [NOTE] Package coq is already installed (current version is 8.11.2).
    The following actions will be performed:
      - install coq-vst 2.7
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-vst.2.7: http]
    [coq-vst.2.7] downloaded from https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-vst: patch]
    Processing  1/2: [coq-vst: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" "BITSIZE=64" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-vst.2.7)
    - Makefile:29: *** FAILURE: You need Coq 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0 but you have this version: The Coq Proof Assistant, version 8.11.2 (February 2021) compiled on Feb 2 2021 12:52:17 with OCaml 4.10.1.  Stop.
    [ERROR] The compilation of coq-vst failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4 BITSIZE=64".
    #=== ERROR while compiling coq-vst.2.7 ========================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.10.1/.opam-switch/build/coq-vst.2.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4 BITSIZE=64
    # exit-code            2
    # env-file             ~/.opam/log/coq-vst-2841-8b8a2d.env
    # output-file          ~/.opam/log/coq-vst-2841-8b8a2d.out
    ### output ###
    # Makefile:29: *** FAILURE: You need Coq 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0 but you have this version: The Coq Proof Assistant, version 8.11.2 (February 2021) compiled on Feb 2 2021 12:52:17 with OCaml 4.10.1.  Stop.
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-vst 2.7
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-vst.2.7 coq.8.11.2' failed.
```