### PR TITLE
coq-vst: allow Coq 8.13.1 in Makefile

### DIFF
--- a/released/packages/coq-vst-32/coq-vst-32.2.7/files/makefile.patch
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7/files/makefile.patch
@@ -5,7 +5,7 @@
  # Check Coq version
  
 -COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13
-+COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0
++COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13.0 or-else 8.13.1
  
  COQV=$(shell $(COQC) -v)
  ifneq ($(IGNORECOQVERSION),true)

--- a/released/packages/coq-vst-32/coq-vst-32.2.7/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7/opam
@@ -39,7 +39,6 @@ tags: [
   "date:2020-12-20"
 ]
 patches: ["makefile.patch"]
-extra-files: [ ["makefile.patch" "md5=a7242f51c9a723a23c9b3d7ffa062d31"] ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz"
   checksum: "sha256=970be13e71bdb013e2b9de64aecf1dda08228dd8ef3a1f6e4bb23ccd3a0896d3"

--- a/released/packages/coq-vst/coq-vst.2.7/files/makefile.patch
+++ b/released/packages/coq-vst/coq-vst.2.7/files/makefile.patch
@@ -5,7 +5,7 @@
  # Check Coq version
  
 -COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13
-+COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13+beta1 or-else 8.13.0
++COQVERSION= 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13.0 or-else 8.13.1
  
  COQV=$(shell $(COQC) -v)
  ifneq ($(IGNORECOQVERSION),true)

--- a/released/packages/coq-vst/coq-vst.2.7/opam
+++ b/released/packages/coq-vst/coq-vst.2.7/opam
@@ -39,7 +39,6 @@ tags: [
   "date:2020-12-20"
 ]
 patches: ["makefile.patch"]
-extra-files: [ ["makefile.patch" "md5=a7242f51c9a723a23c9b3d7ffa062d31"] ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz"
   checksum: "sha256=970be13e71bdb013e2b9de64aecf1dda08228dd8ef3a1f6e4bb23ccd3a0896d3"


### PR DESCRIPTION
This PR allows Coq 8.13.1 in the makefile of coq-vst and coq-vst-32.