### PR TITLE
Added opam packages for CompCert 3.9 (64+32 bit)

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.9/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.9/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+available: os != "macos"
+build: [
+  ["./configure"
+  "ia32-linux" {os = "linux"}
+  "ia32-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "ia32-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 32 bit CompCert on 64 bit MinGW with cygwin build host
+  "-toolprefix"     {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  "i686-pc-cygwin-" {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  # The 32 bit CompCert is a variant which is installed in a non standard folder
+  "-prefix" "%{prefix}%/variants/compcert32"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert32/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.14"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "3.1.0"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (32 bit)"
+description: "This package installs the 32 bit version of CompCert.
+For coexistence with the 64 bit version, the files are installed in:
+%{prefix}%/variants/compcert32/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert32/lib/compcert  (C library)
+%{lib}%/coq-variant/compcert32/compcert (Coq library)
+Please note that the coq module path is compcert and not compcert32,
+so the files cannot be directly Required as compcert32.
+Instead -Q or -R options must be used to bind the compcert32 folder
+to the module path compcert. This is more convenient if one development
+supports both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert32.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert32"
+  "date:2021-05-10"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.9.tar.gz"
+  checksum: "sha512=485cbed95284c93124ecdea536e6fb9ea6a05a72477584204c8c3930759d27b0949041ae567044eda9b716a33bba4315665a8d3860deebf851e10c9a4ef88684"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.9/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.9/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure"
+  "amd64-linux" {os = "linux"}
+  "amd64-macosx" {os = "macos"}
+  "amd64-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 64 bit CompCert on 32 bit MinGW with cygwin build host
+  "-toolprefix"        {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "x86_64-pc-cygwin-"  {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "-prefix" "%{prefix}%"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.14"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "3.1.0"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (64 bit)"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2021-05-10"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.9.tar.gz"
+  checksum: "sha512=485cbed95284c93124ecdea536e6fb9ea6a05a72477584204c8c3930759d27b0949041ae567044eda9b716a33bba4315665a8d3860deebf851e10c9a4ef88684"
+}


### PR DESCRIPTION
This PR adds opam packages for CompCert 3.9.

The dependency versions are in agreement with the CompCert release notes.

@xavierleroy @jhjourdan: FYI
