### PR TITLE
Update dep for coq-infotheo.0.2.2

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.2.2/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.2.2/opam
@@ -23,7 +23,7 @@ depends: [
   "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
-  "coq-mathcomp-analysis" { (>= "0.3.4") }
+  "coq-mathcomp-analysis" { (>= "0.3.4" & < "0.3.8") }
 ]
 
 tags: [


### PR DESCRIPTION
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-infotheo.0.2.2 coq.8.12.1
Return code
    7936
Duration
    4 m 58 s
Output

    # Packages matching: installed
    # Name                  # Installed # Synopsis
    base                    v0.14.1     Full standard library replacement for OCaml
    base-bigarray           base
    base-threads            base
    base-unix               base
    camlp5                  7.14        Preprocessor-pretty-printer of OCaml
    conf-findutils          1           Virtual package relying on findutils
    conf-perl               1           Virtual package relying on perl
    coq                     8.12.1      Formal proof management system
    coq-elpi                1.8.3~8.12  Elpi extension language for Coq
    coq-hierarchy-builder   1.0.0       High level commands to declare and evolve a hierarchy based on packed classes
    coq-mathcomp-algebra    1.12.0      Mathematical Components Library on Algebra
    coq-mathcomp-analysis   0.3.8       An analysis library for mathematical components
    coq-mathcomp-bigenough  1.0.0       A small library to do epsilon - N reasonning
    coq-mathcomp-field      1.12.0      Mathematical Components Library on Fields
    coq-mathcomp-fingroup   1.12.0      Mathematical Components Library on finite groups
    coq-mathcomp-finmap     1.5.1       Finite sets, finite maps, finitely supported functions
    coq-mathcomp-solvable   1.12.0      Mathematical Components Library on finite groups (II)
    coq-mathcomp-ssreflect  1.12.0      Small Scale Reflection
    cppo                    1.6.7       Code preprocessor like cpp for OCaml
    csexp                   1.5.1       Parsing and printing of S-expressions in Canonical form
    dune                    2.8.5       Fast, portable, and opinionated build system
    dune-configurator       2.8.5       Helper library for gathering system configuration
    elpi                    1.12.0      ELPI - Embeddable λProlog Interpreter
    num                     1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml                   4.10.2      The OCaml compiler (virtual package)
    ocaml-base-compiler     4.10.2      Official release 4.10.2
    ocaml-compiler-libs     v0.12.3     OCaml compiler libraries repackaged
    ocaml-config            1           OCaml Switch Configuration
    ocaml-migrate-parsetree 1.8.0       Convert OCaml parsetrees between different versions
    ocamlfind               1.9.1       A library manager for OCaml
    ppx_derivers            1.2.1       Shared [@@deriving] plugin registry
    ppx_deriving            5.1         Type-driven code generation for OCaml
    ppxlib                  0.14.0      Base library and tools for ppx rewriters
    re                      1.9.0       RE is a regular expression library for OCaml
    result                  1.5         Compatibility Result module
    seq                     base        Compatibility package for OCaml's standard iterator type starting from 4.07.
    sexplib0                v0.14.0     Library containing the definition of S-expressions and some base converters
    stdio                   v0.14.0     Standard IO library for OCaml
    [NOTE] Package coq is already installed (current version is 8.12.1).
    The following actions will be performed:
      - install coq-infotheo 0.2.2
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-infotheo.0.2.2: http]
    [coq-infotheo.0.2.2] downloaded from https://github.com/affeldt-aist/infotheo/archive/0.2.2.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-infotheo: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-infotheo.0.2.2)
    - coq_makefile -f _CoqProject -o Makefile.coq
    - make -f Makefile.coq all
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-infotheo.0.2.2'
    - COQDEP VFILES
    - COQC lib/ssrZ.v
    - COQC lib/ssrR.v
    - COQC lib/ssr_ext.v
    - COQC lib/f2.v
    - COQC lib/euclid.v
    - COQC lib/classical_sets_ext.v
    - COQC ecc_modern/max_subset.v
    - COQC lib/Reals_ext.v
    - COQC lib/ssralg_ext.v
    - COQC lib/num_occ.v
    - COQC information_theory/kraft.v
    - COQC ecc_modern/subgraph_partition.v
    - COQC lib/logb.v
    - COQC lib/natbin.v
    - COQC lib/poly_ext.v
    - COQC lib/vandermonde.v
    - COQC lib/Ranalysis_ext.v
    - COQC lib/bigop_ext.v
    - COQC lib/Rbigop.v
    - COQC lib/binary_entropy_function.v
    - COQC ecc_modern/tanner.v
    - COQC lib/hamming.v
    - COQC probability/fdist.v
    - COQC ecc_modern/summary.v
    - COQC ecc_modern/tanner_partition.v
    - COQC probability/proba.v
    - COQC probability/fsdist.v
    - COQC ecc_modern/degree_profile.v
    - COQC lib/dft.v
    - Warning: filter_index_enum is deprecated; use big_enumP instead
    - Warning: filter_index_enum is deprecated; use big_enumP instead
    - Warning: filter_index_enum is deprecated; use big_enumP instead
    - Warning: filter_index_enum is deprecated; use big_enumP instead
    - COQC probability/jfdist.v
    - COQC information_theory/source_code.v
    - COQC toy_examples/expected_value_variance.v
    - COQC toy_examples/expected_value_variance_ordn.v
    - COQC toy_examples/expected_value_variance_tuple.v
    - COQC probability/convex_choice.v
    - COQC probability/graphoid.v
    - File "./probability/convex_choice.v", line 2597, characters 17-23:
    - Error: Illegal application (Non-functional construction): 
    - The expression "a" of type "{convex_set T}"
    - cannot be applied to the term
    -  "x" : "?A"
    - 
    - make[2]: *** [Makefile.coq:715: probability/convex_choice.vo] Error 1
    - make[1]: *** [Makefile.coq:339: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-infotheo.0.2.2'
    - make: *** [Makefile:2: all] Error 2
    [ERROR] The compilation of coq-infotheo failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-infotheo.0.2.2 =================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.2 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-infotheo.0.2.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-infotheo-3853-335865.env
    # output-file          ~/.opam/log/coq-infotheo-3853-335865.out
    ### output ###
    # [...]
    # COQC probability/convex_choice.v
    # COQC probability/graphoid.v
    # File "./probability/convex_choice.v", line 2597, characters 17-23:
    # Error: Illegal application (Non-functional construction): 
    # The expression "a" of type "{convex_set T}"
    # cannot be applied to the term
    #  "x" : "?A"
    # 
    # make[2]: *** [Makefile.coq:715: probability/convex_choice.vo] Error 1
    # make[1]: *** [Makefile.coq:339: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-infotheo.0.2.2'
    # make: *** [Makefile:2: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-infotheo 0.2.2
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-infotheo.0.2.2 coq.8.12.1' failed.
```