### PR TITLE
Put an upper bound on Menhir and MenhirLib

### DIFF
--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform/opam
@@ -48,8 +48,8 @@ install: [
 depends: [
   "coq" {>= "8.12" & < "8.13"}
   "coq-flocq" {>= "3.2.1"}
-  "coq-menhirlib" {>= "20190626"}
-  "menhir" {>= "20190626"}
+  "coq-menhirlib" {>= "20190626" & <= "20210310" }
+  "menhir" {>= "20190626" & <= "20210310" }
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "The CompCert C compiler (using coq-platform supplied version of Flocq)"

--- a/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.7+8.12~coq_platform~open_source/opam
@@ -51,8 +51,8 @@ install: [
 depends: [
   "coq" {>= "8.12" & < "8.13"}
   "coq-flocq" {>= "3.2.1"}
-  "coq-menhirlib" {>= "20190626"}
-  "menhir" {>= "20190626"}
+  "coq-menhirlib" {>= "20190626" & <= "20210310"}
+  "menhir" {>= "20190626" & <= "20210310" }
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "The CompCert C compiler (only open source files + using coq-platform)"

--- a/released/packages/coq-compcert/coq-compcert.3.8/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.8/opam
@@ -30,10 +30,10 @@ install: [
 ]
 depends: [
   "coq" {>= "8.8.0" & < "8.14"}
-  "menhir" {>= "20190626" & != "dev"}
+  "menhir" {>= "20190626" & <= "20210310" }
   "ocaml" {>= "4.05.0"}
   "coq-flocq" {>= "3.1.0"}
-  "coq-menhirlib" {>= "20190626"}
+  "coq-menhirlib" {>= "20190626" & <= "20210310"}
 ]
 synopsis: "The CompCert C compiler (64 bit)"
 tags: [


### PR DESCRIPTION
The latest release 20210419 of Menhir and MenhirLib changes the Coq API in ways that break CompCert <= 3.8.

Cc: @fpottier @MSoegtropIMC

Xref: https://github.com/AbsInt/CompCert/issues/393
