### PR TITLE
Fix Coq version for coq-hierarchy-builder-shim

### DIFF
--- a/released/packages/coq-hierarchy-builder-shim/coq-hierarchy-builder-shim.1.1.0/opam
+++ b/released/packages/coq-hierarchy-builder-shim/coq-hierarchy-builder-shim.1.1.0/opam
@@ -11,7 +11,7 @@ dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
 build: [ make "-C" "shim" "build" ]
 install: [ make "-C" "shim" "install" ]
 conflicts: [ "coq-hierarchy-builder" ]
-depends: [ "coq" ]
+depends: [ "coq" {>= "8.9"} ]
 synopsis: "Shim package for HB"
 description: """
 This package provide the support constants one can use to compile files


### PR DESCRIPTION
An example of install error with Coq 8.8:
```
# Packages matching: installed
# Name              # Installed # Synopsis
base-bigarray       base
base-num            base        Num library distributed with the OCaml compiler
base-threads        base
base-unix           base
camlp5              7.14        Preprocessor-pretty-printer of OCaml
conf-findutils      1           Virtual package relying on findutils
conf-perl           1           Virtual package relying on perl
coq                 8.8.2       Formal proof management system
num                 0           The Num library for arbitrary-precision integer and rational arithmetic
ocaml               4.03.0      The OCaml compiler (virtual package)
ocaml-base-compiler 4.03.0      Official 4.03.0 release
ocaml-config        1           OCaml Switch Configuration
ocamlfind           1.9.1       A library manager for OCaml
[NOTE] Package coq is already installed (current version is 8.8.2).
The following actions will be performed:
  - install coq-hierarchy-builder-shim 1.1.0
<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/1: [coq-hierarchy-builder-shim.1.1.0: http]
[coq-hierarchy-builder-shim.1.1.0] downloaded from https://github.com/math-comp/hierarchy-builder/archive/v1.1.0.tar.gz
Processing  1/1:
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/2: [coq-hierarchy-builder-shim: make shim]
+ /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-C" "shim" "build" (CWD=/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0)
- make: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
- coq_makefile -f _CoqProject -o Makefile.coq
- make -f Makefile.coq
- make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
- COQDEP VFILES
- COQC structures.v
- File "./structures.v", line 2, characters 7-26:
- Error: String.StringSyntax is not a module
- 
- make[2]: *** [Makefile.coq:657: structures.vo] Error 1
- make[1]: *** [Makefile.coq:318: all] Error 2
- make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
- make: *** [Makefile:4: build] Error 2
- make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
[ERROR] The compilation of coq-hierarchy-builder-shim failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -C shim build".
#=== ERROR while compiling coq-hierarchy-builder-shim.1.1.0 ===================#
# context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/bench/run/opam-coq-archive/released
# path                 ~/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C shim build
# exit-code            2
# env-file             ~/.opam/log/coq-hierarchy-builder-shim-642-335865.env
# output-file          ~/.opam/log/coq-hierarchy-builder-shim-642-335865.out
### output ###
# [...]
# make -f Makefile.coq
# make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
# COQDEP VFILES
# COQC structures.v
# File "./structures.v", line 2, characters 7-26:
# Error: String.StringSyntax is not a module
# 
# make[2]: *** [Makefile.coq:657: structures.vo] Error 1
# make[1]: *** [Makefile.coq:318: all] Error 2
# make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
# make: *** [Makefile:4: build] Error 2
# make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.03.0/.opam-switch/build/coq-hierarchy-builder-shim.1.1.0/shim'
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build coq-hierarchy-builder-shim 1.1.0
+- 
- No changes have been performed
# Run eval $(opam env) to update the current shell environment
'opam install -y -v coq-hierarchy-builder-shim.1.1.0 coq.8.8.2' failed.
```