### PR TITLE
Bump Coq lower bound for ITree and SSReflect

### DIFF
--- a/extra-dev/packages/coq-itree/coq-itree.dev/opam
+++ b/extra-dev/packages/coq-itree/coq-itree.dev/opam
@@ -14,7 +14,7 @@ install: [ make "install" ]
 run-test: [ make "-j%{jobs}%" "all" ]
 
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.9"}
   "coq-ext-lib" {>= "0.10.3"}
   "coq-paco" {>= "4.0.0"}
   "ocamlbuild" {with-test}

--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -9,7 +9,7 @@ license: "CeCILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { (>= "8.10" & < "8.13~") | (= "dev") } ]
+depends: [ "coq" { (>= "8.11" & < "8.13~") | (= "dev") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
per:
- DeepSpec/InteractionTrees@672193e2507cf3326b834f5fa47b7518af829b4b
- math-comp/math-comp#686