### PR TITLE
coq-iris-string-ident: fix coq-iris dependency

### DIFF
--- a/released/packages/coq-iris-string-ident/coq-iris-string-ident.0.1.0/opam
+++ b/released/packages/coq-iris-string-ident/coq-iris-string-ident.0.1.0/opam
@@ -13,7 +13,7 @@ This package implements string_to_ident in Ltac2, enabling support for Gallina n
 
 depends: [
   "coq" {>= "8.11" & < "8.14~"}
-  "coq-iris" {(>= "3.3.0" & < "4.0") | = "dev"}
+  "coq-iris" {(>= "3.3.0" & < "3.5.0")}
 ]
 
 build: [make "-j%{jobs}%"]


### PR DESCRIPTION
Iris `dev` is no longer compatible with the plugin (since the plugin is now integrated in Iris proper).