### PR TITLE
require coq >= 8.13.1 in order to have access to Interval.Primitive_ops

### DIFF
--- a/released/packages/coq-approx-models/coq-approx-models.1.0/opam
+++ b/released/packages/coq-approx-models/coq-approx-models.1.0/opam
@@ -18,7 +18,7 @@ verified Chebyshev approximations."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.13" )}
+  "coq" {(>= "8.13.1" )}
   "coq-interval"
   "coq-coquelicot" {(>= "3.2.0")}
 ]


### PR DESCRIPTION
thanks to @silene for spotting this