### PR TITLE
Update Coq version for coq-waterproof.1.0.0

### DIFF
--- a/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
+++ b/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
@@ -18,7 +18,7 @@ authors: [
 license: "LGPL 3.0"
 
 depends: [
-  "coq" {>= "8.10"}
+  "coq" {>= "8.12"}
 ]
 
 build: [


### PR DESCRIPTION
@Nifrec It seems that `coq-waterproof.1.0.0` is not compatible with Coq versions prior 8.12:
https://coq-bench.github.io/clean/Linux-x86_64-4.10.2-2.0.6/released/8.11.2/waterproof/1.0.0.html
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-waterproof.1.0.0 coq.8.11.2
Return code
    7936
Duration
    13 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    coq                 8.11.2      Formal proof management system
    num                 1.4         The legacy Num library for arbitrary-precision integer and rational arithmetic
    ocaml               4.10.2      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.10.2      Official release 4.10.2
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    [NOTE] Package coq is already installed (current version is 8.11.2).
    The following actions will be performed:
      - install coq-waterproof 1.0.0
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-waterproof.1.0.0: http]
    [coq-waterproof.1.0.0] downloaded from https://github.com/impermeable/coq-waterproof/archive/1.0.0.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-waterproof: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-waterproof.1.0.0)
    - coq_makefile -f _CoqProject -o CoqMakefile
    - make --no-print-directory -f CoqMakefile 
    - COQDEP VFILES
    - COQC waterproof/auxiliary.v
    - COQC waterproof/definitions/set_definitions.v
    - COQC waterproof/string_auxiliary.v
    - COQC waterproof/tactics/automation_databases/decidability_db.v
    - File "./waterproof/auxiliary.v", line 63, characters 24-26:
    - Error: Syntax error: '.' expected after [vernac:command] (in [vernac_aux]).
    - 
    - make[2]: *** [CoqMakefile:678: waterproof/auxiliary.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - make[1]: *** [CoqMakefile:327: all] Error 2
    - make: *** [Makefile:12: invoke-coqmakefile] Error 2
    [ERROR] The compilation of coq-waterproof failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-waterproof.1.0.0 ===============================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.10.2 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.10.2/.opam-switch/build/coq-waterproof.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-waterproof-16493-335865.env
    # output-file          ~/.opam/log/coq-waterproof-16493-335865.out
    ### output ###
    # [...]
    # COQDEP VFILES
    # COQC waterproof/auxiliary.v
    # COQC waterproof/definitions/set_definitions.v
    # COQC waterproof/string_auxiliary.v
    # COQC waterproof/tactics/automation_databases/decidability_db.v
    # File "./waterproof/auxiliary.v", line 63, characters 24-26:
    # Error: Syntax error: '.' expected after [vernac:command] (in [vernac_aux]).
    # 
    # make[2]: *** [CoqMakefile:678: waterproof/auxiliary.vo] Error 1
    # make[2]: *** Waiting for unfinished jobs....
    # make[1]: *** [CoqMakefile:327: all] Error 2
    # make: *** [Makefile:12: invoke-coqmakefile] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-waterproof 1.0.0
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-waterproof.1.0.0 coq.8.11.2' failed.
```