### PR TITLE
release monae 0.3.4

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.3.4/opam
+++ b/released/packages/coq-monae/coq-monae.0.3.4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/monae"
+dev-repo: "git+https://github.com/affeldt-aist/monae.git"
+bug-reports: "https://github.com/affeldt-aist/monae/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Monads and equational reasoning in Coq"
+description: """
+This Coq library contains a hierarchy of monads with their laws used
+in several examples of monadic equational reasoning."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install_full"]
+depends: [
+  "coq" { (>= "8.13" & < "8.14~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-fingroup" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
+  "coq-mathcomp-analysis" { (>= "0.3.6" & <= "0.3.7") | (>= "0.3.9" & < "0.4~") }
+  "coq-infotheo" { >= "0.3.2" & < "0.4~"}
+  "coq-paramcoq" { >= "1.1.2" & < "1.2~" }
+]
+
+tags: [
+  "keyword:monae"
+  "keyword:effects"
+  "keyword:probability"
+  "keyword:nondeterminism"
+  "logpath:monae"
+  "date:2021-06-18"
+]
+authors: [
+  "Reynald Affeldt"
+  "David Nowak"
+  "Takafumi Saikawa"
+  "Jacques Garrigue"
+  "Celestine Sauvage"
+  "Kazunari Tanaka"
+]
+url {
+  http: "https://github.com/affeldt-aist/monae/archive/0.3.4.tar.gz"
+  checksum: "sha512=5dc9ea4a260da88be308ad4fc29b88fff85bb575fd03105c085ad9f2ee562b2287a05f7f8be93cdd17755f2157382230402091e37658765bea4b662d2688a18c"
+}


### PR DESCRIPTION
This release just adds compatibility with MathComp-Analysis 0.3.9.

(With apologies for the recent noise about several compilation errors that are one me,
and renewed thanks for maintaining this great archive despite it!)