### PR TITLE
[coqide] Use native dune build setup

### DIFF
--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -31,11 +31,7 @@ build: [
     "-datadir" "%{share}%/coq"
     "-native-compiler" {os = "macos"} "no" {os = "macos"}
   ]
-  [make "-j%{jobs}%" "coqide"]
-]
-install: [
-  make
-  "install-coqide"
+  [ "dune" "build" "-p" name "-j"  jobs ]
 ]
 
 url {


### PR DESCRIPTION
Coqide is a fully dunerized package without Coq-specific extensions,
so this build / install method is more straightforward and avoids
issues pointed out in #1744 .