### PR TITLE
Coq 8.14.dev

### DIFF
--- a/core-dev/packages/coq/coq.8.14.dev/opam
+++ b/core-dev/packages/coq/coq.8.14.dev/opam
@@ -39,12 +39,12 @@ build: [
     "-coqide" "no"
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
-  [make "-j%{jobs}%"]
+  [ make "-j%{jobs}%" ]
 ]
 install: [
-  [make "install"]
+  [ make "install" ]
 ]
 
 url {
-  src: "git+https://github.com/coq/coq.git#master"
+  src: "git+https://github.com/coq/coq.git#v8.14"
 }

--- a/core-dev/packages/coqide/coqide.8.14.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.14.dev/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1-only"
+synopsis: "IDE of the Coq formal proof management system"
+description: """
+CoqIDE is a graphical user interface for interactive development
+of mathematical definitions, executable algorithms, and proofs of theorems
+using the Coq proof assistant.
+"""
+
+depends: [
+  "coq" {= version}
+  "ocamlfind" {build}
+  "dune" {>= "2.5.1"}
+  "conf-findutils" {build}
+  "lablgtk3-sourceview3"
+  "conf-adwaita-icon-theme"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" doc
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [ make "-j%{jobs}%" "coqide" ]
+]
+install: [
+  [ make "install-coqide" ]
+]
+
+url {
+  src: "git+https://github.com/coq/coq.git#v8.14"
+}

--- a/core-dev/packages/coqide/coqide.8.14.dev/opam
+++ b/core-dev/packages/coqide/coqide.8.14.dev/opam
@@ -31,10 +31,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
   ]
-  [ make "-j%{jobs}%" "coqide" ]
-]
-install: [
-  [ make "install-coqide" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
 url {


### PR DESCRIPTION
This is a first attempt at having an Opam package fit for 8.14. There are a few issues though.

1. I was not able to install Coqide, due to conflicting requirements over Dune:
   ```console
   $ opam install lablgtk3=3.1.1
   The following actions will be performed:
     ↘ downgrade dune              2.5.1 to 2.0.1 [required by lablgtk3]
   ```

2. Despite having `coq-native` installed, support for the native compiler was disabled:
   ```console
   $ rlwrap coqtop
   Welcome to Coq 8.14+alpha
   
   Coq < Eval native_compute in (1 + 1).
   Toplevel input, characters 0-31:
   > Eval native_compute in (1 + 1).
   > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   Warning: native_compute disabled at configure time; falling back to
   vm_compute. [native-compute-disabled,native-compiler]
   ```
