### PR TITLE
HTTP: requires Coq >= 8.13

### DIFF
--- a/extra-dev/packages/coq-http/coq-http.dev/opam
+++ b/extra-dev/packages/coq-http/coq-http.dev/opam
@@ -14,7 +14,7 @@ build: [make "-j%{jobs}%" ]
 run-test: [make "-j" jobs "test"]
 install: [make "install" "INSTALLDIR=%{bin}%"]
 depends: [
-  "coq" { >= "8.12~" }
+  "coq" { >= "8.13~" }
   "ocamlbuild" 
   "coq-itree-io" 
   "coq-parsec" 


### PR DESCRIPTION
This PR and QuickChick/QuickChick#222 fix each other. No blocking in any direction since this is dev version.