### PR TITLE
Update required Coq version to '>= "8.12"'

### DIFF
--- a/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
+++ b/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
@@ -18,7 +18,7 @@ authors: [
 license: "LGPL 3.0"
 
 depends: [
-  "coq" {>= "8.10"}
+  "coq" {>= "8.12"}
 ]
 
 build: [


### PR DESCRIPTION
Should fix the following error: [https://coq-bench.github.io/clean/Linux-x86_64-4.10.2-2.0.6/released/8.11.2/waterproof/1.0.0.html]