### PR TITLE
adjust bound for coq-pocklington.8.12.0 for 8.14

### DIFF
--- a/extra-dev/packages/coq-pocklington/coq-pocklington.dev/opam
+++ b/extra-dev/packages/coq-pocklington/coq-pocklington.dev/opam
@@ -14,7 +14,7 @@ large natural numbers. Includes a formal proof of Fermat's little theorem."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.7" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.7" & < "8.15~") | (= "dev")}
 ]
 
 tags: [

--- a/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
+++ b/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
@@ -14,7 +14,7 @@ large natural numbers. Includes a formal proof of Fermat's little theorem."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.7" & < "8.14~"}
+  "coq" {>= "8.7" & < "8.15~"}
 ]
 
 tags: [


### PR DESCRIPTION
To enable having a Gödel release for 8.14 at some point.