### PR TITLE
coq-coqeal.1.0.5 does not work with coq.dev

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
@@ -16,7 +16,7 @@ This libary contains a subset of the work that was developed in the context of t
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq" {>= "8.10" & < "8.14~"}
   "coq-bignums" 
   "coq-paramcoq" {(>= "1.1.1") | (= "dev")}
   "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}


### PR DESCRIPTION
`coq-coqeal.1.0.5` does not work with `coq.dev`, since it uses the `omega` tactic which has been removed from Coq recently. The master branch of CoqEAL has been fixed in CoqEAL/CoqEAL#38. @CohenCyril @proux01 