### PR TITLE
Fix OCaml version for coq-elpi

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.1.9.0/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.9.0/opam
@@ -11,6 +11,7 @@ install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 depends: [
   "elpi" {>= "1.13.0" & < "1.14.0~"}
   "coq" {>= "8.13" & < "8.14~" }
+  "ocaml" {< "4.12~"}
   ]
 tags: [ "logpath:elpi" ]
 synopsis: "Elpi extension language for Coq"

--- a/released/packages/coq-elpi/coq-elpi.1.9.1/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.9.1/opam
@@ -13,6 +13,7 @@ install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 depends: [
   "elpi" {>= "1.13.0" & < "1.14.0~"}
   "coq" {>= "8.13" & < "8.14~" }
+  "ocaml" {< "4.12~"}
   ]
 tags: [ "logpath:elpi" ]
 synopsis: "Elpi extension language for Coq"

--- a/released/packages/coq-elpi/coq-elpi.1.9.2/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.9.2/opam
@@ -13,6 +13,7 @@ install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 depends: [
   "elpi" {>= "1.13.0" & < "1.14.0~"}
   "coq" {>= "8.13" & < "8.14~" }
+  "ocaml" {< "4.12~"}
   ]
 tags: [ "logpath:elpi" ]
 synopsis: "Elpi extension language for Coq"


### PR DESCRIPTION
@gares ; this does not seem to concern the newer versions of `coq-elpi`.
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 2h opam install -y -v coq-elpi.1.9.0 coq.8.13.0
Return code
    7936
Duration
    13 s
