### PR TITLE
Package coq-menhirlib.20210310

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
@@ -6,7 +6,7 @@ authors: [
 ]
 homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
 dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
-bug-reports: "jacques-henri.jourdan@lri.fr"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
 license: "LGPL-3.0-or-later"
 build: [
   [make "-C" "coq-menhirlib" "-j%{jobs}%"]

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "jacques-henri.jourdan@lri.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20210310" }
+]
+tags: [
+  "date:2021-03-10"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20210310/archive.tar.gz"
+  checksum: [
+    "md5=1cbc71c0bc1f3ddc3e71d5c1f919fd1a"
+    "sha512=3c309fa2cc4ad7c6fba85107bd946a542894882fa39741496b150307e93455b717418f19e94b5dad06ab269f5c55e8dc25705c96c0a5092e623fa38f1ce43c7f"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20210310`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: jacques-henri.jourdan@lri.fr

---
:camel: Pull-request generated by opam-publish v2.0.3