### PR TITLE
Do not install camlp5, ocamlfind, and ocamlbuild.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,6 @@ before_script:
   - export OPAM_VERSION=2.0.6
   - export OPAM_ROOT_DIR=${HOME}/opam-root-${COMPILER}-${OPAM_VERSION}-${OPAM_VARIANT}
   - export OPAM_ROOT_CACHE=${HOME}/opam-cache/cache-${COMPILER}-${OPAM_VERSION}-${OPAM_VARIANT}.tgz
-  - export EXTRA_OPAM="ocamlbuild" # some packages build extracted code this way
   - apt-get update -qy
   - apt-get install unzip libgtksourceview2.0-dev libgtksourceview-3.0-dev libncurses5-dev curl jq ruby bubblewrap time libgmp-dev coinor-csdp libstring-shellquote-perl libipc-system-simple-perl -y
   - test -e $OPAM_ROOT_CACHE || scripts/opam-coq-init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ variables:
 cache:
   paths:
     - opam-cache
+  key: v2
 
 before_script:
   - export HOME=$(pwd)

--- a/released/packages/coq-vst-32/coq-vst-32.2.7.1/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7.1/opam
@@ -33,7 +33,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2020-12-20"

--- a/released/packages/coq-vst-32/coq-vst-32.2.7/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.7/opam
@@ -33,7 +33,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2020-12-20"

--- a/released/packages/coq-vst-32/coq-vst-32.2.8/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.8/opam
@@ -33,7 +33,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2021-06-01"

--- a/released/packages/coq-vst/coq-vst.2.7.1/opam
+++ b/released/packages/coq-vst/coq-vst.2.7.1/opam
@@ -33,7 +33,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2020-12-20"

--- a/released/packages/coq-vst/coq-vst.2.7/opam
+++ b/released/packages/coq-vst/coq-vst.2.7/opam
@@ -37,7 +37,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2020-12-20"

--- a/released/packages/coq-vst/coq-vst.2.8/opam
+++ b/released/packages/coq-vst/coq-vst.2.8/opam
@@ -33,7 +33,7 @@ depends: [
   "coq-flocq" {>= "3.2.1"}
 ]
 tags: [
-  "category:CS/Semantics and Compilation/Semantics"
+  "category:Computer Science/Semantics and Compilation/Semantics"
   "keyword:C"
   "logpath:VST"
   "date:2021-06-01"

--- a/scripts/opam-coq-init
+++ b/scripts/opam-coq-init
@@ -10,7 +10,6 @@ if [ ${OPAM_VARIANT} = "plain" ]; then EXTRA_FLAGS=--disable-sandboxing; fi
 opam init --root=$OPAM_ROOT_DIR --compiler=$COMPILER -n -y $EXTRA_FLAGS
 eval $(opam env --root=$OPAM_ROOT_DIR --set-root)
 opam config list
-opam install -y camlp5 ocamlfind $EXTRA_OPAM
 opam list
 mkdir -p ${HOME}/opam-cache
 tar czf $OPAM_ROOT_CACHE $OPAM_ROOT_DIR


### PR DESCRIPTION
If a package needs those, it should explicitly depend on them. Having them installed by default prevents detecting this issue, e.g., #1769.