### PR TITLE
CompCert 3.8: incompatible with Menhir dev

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.8/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.8/opam
@@ -30,7 +30,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.8.0" & < "8.14"}
-  "menhir" {>= "20190626"}
+  "menhir" {>= "20190626" & != "dev"}
   "ocaml" {>= "4.05.0"}
   "coq-flocq" {>= "3.1.0"}
   "coq-menhirlib" {>= "20190626"}


### PR DESCRIPTION
CompCert 3.8 [requires `menhir --version` to be numerical](https://github.com/AbsInt/CompCert/blob/v3.8/configure#L587-L611), but the dev version prints `menhir, version unreleased`.
There should be a way to patch the `configure` file and fix it, but I'm not familiar with patching. Feel free to push changes on my branch.