### PR TITLE
Update Coq dependency for coq-flocq.3.4.1

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.3.4.1/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.4.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.7"}
+  "coq" {(>= "8.7" & < "8.11~") | >= "8.12"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]


### PR DESCRIPTION
@silene As per the last Coq bench iteration, this package fails with Coq 8.11. I did some tests in local with Coq `8.10.2` and it works. With `8.12.2` it works too.
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-flocq.3.4.1 coq.8.11.1
Return code
    7936
Duration
    6 m 35 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-g++            1.0         Virtual package relying on the g++ compiler (for C++)
    coq                 8.11.1      Formal proof management system
    num                 1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml               4.08.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.08.1      Official release 4.08.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    [NOTE] Package coq is already installed (current version is 8.11.1).
    The following actions will be performed:
      - install coq-flocq 3.4.1
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-flocq.3.4.1: http]
    [coq-flocq.3.4.1] downloaded from https://gforge.inria.fr/frs/download.php/file/38442/flocq-3.4.1.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-flocq: ./configure]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./configure" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq.3.4.1)
    - checking for coqc... /home/bench/.opam/ocaml-base-compiler.4.08.1/bin/coqc
    - checking Coq version... 8.11.1
    - checking for coqdep... /home/bench/.opam/ocaml-base-compiler.4.08.1/bin/coqdep
    - checking for coqdoc... /home/bench/.opam/ocaml-base-compiler.4.08.1/bin/coqdoc
    - checking for g++... g++
    - checking whether the C++ compiler works... yes
    - checking for C++ compiler default output file name... a.out
    - checking for suffix of executables... 
    - 
    - checking whether we are cross compiling... no
    - checking for suffix of object files... o
    - checking whether we are using the GNU C++ compiler... yes
    - checking whether g++ accepts -g... yes
    - configure: building remake...
    - /usr/bin/ld: /tmp/cc1LBAXv.o: in function `main':
    - remake.cpp:(.text.startup+0xae0): warning: the use of `tempnam' is dangerous, better use `mkstemp'
    - configure: creating ./config.status
    - config.status: creating Remakefile
    - config.status: creating src/Version.v
    - config.status: creating src/IEEE754/SpecFloatCompat.v
    Processing  1/2: [coq-flocq: ./remake]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "./remake" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq.3.4.1)
    - Building src/Version.vo
    - Building src/Core/Raux.vo
    - Building src/Core/Zaux.vo
    - Building src/Core/Defs.vo
    - Building src/IEEE754/SpecFloatCompat.vo
    - Building src/Core/Digits.vo
    - Building src/Core/Float_prop.vo
    - Building src/Core/FIX.vo
    - Building src/Core/FLT.vo
    - Building src/Core/Generic_fmt.vo
    - Building src/Core/FLX.vo
    - Building src/Core/Round_pred.vo
    - Building src/Core/Round_NE.vo
    - Building src/Core/Ulp.vo
    - Building src/Core/FTZ.vo
    - Building src/Core/Core.vo
    - Building src/Calc/Bracket.vo
    - Building src/Calc/Div.vo
    - Finished src/IEEE754/SpecFloatCompat.vo
    - Building src/Calc/Operations.vo
    - Building src/Calc/Round.vo
    - Building src/Calc/Sqrt.vo
    - Building src/Prop/Div_sqrt_error.vo
    - Finished src/Version.vo
    - Building src/Prop/Mult_error.vo
    - Building src/Prop/Relative.vo
    - Building src/Prop/Sterbenz.vo
    - Building src/Prop/Plus_error.vo
    - Building src/Prop/Round_odd.vo
    - Building src/Prop/Double_rounding.vo
    - Building src/IEEE754/PrimFloat.vo
    - Building src/IEEE754/BinarySingleNaN.vo
    - Building src/IEEE754/Binary.vo
    - Building src/IEEE754/Bits.vo
    - Building src/Pff/Pff.vo
    - Building src/Pff/Pff2FlocqAux.vo
    - Building src/Pff/Pff2Flocq.vo
    - Finished src/Core/Zaux.vo
    - Finished src/Core/Digits.vo
    - File "./src/Pff/Pff.v", line 1088, characters 0-30:
    - Warning:
    - New coercion path [Z.of_nat; IZR] : nat >-> R is ambiguous with existing 
    - [INR] : nat >-> R. [ambiguous-paths,typechecker]
    - Finished src/Core/Raux.vo
    - File "./src/Pff/Pff.v", line 1293, characters 0-16:
    - Warning:
    - New coercion path [Z.of_nat; IZR] : nat >-> R is ambiguous with existing 
    - [INR] : nat >-> R. [ambiguous-paths,typechecker]
    - Finished src/Core/Defs.vo
    - Finished src/Core/Float_prop.vo
    - Finished src/Core/Round_pred.vo
    - Finished src/Calc/Operations.vo
    - Finished src/Calc/Bracket.vo
    - Finished src/Core/Generic_fmt.vo
    - Finished src/Calc/Sqrt.vo
    - Finished src/Calc/Div.vo
    - Finished src/Prop/Sterbenz.vo
    - Finished src/Core/Ulp.vo
    - Finished src/Core/Round_NE.vo
    - Finished src/Core/FIX.vo
    - Finished src/Core/FLX.vo
    - Finished src/Core/FTZ.vo
    - Finished src/Core/FLT.vo
    - Finished src/Core/Core.vo
    - Finished src/Prop/Relative.vo
    - Finished src/Prop/Round_odd.vo
    - Finished src/Prop/Plus_error.vo
    - Finished src/Calc/Round.vo
    - Finished src/Prop/Mult_error.vo
    - Finished src/Prop/Double_rounding.vo
    - Finished src/IEEE754/BinarySingleNaN.vo
    - Finished src/IEEE754/Binary.vo
    - File "./src/IEEE754/PrimFloat.v", line 79, characters 29-31:
    - Error:
    - Syntax error: [tactic:binder_tactic] or [tactic:tactic_expr] or [tactic_then_locality] expected after ';' (in [tactic:tactic_expr]).
    - 
    - Failed to build src/IEEE754/PrimFloat.vo
    - Failed to build all
    - Finished src/IEEE754/Bits.vo
    - Finished src/Prop/Div_sqrt_error.vo
    - Finished src/Pff/Pff.vo
    - File "./src/Pff/Pff2FlocqAux.v", line 23, characters 0-24:
    - Warning:
    - New coercion path [BinInt.Z.of_nat; Rdefinitions.IZR] : nat >-> Rdefinitions.RbaseSymbolsImpl.R is ambiguous with existing 
    - [Raxioms.INR] : nat >-> Rdefinitions.RbaseSymbolsImpl.R.
    - [ambiguous-paths,typechecker]
    - Finished src/Pff/Pff2FlocqAux.vo
    - File "./src/Pff/Pff2Flocq.v", line 23, characters 0-32:
    - Warning:
    - New coercion path [Z.of_nat; IZR] : nat >-> R is ambiguous with existing 
    - [INR] : nat >-> R. [ambiguous-paths,typechecker]
    - Finished src/Pff/Pff2Flocq.vo
    [ERROR] The compilation of coq-flocq failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build ./remake -j4".
    #=== ERROR while compiling coq-flocq.3.4.1 ====================================#
    # context              2.0.5 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.08.1/.opam-switch/build/coq-flocq.3.4.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./remake -j4
    # exit-code            1
    # env-file             ~/.opam/log/coq-flocq-15619-2dea01.env
    # output-file          ~/.opam/log/coq-flocq-15619-2dea01.out
    ### output ###
    # [...]
    # Finished src/Pff/Pff.vo
    # File "./src/Pff/Pff2FlocqAux.v", line 23, characters 0-24:
    # Warning:
    # New coercion path [BinInt.Z.of_nat; Rdefinitions.IZR] : nat >-> Rdefinitions.RbaseSymbolsImpl.R is ambiguous with existing 
    # [Raxioms.INR] : nat >-> Rdefinitions.RbaseSymbolsImpl.R.
    # [ambiguous-paths,typechecker]
    # Finished src/Pff/Pff2FlocqAux.vo
    # File "./src/Pff/Pff2Flocq.v", line 23, characters 0-32:
    # Warning:
    # New coercion path [Z.of_nat; IZR] : nat >-> R is ambiguous with existing 
    # [INR] : nat >-> R. [ambiguous-paths,typechecker]
    # Finished src/Pff/Pff2Flocq.vo
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-flocq 3.4.1
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-flocq.3.4.1 coq.8.11.1' failed.
```
