### PR TITLE
Fix checksum for coq-bdds.8.10.0

### DIFF
--- a/released/packages/coq-bdds/coq-bdds.8.10.0/opam
+++ b/released/packages/coq-bdds/coq-bdds.8.10.0/opam
@@ -40,5 +40,5 @@ in Coq. See file README for operation."""
 flags: light-uninstall
 url {
   src: "https://github.com/coq-contribs/bdds/archive/v8.10.0.tar.gz"
-  checksum: "md5=9e25331342938b96cb45c1428d72a087"
+  checksum: "md5=9d8155b5718bc6032daf45451eda40d6"
 }


### PR DESCRIPTION
Fix the checksum for `coq-bdds.8.10.0`. This was not reported by https://coq-bench.github.io/ as it was considered a download error. @herbelin 