### PR TITLE
Fix Coq version for coq-vst.2.7

### DIFF
--- a/released/packages/coq-vst/coq-vst.2.7/opam
+++ b/released/packages/coq-vst/coq-vst.2.7/opam
@@ -28,7 +28,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12" & < "8.14"}
+  "coq" {>= "8.12" & < "8.13.2"}
   "coq-compcert" {(= "3.8") | (= "3.8~open-source")}
   "coq-flocq" {>= "3.2.1"}
 ]


### PR DESCRIPTION
The error is the following:
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 20h opam install -y -v coq-vst.2.7 coq.8.13.2
Return code
    7936
Duration
    6 s
Output

    # Packages matching: installed
    # Name                # Installed # Synopsis
    base-bigarray         base
    base-threads          base
    base-unix             base
    conf-findutils        1           Virtual package relying on findutils
    conf-g++              1.0         Virtual package relying on the g++ compiler (for C++)
    conf-gmp              3           Virtual package relying on a GMP lib system installation
    coq                   8.13.2      Formal proof management system
    coq-compcert          3.8         The CompCert C compiler (64 bit)
    coq-flocq             3.4.0       A formalization of floating-point arithmetic for the Coq system
    coq-menhirlib         20210310    A support library for verified Coq parsers produced by Menhir
    dune                  2.8.5       Fast, portable, and opinionated build system
    menhir                20210310    An LR(1) parser generator
    menhirLib             20210310    Runtime support library for parsers generated by Menhir
    menhirSdk             20210310    Compile-time library for auxiliary tools related to Menhir
    num                   1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                 4.12.0      The OCaml compiler (virtual package)
    ocaml-base-compiler   4.12.0      Official release 4.12.0
    ocaml-config          2           OCaml Switch Configuration
    ocaml-options-vanilla 1           Ensure that OCaml is compiled with no special options enabled
    ocamlfind             1.9.1       A library manager for OCaml
    zarith                1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.13.2).
    The following actions will be performed:
      - install coq-vst 2.7
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-vst.2.7: http]
    [coq-vst.2.7] downloaded from https://github.com/PrincetonUniversity/VST/archive/v2.7.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-vst: patch]
    Processing  1/2: [coq-vst: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" "BITSIZE=64" (CWD=/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-vst.2.7)
    - Makefile:29: *** FAILURE: You need Coq 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13.0 or-else 8.13.1 but you have this version: The Coq Proof Assistant, version 8.13.2 (April 2021) compiled on Apr 17 2021 19:46:25 with OCaml 4.12.0.  Stop.
    [ERROR] The compilation of coq-vst failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4 BITSIZE=64".
    #=== ERROR while compiling coq-vst.2.7 ========================================#
    # context              2.0.8 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-vst.2.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4 BITSIZE=64
    # exit-code            2
    # env-file             ~/.opam/log/coq-vst-31057-8b8a2d.env
    # output-file          ~/.opam/log/coq-vst-31057-8b8a2d.out
    ### output ###
    # Makefile:29: *** FAILURE: You need Coq 8.12.0 or-else 8.12.1 or-else 8.12.2 or-else 8.13.0 or-else 8.13.1 but you have this version: The Coq Proof Assistant, version 8.13.2 (April 2021) compiled on Apr 17 2021 19:46:25 with OCaml 4.12.0.  Stop.
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-vst 2.7
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-vst.2.7 coq.8.13.2' failed.
```