### PR TITLE
Add ocamlfind dependency to coq-bignums.8.12.0

### DIFF
--- a/released/packages/coq-bignums/coq-bignums.8.12.0/opam
+++ b/released/packages/coq-bignums/coq-bignums.8.12.0/opam
@@ -19,6 +19,7 @@ install: [
 ]
 depends: [
   "ocaml"
+  "ocamlfind" {build}
   "coq" {>= "8.12" & < "8.13~"}
 ]
 tags: [


### PR DESCRIPTION
Usually `ocamlfind` is installed with Coq but may be removed after the install.