### PR TITLE
Fix deps for monae 0.3.2

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.3.2/opam
+++ b/released/packages/coq-monae/coq-monae.0.3.2/opam
@@ -20,7 +20,7 @@ depends: [
   "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
-  "coq-mathcomp-analysis" { (>= "0.3.6" & < "0.4~") }
+  "coq-mathcomp-analysis" { (>= "0.3.6" & <= "0.3.7") }
   "coq-infotheo" { >= "0.3.2" & < "0.4~"}
   "coq-paramcoq" { >= "1.1.2" & < "1.2~" }
 ]


### PR DESCRIPTION
I have a failing CI with the following deps:
- coq 8.13
- coq-mathcomp-analysis 0.3.9
- coq-infotheo 0.3.3
- coq-monae 0.3.2

```
#=== ERROR while compiling coq-monae.0.3.2 ====================================#
# context     2.0.8 | macos/x86_64 | ocaml-variants.4.11.1+flambda | pinned(https://github.com/affeldt-aist/monae/archive/0.3.2.tar.gz)
# path        ~/.opam/coq8.13/.opam-switch/build/coq-monae.0.3.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build make -j3
# exit-code   2
# env-file    ~/.opam/log/coq-monae-13729-b1a82b.env
# output-file ~/.opam/log/coq-monae-13729-b1a82b.out
### output ###
# [...]
# "rT" and "Prop").
#
# make[2]: *** [monad_model.vo] Error 1
# make[2]: *** Waiting for unfinished jobs....
# File "./gcm_model.v", line 394, characters 2-34:
# Error: The LHS of affine_image_conv_set
#     [set _ x | x in _ :<|_|>: _]
# does not match any subterm of the goal
#
# make[2]: *** [gcm_model.vo] Error 1
# make[1]: *** [all] Error 2
# make: *** [all] Error 2



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><>  🐫
┌─ The following actions failed
│ λ build coq-monae 0.3.2
```

This PR sets the interval for coq-mathcomp-analysis just like in PR #1743.

CC @affeldt-aist 