### PR TITLE
Update package coq-unimath

### DIFF
--- a/extra-dev/packages/coq-unimath/coq-unimath.dev/opam
+++ b/extra-dev/packages/coq-unimath/coq-unimath.dev/opam
@@ -7,13 +7,11 @@ license: "Kind of MIT"
 authors: ["The UniMath Development Team"]
 build: [make "BUILD_COQ=no" "-j%{jobs}%"]
 install: [make "BUILD_COQ=no" "install"]
-remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/UniMath"]
 depends: [
   "ocaml"
-  "coq" {= "dev"}
+  "coq" {>= "8.12.2"}
 ]
-synopsis: "UniMath"
-flags: light-uninstall
+synopsis: "Library of Univalent Mathematics"
 url {
   src: "git+https://github.com/UniMath/UniMath.git#master"
 }


### PR DESCRIPTION
- Weaken dependencies to allow recent stable versions of Coq.
- Drop remove instructions no longer needed since opam 2.0.
- Expand synopsis.