### PR TITLE
Updating LibHyps to 1.0.2.

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.1.0.2/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.1.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Pierre.Courtieu@lecnam.net"
+synopsis: "Hypotheses manipulation library"
+
+homepage: "https://github.com/Matafou/LibHyps"
+dev-repo: "git+https://github.com/Matafou/LibHyps.git"
+bug-reports: "https://github.com/Matafou/LibHyps/issues"
+doc: "https://github.com/Matafou/LibHyps"
+license: "GPL-3.0-or-later"
+
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+
+install: [make "install"]
+
+depends: [
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+]
+
+tags: [
+  "keyword:proof environment manipulation"
+  "keyword:forward reasoning"
+  "keyword:hypothesis naming"
+  "logpath:LibHyps"
+  "date:2021-04-02"
+]
+
+authors: [
+ "Pierre Courtieu"
+]
+
+description: "
+This library defines a set of tactics to manipulate hypothesis
+individually or by group. In particular it allows applying a tactic on
+each hypothesis of a goal, or only on *new* hypothesis after some
+tactic. Examples of manipulations: automatic renaming, subst, revert,
+or any tactic expecting a hypothesis name as argument. "
+
+url {
+    http: "https://github.com/Matafou/LibHyps/archive/libhyps-1.0.2.tar.gz"
+    checksum: "9ebb00f3227c316e8aa798addfcabd6a"
+}


### PR DESCRIPTION
Small update.
1) Question about the release process: this version is supposed to replace the previous one, whatever coq version. Should I remove the previous version from the archive? Or should previous version be still there?
2) This is not the case here but if I want to have several versions of this library that are compatible with non-disjoint sets of coq versions, is it possible, discouraged or forbidden?