### PR TITLE
Add ocamlfind dep for coq-paramcoq.1.1.2+coq8.11

### DIFF
--- a/released/packages/coq-paramcoq/coq-paramcoq.1.1.2+coq8.11/opam
+++ b/released/packages/coq-paramcoq/coq-paramcoq.1.1.2+coq8.11/opam
@@ -10,6 +10,8 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.11" & < "8.12~"}
+  "ocaml"
+  "ocamlfind" {build}
 ]
 
 tags: [


### PR DESCRIPTION
An example of error:
```
Command
    opam list; echo; ulimit -Sv 4000000; timeout 2h opam install -y --deps-only coq-monae.0.2.1 coq.8.11.2
Return code
    7936
Duration
    1 h 12 m
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    coq                 8.11.2      Formal proof management system
    num                 1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml               4.07.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.07.1      Official release 4.07.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    The following actions will be performed:
      - install   coq-paramcoq             1.1.2+coq8.11
      - install   seq                      base
      - install   conf-m4                  1              [required by ocamlfind]
      - install   coq-mathcomp-ssreflect   1.11.0
      - install   ocaml-secondary-compiler 4.08.1-1
      - install   conf-perl                1
      - downgrade ocamlfind                1.9.1 to 1.8.1
      - install   coq-mathcomp-fingroup    1.11.0
      - install   coq-mathcomp-bigenough   1.0.0
      - install   camlp5                   7.14
      - install   ocamlfind-secondary      1.8.1
      - install   coq-mathcomp-algebra     1.11.0
      - install   coq-mathcomp-finmap      1.5.1
      - install   dune                     2.8.4
      - install   coq-mathcomp-solvable    1.11.0
      - install   sexplib0                 v0.14.0
      - install   result                   1.5
      - install   re                       1.9.0
      - install   ppx_derivers             1.2.1
      - install   ocaml-compiler-libs      v0.12.3
      - install   cppo                     1.6.7
      - install   coq-mathcomp-field       1.11.0
      - install   csexp                    1.4.0
      - install   ocaml-migrate-parsetree  1.8.0
      - install   dune-configurator        2.8.4
      - install   base                     v0.14.0
      - install   stdio                    v0.14.0
      - install   ppxlib                   0.14.0
      - install   ppx_deriving             5.1
      - install   elpi                     1.11.4-1
      - install   coq-elpi                 1.5.0
      - install   coq-hierarchy-builder    0.10.0
      - install   coq-mathcomp-analysis    0.3.4
      - install   coq-infotheo             0.2.1
    ===== 33 to install | 1 to downgrade =====
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    [coq-elpi.1.5.0] downloaded from https://github.com/LPCIC/coq-elpi/archive/v1.5.0.tar.gz
    [base.v0.14.0] downloaded from cache at https://opam.ocaml.org/cache
    [coq-hierarchy-builder.0.10.0] downloaded from https://github.com/math-comp/hierarchy-builder/archive/v0.10.0.tar.gz
    [coq-infotheo.0.2.1] downloaded from https://github.com/affeldt-aist/infotheo/archive/0.2.1.tar.gz
    [camlp5.7.14] downloaded from cache at https://opam.ocaml.org/cache
    [coq-mathcomp-algebra.1.11.0] downloaded from https://github.com/math-comp/math-comp/archive/mathcomp-1.11.0.tar.gz
    [coq-mathcomp-analysis.0.3.4] downloaded from https://github.com/math-comp/analysis/archive/0.3.4.tar.gz
    [coq-mathcomp-field.1.11.0] found in cache
    [coq-mathcomp-fingroup.1.11.0] found in cache
    [coq-mathcomp-bigenough.1.0.0] downloaded from https://github.com/math-comp/bigenough/archive/1.0.0.tar.gz
    [coq-mathcomp-solvable.1.11.0] found in cache
    [coq-mathcomp-ssreflect.1.11.0] found in cache
    [coq-mathcomp-finmap.1.5.1] downloaded from https://github.com/math-comp/finmap/archive/1.5.1.tar.gz
    [coq-paramcoq.1.1.2+coq8.11] downloaded from https://github.com/coq-community/paramcoq/archive/v1.1.2+coq8.11.tar.gz
    [cppo.1.6.7] downloaded from cache at https://opam.ocaml.org/cache
    [csexp.1.4.0] downloaded from cache at https://opam.ocaml.org/cache
    [dune.2.8.4] downloaded from cache at https://opam.ocaml.org/cache
    [elpi.1.11.4-1] downloaded from cache at https://opam.ocaml.org/cache
    [ocaml-compiler-libs.v0.12.3] downloaded from cache at https://opam.ocaml.org/cache
    [dune-configurator.2.8.4] downloaded from cache at https://opam.ocaml.org/cache
    [ocaml-migrate-parsetree.1.8.0] downloaded from cache at https://opam.ocaml.org/cache
    [ocamlfind.1.8.1] downloaded from cache at https://opam.ocaml.org/cache
    [ppx_derivers.1.2.1] downloaded from cache at https://opam.ocaml.org/cache
    [ocaml-secondary-compiler.4.08.1-1] downloaded from cache at https://opam.ocaml.org/cache
    [ocamlfind-secondary.1.8.1] downloaded from cache at https://opam.ocaml.org/cache
    [ppx_deriving.5.1] downloaded from cache at https://opam.ocaml.org/cache
    [result.1.5] downloaded from cache at https://opam.ocaml.org/cache
    [ppxlib.0.14.0] downloaded from cache at https://opam.ocaml.org/cache
    [re.1.9.0] downloaded from cache at https://opam.ocaml.org/cache
    [sexplib0.v0.14.0] downloaded from cache at https://opam.ocaml.org/cache
    [stdio.v0.14.0] downloaded from cache at https://opam.ocaml.org/cache
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    [WARNING] While removing ocamlfind.1.9.1: not removing files that changed since:
                - man/man5/site-lib.5
                - man/man5/findlib.conf.5
                - man/man5/META.5
                - man/man1/ocamlfind.1
                - lib/unix/META
                - lib/toplevel/topfind
                - lib/threads/META
                - lib/str/META
                - lib/stdlib/META
                - lib/raw_spacetime/META
                - lib/ocamldoc/META
                - lib/ocaml/topfind
                - lib/graphics/META
                - lib/findlib/topfind.mli
                - lib/findlib/topfind.cmi
                - lib/findlib/fl_package_base.mli
                - lib/findlib/fl_package_base.cmi
                - lib/findlib/fl_metatoken.cmi
                - lib/findlib/fl_metascanner.mli
                - lib/findlib/fl_metascanner.cmi
                - lib/findlib/fl_dynload.mli
                - lib/findlib/fl_dynload.cmi
                - lib/findlib/findlib_top.cmxs
                - lib/findlib/findlib_top.cmxa
                - lib/findlib/findlib_top.cma
                - lib/findlib/findlib_top.a
                - lib/findlib/findlib_dynload.cmxs
                - lib/findlib/findlib_dynload.cmxa
                - lib/findlib/findlib_dynload.cma
                - lib/findlib/findlib_dynload.a
                - lib/findlib/findlib.mli
                - lib/findlib/findlib.cmxs
                - lib/findlib/findlib.cmxa
                - lib/findlib/findlib.cmi
                - lib/findlib/findlib.cma
                - lib/findlib/findlib.a
                - lib/findlib/Makefile.packages
                - lib/findlib/Makefile.config
                - lib/findlib/META
                - lib/findlib.conf
                - lib/dynlink/META
                - lib/compiler-libs/META
                - lib/bytes/META
                - lib/bigarray/META
    [NOTE] While removing ocamlfind.1.9.1: not removing non-empty directories:
             - lib/unix
             - lib/threads
             - lib/str
             - lib/stdlib
             - lib/raw_spacetime
             - lib/ocamldoc
             - lib/graphics
             - lib/findlib
             - lib/dynlink
             - lib/compiler-libs
             - lib/bytes
             - lib/bigarray
    -> removed   ocamlfind.1.9.1
    -> installed conf-m4.1
    [ERROR] The compilation of coq-paramcoq failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    -> installed conf-perl.1
    -> installed ocamlfind.1.8.1
    -> installed seq.base
    -> installed coq-mathcomp-ssreflect.1.11.0
    -> installed coq-mathcomp-bigenough.1.0.0
    -> installed camlp5.7.14
    -> installed coq-mathcomp-finmap.1.5.1
    -> installed coq-mathcomp-fingroup.1.11.0
    -> installed ocaml-secondary-compiler.4.08.1-1
    -> installed ocamlfind-secondary.1.8.1
    -> installed dune.2.8.4
    -> installed cppo.1.6.7
    -> installed ocaml-compiler-libs.v0.12.3
    -> installed ppx_derivers.1.2.1
    -> installed result.1.5
    -> installed re.1.9.0
    -> installed sexplib0.v0.14.0
    -> installed csexp.1.4.0
    -> installed dune-configurator.2.8.4
    -> installed ocaml-migrate-parsetree.1.8.0
    -> installed base.v0.14.0
    -> installed coq-mathcomp-algebra.1.11.0
    -> installed stdio.v0.14.0
    -> installed ppxlib.0.14.0
    -> installed ppx_deriving.5.1
    -> installed elpi.1.11.4-1
    -> installed coq-mathcomp-solvable.1.11.0
    -> installed coq-elpi.1.5.0
    -> installed coq-hierarchy-builder.0.10.0
    -> installed coq-mathcomp-field.1.11.0
    -> installed coq-mathcomp-analysis.0.3.4
    -> installed coq-infotheo.0.2.1
    #=== ERROR while compiling coq-paramcoq.1.1.2+coq8.11 =========================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-paramcoq.1.1.2+coq8.11
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-paramcoq-11701-78b2de.env
    # output-file          ~/.opam/log/coq-paramcoq-11701-78b2de.out
    ### output ###
    # [...]
    # CAMLOPT -c -for-pack Paramcoq src/relations.ml
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # make[2]: *** [Makefile.coq:625: src/debug.cmx] Error 127
    # make[2]: *** Waiting for unfinished jobs....
    # make[2]: *** [Makefile.coq:625: src/relations.cmx] Error 127
    # CAMLOPT -c -for-pack Paramcoq src/parametricity.ml
    # /bin/sh: 1: /home/bench/.opam/ocaml-base-compiler.4.07.1/bin/ocamlfind: not found
    # make[2]: *** [Makefile.coq:626: src/parametricity.cmx] Error 127
    # make[1]: *** [Makefile.coq:327: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.07.1/.opam-switch/build/coq-paramcoq.1.1.2+coq8.11'
    # make: *** [Makefile:5: coq] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-paramcoq 1.1.2+coq8.11
    +- 
    +- The following changes have been performed
    | - downgrade ocamlfind                1.9.1 to 1.8.1
    | - install   base                     v0.14.0
    | - install   camlp5                   7.14
    | - install   conf-m4                  1
    | - install   conf-perl                1
    | - install   coq-elpi                 1.5.0
    | - install   coq-hierarchy-builder    0.10.0
    | - install   coq-infotheo             0.2.1
    | - install   coq-mathcomp-algebra     1.11.0
    | - install   coq-mathcomp-analysis    0.3.4
    | - install   coq-mathcomp-bigenough   1.0.0
    | - install   coq-mathcomp-field       1.11.0
    | - install   coq-mathcomp-fingroup    1.11.0
    | - install   coq-mathcomp-finmap      1.5.1
    | - install   coq-mathcomp-solvable    1.11.0
    | - install   coq-mathcomp-ssreflect   1.11.0
    | - install   cppo                     1.6.7
    | - install   csexp                    1.4.0
    | - install   dune                     2.8.4
    | - install   dune-configurator        2.8.4
    | - install   elpi                     1.11.4-1
    | - install   ocaml-compiler-libs      v0.12.3
    | - install   ocaml-migrate-parsetree  1.8.0
    | - install   ocaml-secondary-compiler 4.08.1-1
    | - install   ocamlfind-secondary      1.8.1
    | - install   ppx_derivers             1.2.1
    | - install   ppx_deriving             5.1
    | - install   ppxlib                   0.14.0
    | - install   re                       1.9.0
    | - install   result                   1.5
    | - install   seq                      base
    | - install   sexplib0                 v0.14.0
    | - install   stdio                    v0.14.0
    +- 
```