### PR TITLE
Release coq-hydra-battles and coq-addition-chains.

### DIFF
--- a/released/packages/coq-addition-chains/coq-addition-chains.0.4/opam
+++ b/released/packages/coq-addition-chains/coq-addition-chains.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/hydra-battles"
+dev-repo: "git+https://github.com/coq-community/hydra-battles.git"
+bug-reports: "https://github.com/coq-community/hydra-battles/issues"
+license: "MIT"
+
+synopsis: "Exponentiation algorithms following addition chains"
+description: """
+Addition chains are algorithms for computations of the p-th power of some x, 
+with the least number of multiplication as possible. We present a few implementations of addition chains, with proofs of their correctness"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq-paramcoq" {(>= "1.1.2" & < "1.2~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.11.0" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-algebra"
+]
+
+tags: [
+  "category:Mathematics/Combinatorics and Graph Theory"
+  "keyword:addition chains"
+  "keyword:exponentiation algorithms"
+  "logpath:additions"
+  "date:2021-05-19"
+]
+authors: [
+  "Pierre Castéran"
+  "Yves Bertot"
+]
+
+url {
+  src: "https://github.com/coq-community/hydra-battles/archive/v0.4.tar.gz"
+  checksum: "sha256=bba82794e49e03fd82fcee592b2b037ec20669d10e6c47ed8b4f8a7f851756eb"
+}

--- a/released/packages/coq-additions/coq-additions.8.10.0/opam
+++ b/released/packages/coq-additions/coq-additions.8.10.0/opam
@@ -20,6 +20,8 @@ authors: [
 bug-reports: "https://github.com/coq-contribs/additions/issues"
 dev-repo: "git+https://github.com/coq-contribs/additions.git"
 synopsis: "Addition Chains"
+description: """
+Note: this package has been superseded by coq-addition-chains."""
 flags: light-uninstall
 url {
   src: "https://github.com/coq-contribs/additions/archive/v8.10.0.tar.gz"

--- a/released/packages/coq-cantor/coq-cantor.8.10.0/opam
+++ b/released/packages/coq-cantor/coq-cantor.8.10.0/opam
@@ -27,6 +27,8 @@ bug-reports: "https://github.com/coq-contribs/cantor/issues"
 dev-repo: "git+https://github.com/coq-contribs/cantor.git"
 synopsis: "On Ordinal Notations"
 description: """
+Note: this package has been superseded by coq-hydra-battles.
+
 This contribution contains data structures for ordinals
 less than Gamma0 under Cantor and Veblen normal
 forms. Well-foundedness is established thanks to RPO with status for

--- a/released/packages/coq-hydra-battles/coq-hydra-battles.0.4/opam
+++ b/released/packages/coq-hydra-battles/coq-hydra-battles.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/hydra-battles"
+dev-repo: "git+https://github.com/coq-community/hydra-battles.git"
+bug-reports: "https://github.com/coq-community/hydra-battles/issues"
+license: "MIT"
+
+synopsis: "Exploration of some properties of Kirby and Paris' hydra battles, with the help of Coq"
+description: """
+An exploration of some properties of Kirby and Paris' hydra battles,
+with the help of the Coq Proof assistant. This development includes
+the study of several representations of ordinal numbers, and a part
+of the so-called Ketonen and Solovay machinery (combinatorial
+properties of epsilon0)."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq-equations" {(>= "1.2" & < "1.3~") | (= "dev")}
+]
+
+tags: [
+  "category:Mathematics/Combinatorics and Graph Theory"
+  "category:Mathematics/Logic/Foundations"
+  "keyword:Ketonen-Solovay machinery"
+  "keyword:ordinals"
+  "keyword:primitive recursive functions"
+  "logpath:hydras"
+  "date:2021-05-19"
+]
+authors: [
+  "Pierre Castéran"
+]
+
+url {
+  src: "https://github.com/coq-community/hydra-battles/archive/v0.4.tar.gz"
+  checksum: "sha256=bba82794e49e03fd82fcee592b2b037ec20669d10e6c47ed8b4f8a7f851756eb"
+}


### PR DESCRIPTION
These packages supersede the coq-contribs cantor and additions.

cc @Casteran @herbelin 