### PR TITLE
Fix deps of coq-graph-theory.0.8

### DIFF
--- a/released/packages/coq-graph-theory/coq-graph-theory.0.8/opam
+++ b/released/packages/coq-graph-theory/coq-graph-theory.0.8/opam
@@ -22,7 +22,7 @@ depends: [
   "coq" {>= "8.11" & < "8.14~"}
   "coq-mathcomp-ssreflect" {>= "1.10" & < "1.13~"}
   "coq-mathcomp-finmap" 
-  "coq-hierarchy-builder" { >= "0.10" }
+  "coq-hierarchy-builder" { (>= "1.0.0") & (!= "1.1.0") }
 ]
 
 tags: [


### PR DESCRIPTION
Example of error, which seem related to the recent upgrade of hierchy-builder: @chdoc 
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-graph-theory.0.8 coq.8.11.1
Return code
    7936
Duration
    48 s
Output

    # Packages matching: installed
    # Name                  # Installed # Synopsis
    base                    v0.14.1     Full standard library replacement for OCaml
    base-bigarray           base
    base-threads            base
    base-unix               base
    camlp5                  7.14        Preprocessor-pretty-printer of OCaml
    conf-findutils          1           Virtual package relying on findutils
    conf-perl               1           Virtual package relying on perl
    coq                     8.11.1      Formal proof management system
    coq-elpi                1.6.2~8.11  Elpi extension language for Coq
    coq-hierarchy-builder   1.1.0       High level commands to declare and evolve a hierarchy based on packed classes
    coq-mathcomp-bigenough  1.0.0       A small library to do epsilon - N reasonning
    coq-mathcomp-finmap     1.5.1       Finite sets, finite maps, finitely supported functions
    coq-mathcomp-ssreflect  1.12.0      Small Scale Reflection
    cppo                    1.6.7       Code preprocessor like cpp for OCaml
    csexp                   1.5.1       Parsing and printing of S-expressions in Canonical form
    dune                    2.8.5       Fast, portable, and opinionated build system
    dune-configurator       2.8.5       Helper library for gathering system configuration
    elpi                    1.11.4-1    ELPI - Embeddable λProlog Interpreter
    num                     1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                   4.11.1      The OCaml compiler (virtual package)
    ocaml-base-compiler     4.11.1      Official release 4.11.1
    ocaml-compiler-libs     v0.12.3     OCaml compiler libraries repackaged
    ocaml-config            1           OCaml Switch Configuration
    ocaml-migrate-parsetree 1.8.0       Convert OCaml parsetrees between different versions
    ocamlfind               1.9.1       A library manager for OCaml
    ppx_derivers            1.2.1       Shared [@@deriving] plugin registry
    ppx_deriving            5.1         Type-driven code generation for OCaml
    ppxlib                  0.14.0      Base library and tools for ppx rewriters
    re                      1.9.0       RE is a regular expression library for OCaml
    result                  1.5         Compatibility Result module
    seq                     base        Compatibility package for OCaml's standard iterator type starting from 4.07.
    sexplib0                v0.14.0     Library containing the definition of S-expressions and some base converters
    stdio                   v0.14.0     Standard IO library for OCaml
    [NOTE] Package coq is already installed (current version is 8.11.1).
    The following actions will be performed:
      - install coq-graph-theory 0.8
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-graph-theory.0.8: http]
    [coq-graph-theory.0.8] downloaded from https://github.com/coq-community/graph-theory/archive/v0.8.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-graph-theory: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.11.1/.opam-switch/build/coq-graph-theory.0.8)
    - coq_makefile -f _CoqProject -o Makefile.coq
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.11.1/.opam-switch/build/coq-graph-theory.0.8'
    - COQDEP VFILES
    - COQC theories/edone.v
    - COQC theories/bounded.v
    - COQC theories/setoid_bigop.v
    - COQC theories/preliminaries.v
    - File "./theories/setoid_bigop.v", line 37, characters 0-43:
    - Warning:
    - The syntax "HB.instance Key FactoryInstance" is deprecated, use "HB.instance Definition" instead
    - [lib,elpi]
    - File "./theories/setoid_bigop.v", line 39, characters 0-42:
    - Warning:
    - The syntax "HB.instance Key FactoryInstance" is deprecated, use "HB.instance Definition" instead
    - [lib,elpi]
    - Warning: mem_imset is deprecated; use imset_f instead
    - Warning: mem_imset is deprecated; use imset_f instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - Warning: sorted_le_nth is deprecated; use sorted_leq_nth instead
    - COQC theories/bij.v
    - COQC theories/set_tac.v
    - COQC theories/finmap_plus.v
    - COQC theories/finite_quotient.v
    - COQC theories/digraph.v
    - COQC theories/structures.v
    - COQC theories/equiv.v
    - COQC theories/pttdom.v
    - File "./theories/pttdom.v", line 45, characters 0-858:
    - Error:
    - elpi: parameter illtyped: In environment
    - A : Type
    - The term "id_phant" has type "phantom Type A -> phantom Type A"
    - while it is expected to have type
    -  "unify Type Type A ?t (Some (is_not_canonically_a, setoid))".
    - 
    - make[2]: *** [Makefile.coq:677: theories/pttdom.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - make[1]: *** [Makefile.coq:327: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.11.1/.opam-switch/build/coq-graph-theory.0.8'
    - make: *** [Makefile:2: all] Error 2
    [ERROR] The compilation of coq-graph-theory failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-graph-theory.0.8 ===============================#
    # context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.11.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.11.1/.opam-switch/build/coq-graph-theory.0.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-graph-theory-17826-335865.env
    # output-file          ~/.opam/log/coq-graph-theory-17826-335865.out
    ### output ###
    # [...]
    # Error:
    # elpi: parameter illtyped: In environment
    # A : Type
    # The term "id_phant" has type "phantom Type A -> phantom Type A"
    # while it is expected to have type
    #  "unify Type Type A ?t (Some (is_not_canonically_a, setoid))".
    # 
    # make[2]: *** [Makefile.coq:677: theories/pttdom.vo] Error 1
    # make[2]: *** Waiting for unfinished jobs....
    # make[1]: *** [Makefile.coq:327: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.11.1/.opam-switch/build/coq-graph-theory.0.8'
    # make: *** [Makefile:2: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-graph-theory 0.8
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-graph-theory.0.8 coq.8.11.1' failed.
```