### PR TITLE
Fix minimum Coq version for hydra-battles.

### DIFF
--- a/extra-dev/packages/coq-hydra-battles/coq-hydra-battles.dev/opam
+++ b/extra-dev/packages/coq-hydra-battles/coq-hydra-battles.dev/opam
@@ -17,7 +17,7 @@ properties of epsilon0)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.13" & < "8.14~") | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.3~") | (= "dev")}
 ]
 


### PR DESCRIPTION
cc @palmskog @Casteran

Discovered while the CI for https://github.com/coq-community/goedel now fails on Coq 8.11 and 8.12.

Note that this won't be sufficient to fix it, because the opam file currently requires `"coq-hydra-battles" {= "dev"}`. So we should either drop compatibility with 8.11-8.12 in goedel, or relax the constraint to allow building goedel with hydra-battles 0.4.