### PR TITLE
coq-unicoq.dev requires coq.dev (8.14)

### DIFF
--- a/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
+++ b/extra-dev/packages/coq-unicoq/coq-unicoq.dev/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12.0" | = "dev"}
+  "coq" {= "dev"}
 ]
 synopsis: "An enhanced unification algorithm for Coq"
 tags: [


### PR DESCRIPTION
UniCoq after unicoq/unicoq#57 does not compile with Coq 8.12 and 8.13 anymore. It requires coq/coq#13958. @mattam82 @beta-ziliani 
