### PR TITLE
Fix optional argument warning in coq-elpi with ocaml-4.12

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.1.8.1/files/coq_elpi_HOAS.diff
+++ b/released/packages/coq-elpi/coq-elpi.1.8.1/files/coq_elpi_HOAS.diff
@@ -1,0 +1,39 @@
+diff --git a/src/coq_elpi_HOAS.ml b/src/coq_elpi_HOAS.ml
+index 853c8cf..f747b3a 100644
+--- a/src/coq_elpi_HOAS.ml
++++ b/src/coq_elpi_HOAS.ml
+@@ -1422,13 +1422,13 @@ let goal_namec = E.Constants.declare_global_symbol "goal-name"
+ let mk_goal hyps ev ty attrs =
+   E.mkApp goalc hyps [ev;ty; U.list_to_lp_list attrs]
+ 
+-let in_elpi_goal ?goal_name ~hyps ~raw_ev ~ty =
++let in_elpi_goal ~goal_name ~hyps ~raw_ev ~ty =
+   let name = match goal_name with None -> Anonymous | Some x -> Name x in
+   let name = E.mkApp goal_namec (in_elpi_name name) [] in
+   mk_goal hyps raw_ev ty [name]
+ 
+-let in_elpi_solve ?goal_name ~hyps ~raw_ev ~ty ~args ~new_goals =
+-  let g = in_elpi_goal ?goal_name ~hyps ~raw_ev ~ty in
++let in_elpi_solve ~goal_name ~hyps ~raw_ev ~ty ~args ~new_goals =
++  let g = in_elpi_goal ~goal_name ~hyps ~raw_ev ~ty in
+   let gl = E.mkCons g E.mkNil in
+   E.mkApp solvec args [gl; new_goals]
+ 
+@@ -1446,7 +1446,7 @@ let embed_goal ~depth state k =
+           let state, hyps, raw_ev, _, goal_ty, gls =
+             in_elpi_evar_concl evar_concl elpi_raw_goal_evar elpi_goal_evar
+               coq_ctx hyps ~calldepth ~depth state in
+-         state, in_elpi_goal ?goal_name ~hyps ~raw_ev ~ty:goal_ty, gls)
++         state, in_elpi_goal ~goal_name ~hyps ~raw_ev ~ty:goal_ty, gls)
+ 
+ let goal2query env sigma goal loc ?main args ~in_elpi_arg ~depth:calldepth state =
+   if not (Evd.is_undefined sigma goal) then
+@@ -1478,7 +1478,7 @@ let goal2query env sigma goal loc ?main args ~in_elpi_arg ~depth:calldepth state
+           let state, args =
+             CList.fold_left_map (in_elpi_arg ~depth coq_ctx [] sigma) state args in
+           let args = U.list_to_lp_list args in
+-          let q = in_elpi_solve ?goal_name ~hyps ~raw_ev ~ty:goal_ty ~args ~new_goals in
++          let q = in_elpi_solve ~goal_name ~hyps ~raw_ev ~ty:goal_ty ~args ~new_goals in
+           state, q, gls
+       | Some text ->
+           let state, q = API.Quotation.lp ~depth state loc text in

--- a/released/packages/coq-elpi/coq-elpi.1.8.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.8.1/opam
@@ -12,6 +12,7 @@ depends: [
   "elpi" {>= "1.12.0" & < "1.13.0~"}
   "coq" {>= "8.13" & < "8.14~" }
   ]
+patches: [ "coq_elpi_HOAS.diff" ]
 tags: [ "logpath:elpi" ]
 synopsis: "Elpi extension language for Coq"
 description: """


### PR DESCRIPTION
This warning causes an error when compiling the plugin, making impossible to install it on ocaml-4.12.
(Coq should not error on warnings when compiling plugins, but this is another story)