### PR TITLE
coq-record-update 0.3.0: fix required Coq version

### DIFF
--- a/released/packages/coq-record-update/coq-record-update.0.3.0/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.0/opam
@@ -16,7 +16,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%" "NO_TEST=1"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
As someone pointed out in tchajed/coq-record-update#24, the Coq opam archive has the wrong version constraints for coq-record-update, meaning it can't be installed with Coq 8.13 even though it's compatible.