Output

    # Packages matching: installed
    # Name                  # Installed # Synopsis
    base                    v0.14.1     Full standard library replacement for OCaml
    base-bigarray           base
    base-threads            base
    base-unix               base
    camlp5                  7.14        Preprocessor-pretty-printer of OCaml
    conf-findutils          1           Virtual package relying on findutils
    conf-gmp                3           Virtual package relying on a GMP lib system installation
    conf-perl               1           Virtual package relying on perl
    coq                     8.13.0      Formal proof management system
    cppo                    1.6.7       Code preprocessor like cpp for OCaml
    csexp                   1.5.1       Parsing and printing of S-expressions in Canonical form
    dune                    2.8.5       Fast, portable, and opinionated build system
    dune-configurator       2.8.5       Helper library for gathering system configuration
    elpi                    1.13.0      ELPI - Embeddable λProlog Interpreter
    num                     1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                   4.12.0      The OCaml compiler (virtual package)
    ocaml-base-compiler     4.12.0      Official release 4.12.0
    ocaml-compiler-libs     v0.12.3     OCaml compiler libraries repackaged
    ocaml-config            2           OCaml Switch Configuration
    ocaml-migrate-parsetree 1.8.0       Convert OCaml parsetrees between different versions
    ocaml-options-vanilla   1           Ensure that OCaml is compiled with no special options enabled
    ocamlfind               1.9.1       A library manager for OCaml
    ppx_derivers            1.2.1       Shared [@@deriving] plugin registry
    ppx_deriving            4.5         Type-driven code generation for OCaml >=4.02.2
    ppx_tools               6.3         Tools for authors of ppx rewriters and other syntactic tools
    ppxfind                 1.4         Tool combining ocamlfind and ppx
    ppxlib                  0.14.0      Base library and tools for ppx rewriters
    re                      1.9.0       RE is a regular expression library for OCaml
    result                  1.5         Compatibility Result module
    seq                     base        Compatibility package for OCaml's standard iterator type starting from 4.07.
    sexplib0                v0.14.0     Library containing the definition of S-expressions and some base converters
    stdio                   v0.14.0     Standard IO library for OCaml
    zarith                  1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.13.0).
    The following actions will be performed:
      - install coq-elpi 1.9.0
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-elpi.1.9.0: http]
    [coq-elpi.1.9.0] downloaded from https://github.com/LPCIC/coq-elpi/archive/v1.9.0.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-elpi: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "COQBIN=/home/bench/.opam/ocaml-base-compiler.4.12.0/bin/" "ELPIDIR=/home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi" (CWD=/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-elpi.1.9.0)
    - Using coq found in /home/bench/.opam/ocaml-base-compiler.4.12.0/bin/, from COQBIN or PATH
    - echo "let elpi_dir = \"/home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi\";;" > src/coq_elpi_config.ml
    - COQDEP VFILES
    - COQPP src/coq_elpi_vernacular_syntax.mlg
    - CAMLDEP src/coq_elpi_builtins.mli
    - CAMLDEP src/coq_elpi_goal_HOAS.mli
    - CAMLDEP src/coq_elpi_glob_quotation.mli
    - CAMLDEP src/coq_elpi_HOAS.mli
    - CAMLDEP src/coq_elpi_utils.mli
    - CAMLDEP src/coq_elpi_vernacular.mli
    - OCAMLLIBDEP src/elpi_plugin.mlpack
    - CAMLDEP src/coq_elpi_config.ml
    - CAMLDEP src/coq_elpi_builtins.ml
    - CAMLDEP src/coq_elpi_builtins_HOAS.ml
    - CAMLDEP src/coq_elpi_goal_HOAS.ml
    - CAMLDEP src/coq_elpi_glob_quotation.ml
    - CAMLDEP src/coq_elpi_name_quotation.ml
    - CAMLDEP src/coq_elpi_HOAS.ml
    - CAMLDEP src/coq_elpi_utils.ml
    - CAMLDEP src/coq_elpi_vernacular.ml
    - CAMLDEP src/coq_elpi_vernacular_syntax.ml
    - FILL .merlin
    - echo "PKG camlp5" >> .merlin
    - echo "S /home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi" >> .merlin
    - echo "B /home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi" >> .merlin
    - if [ "/home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi" != "elpi/findlib/elpi" ]; then\
    - 	echo "PKG elpi" >> .merlin;\
    - fi
    - Using coq found in /home/bench/.opam/ocaml-base-compiler.4.12.0/bin/, from COQBIN or PATH
    - ########################## building plugin ##########################
    - CAMLC -c src/coq_elpi_HOAS.mli
    - CAMLC -c src/coq_elpi_goal_HOAS.mli
    - CAMLC -c src/coq_elpi_vernacular.mli
    - CAMLC -c src/coq_elpi_utils.mli
    - CAMLC -c src/coq_elpi_glob_quotation.mli
    - CAMLC -c src/coq_elpi_vernacular_syntax.ml
    - CAMLC -c src/coq_elpi_config.ml
    - CAMLC -c src/coq_elpi_builtins.mli
    - CAMLC -c src/coq_elpi_vernacular.ml
    - File "src/coq_elpi_vernacular.ml", line 80, characters 29-47:
    - 80 | let compare_qualified_name = Pervasives.compare
    -                                   ^^^^^^^^^^^^^^^^^^
    - Alert deprecated: module Stdlib.Pervasives
    - Use Stdlib instead.
    - 
    - If you need to stay compatible with OCaml < 4.07, you can use the 
    - stdlib-shims library: https://github.com/ocaml/stdlib-shims
    - File "src/coq_elpi_vernacular.ml", line 362, characters 18-36:
    - 362 | let compare_src = Pervasives.compare
    -                         ^^^^^^^^^^^^^^^^^^
    - Alert deprecated: module Stdlib.Pervasives
    - Use Stdlib instead.
    - 
    - If you need to stay compatible with OCaml < 4.07, you can use the 
    - stdlib-shims library: https://github.com/ocaml/stdlib-shims
    - File "src/coq_elpi_vernacular.ml", line 405, characters 11-25:
    - 405 | let elpi = Pervasives.ref None
    -                  ^^^^^^^^^^^^^^
    - Alert deprecated: module Stdlib.Pervasives
    - Use Stdlib instead.
    - 
    - If you need to stay compatible with OCaml < 4.07, you can use the 
    - stdlib-shims library: https://github.com/ocaml/stdlib-shims
    - CAMLC -c src/coq_elpi_utils.ml
    - CAMLC -c src/coq_elpi_HOAS.ml
    - File "src/coq_elpi_HOAS.ml", line 1443, characters 18-27:
    - 1443 | let in_elpi_goal ?goal_name ~hyps ~raw_ev ~ty =
    -                          ^^^^^^^^^
    - Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
    - File "src/coq_elpi_HOAS.ml", line 1448, characters 19-28:
    - 1448 | let in_elpi_solve ?goal_name ~hyps ~raw_ev ~ty ~args ~new_goals =
    -                           ^^^^^^^^^
    - Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
    - make[1]: *** [Makefile.coq:663: src/coq_elpi_HOAS.cmo] Error 2
    - make: *** [Makefile:28: all] Error 2
    [ERROR] The compilation of coq-elpi failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make COQBIN=/home/bench/.opam/ocaml-base-compiler.4.12.0/bin/ ELPIDIR=/home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi".
    #=== ERROR while compiling coq-elpi.1.9.0 =====================================#
    # context              2.0.8 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-elpi.1.9.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make COQBIN=/home/bench/.opam/ocaml-base-compiler.4.12.0/bin/ ELPIDIR=/home/bench/.opam/ocaml-base-compiler.4.12.0/lib/elpi
    # exit-code            2
    # env-file             ~/.opam/log/coq-elpi-1286-335865.env
    # output-file          ~/.opam/log/coq-elpi-1286-335865.out
    ### output ###
    # [...]
    # CAMLC -c src/coq_elpi_utils.ml
    # CAMLC -c src/coq_elpi_HOAS.ml
    # File "src/coq_elpi_HOAS.ml", line 1443, characters 18-27:
    # 1443 | let in_elpi_goal ?goal_name ~hyps ~raw_ev ~ty =
    #                          ^^^^^^^^^
    # Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
    # File "src/coq_elpi_HOAS.ml", line 1448, characters 19-28:
    # 1448 | let in_elpi_solve ?goal_name ~hyps ~raw_ev ~ty ~args ~new_goals =
    #                           ^^^^^^^^^
    # Error (warning 16 [unerasable-optional-argument]): this optional argument cannot be erased.
    # make[1]: *** [Makefile.coq:663: src/coq_elpi_HOAS.cmo] Error 2
    # make: *** [Makefile:28: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-elpi 1.9.0
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-elpi.1.9.0 coq.8.13.0' failed.
```