### PR TITLE
Update deps of coq-metacoq-pcuic.1.0~beta2+8.13

### DIFF
--- a/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
+++ b/released/packages/coq-metacoq-pcuic/coq-metacoq-pcuic.1.0~beta2+8.13/opam
@@ -23,7 +23,7 @@ install: [
 ]
 depends: [
   "coq" {>= "8.13" & < "8.14~"}
-  "coq-equations" { >= "1.2.3" }
+  "coq-equations" { >= "1.2.3" & < "1.3~" }
   "coq-metacoq-template" {= version}
 ]
 synopsis: "A type system equivalent to Coq's and its metatheory"


### PR DESCRIPTION
There is the following error, so I guess this is due to the recent upgrade of Equations: @mattam82 
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-metacoq-pcuic.1.0~beta2+8.13 coq.8.13.0
Return code
    7936
Duration
    31 s
Output

    # Packages matching: installed
    # Name                # Installed    # Synopsis
    base-bigarray         base
    base-threads          base
    base-unix             base
    conf-findutils        1              Virtual package relying on findutils
    conf-gmp              3              Virtual package relying on a GMP lib system installation
    coq                   8.13.0         Formal proof management system
    coq-equations         1.3~beta+8.13  A function definition package for Coq
    coq-metacoq-template  1.0~beta2+8.13 A quoting and unquoting library for Coq in Coq
    num                   1.4            The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                 4.12.0         The OCaml compiler (virtual package)
    ocaml-base-compiler   4.12.0         Official release 4.12.0
    ocaml-config          2              OCaml Switch Configuration
    ocaml-options-vanilla 1              Ensure that OCaml is compiled with no special options enabled
    ocamlfind             1.9.1          A library manager for OCaml
    zarith                1.12           Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.13.0).
    The following actions will be performed:
      - install coq-metacoq-pcuic 1.0~beta2+8.13
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    [coq-metacoq-pcuic.1.0~beta2+8.13] found in cache
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-metacoq-pcuic: sh]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "sh" "./configure.sh" (CWD=/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13)
    - make -C template-coq mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/template-coq'
    - rm -f Makefile.coq
    - rm -f Makefile.plugin
    - rm -f Makefile.template
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/template-coq'
    - make -C pcuic mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    - rm -f metacoq-config
    - rm -f Makefile.plugin _PluginProject
    - rm -f Makefile.pcuic _CoqProject
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    - make -C safechecker mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/safechecker'
    - rm -f metacoq-config
    - rm -f Makefile.plugin _PluginProject
    - rm -f Makefile.safechecker _CoqProject
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/safechecker'
    - make -C erasure mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/erasure'
    - rm -f Makefile.plugin
    - rm -f Makefile.erasure
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/erasure'
    - make -C examples mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/examples'
    - rm -f Makefile.coq
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/examples'
    - make -C test-suite mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/test-suite'
    - rm -f Makefile.coq
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/test-suite'
    - make -C translations mrproper
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/translations'
    - rm -f Makefile.coq
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/translations'
    - Building MetaCoq globally (default)
    Processing  1/2: [coq-metacoq-pcuic: make 4]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j" "4" "-C" "pcuic" (CWD=/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13)
    - make: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    - cat metacoq-config > _CoqProject
    - cat _CoqProject.in >> _CoqProject
    - coq_makefile -f _CoqProject -o Makefile.pcuic 
    - make -f Makefile.pcuic
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    - COQDEP VFILES
    - *** Warning: in file theories/PCUICUtils.v, library Equations.Equations is required and has not been found in the loadpath!
    - COQC theories/PCUICPrimitive.v
    - COQC theories/PCUICAst.v
    - COQC theories/PCUICSize.v
    - COQC theories/TemplateToPCUIC.v
    - File "./theories/PCUICSize.v", line 29, characters 4-5:
    - Warning: Unused variable x catches more than one case.
    - [unused-pattern-matching-variable,pattern-matching]
    - COQC theories/PCUICAstUtils.v
    - File "./theories/PCUICAstUtils.v", line 869, characters 0-82:
    - Warning: Not a truly recursive fixpoint. [non-recursive,fixpoints]
    - COQC theories/PCUICUtils.v
    - COQC theories/PCUICInduction.v
    - COQC theories/PCUICToTemplate.v
    - File "./theories/PCUICUtils.v", line 6, characters 15-34:
    - Error: Unable to locate library Equations.Equations.
    - 
    - make[2]: *** [Makefile.pcuic:720: theories/PCUICUtils.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - make[1]: *** [Makefile.pcuic:343: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    - make: *** [Makefile:21: theory] Error 2
    - make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    [ERROR] The compilation of coq-metacoq-pcuic failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j 4 -C pcuic".
    #=== ERROR while compiling coq-metacoq-pcuic.1.0~beta2+8.13 ===================#
    # context              2.0.8 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j 4 -C pcuic
    # exit-code            2
    # env-file             ~/.opam/log/coq-metacoq-pcuic-26000-6d07ae.env
    # output-file          ~/.opam/log/coq-metacoq-pcuic-26000-6d07ae.out
    ### output ###
    # [...]
    # COQC theories/PCUICUtils.v
    # COQC theories/PCUICInduction.v
    # COQC theories/PCUICToTemplate.v
    # File "./theories/PCUICUtils.v", line 6, characters 15-34:
    # Error: Unable to locate library Equations.Equations.
    # 
    # make[2]: *** [Makefile.pcuic:720: theories/PCUICUtils.vo] Error 1
    # make[2]: *** Waiting for unfinished jobs....
    # make[1]: *** [Makefile.pcuic:343: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    # make: *** [Makefile:21: theory] Error 2
    # make: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.12.0/.opam-switch/build/coq-metacoq-pcuic.1.0~beta2+8.13/pcuic'
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-metacoq-pcuic 1.0~beta2+8.13
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-metacoq-pcuic.1.0~beta2+8.13 coq.8.13.0' failed.
```
