### PR TITLE
Fix deps for infotheo.0.3.3

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.3.3/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.3.3/opam
@@ -23,7 +23,7 @@ depends: [
   "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
-  "coq-mathcomp-analysis" { (>= "0.3.6" & <= "0.3.7") | (>= "0.3.9" & < "0.4~") }
+  "coq-mathcomp-analysis" { (>= "0.3.6" & <= "0.3.7") | (>= "0.3.9" & < "0.3.10~") }
 ]
 
 tags: [


### PR DESCRIPTION
`infotheo.0.3.3` is incompatible with `mathcomp-analysis.0.3.10`. 
This PR addresses this issue. 
An example of the build error from CI:

```
  #=== ERROR while compiling coq-infotheo.0.3.3 =================================#
  # context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.05.0 | https://coq.inria.fr/opam/released#2021-08-12 21:20
  # path                 ~/.opam/4.05.0/.opam-switch/build/coq-infotheo.0.3.3
  # command              /usr/bin/make -j2
  # exit-code            2
  # env-file             ~/.opam/log/coq-infotheo-79-971af5.env
  # output-file          ~/.opam/log/coq-infotheo-79-971af5.out
  ### output ###
  # [...]
  # COQC lib/ssr_ext.v
  # COQC lib/f2.v
  # COQC lib/euclid.v
  # COQC lib/classical_sets_ext.v
  # File "./lib/classical_sets_ext.v", line 33, characters 12-19:
  # Error: The reference bigsetU was not found in the current environment.
  # 
  # make[2]: *** [Makefile.coq:720: lib/classical_sets_ext.vo] Error 1
  # make[2]: *** Waiting for unfinished jobs....
  # make[1]: *** [Makefile.coq:343: all] Error 2
  # make[1]: Leaving directory '/home/coq/.opam/4.05.0/.opam-switch/build/coq-infotheo.0.3.3'
  # make: *** [Makefile:2: all] Error 2
  
  
  
  <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
  +- The following actions failed
  | - build coq-infotheo 0.3.3
  +- 
  +- The following changes have been performed (the rest was aborted)
  | - install camlp5                  7.14
  | - install coq-elpi                1.9.7
  | - install coq-equations           1.3~beta+8.13
  | - install coq-hierarchy-builder   1.1.0
  | - install coq-mathcomp-analysis   0.3.10
  | - install coq-mathcomp-bigenough  1.0.0
  | - install coq-mathcomp-finmap     1.5.1
  | - install coq-paramcoq            1.1.2+coq8.13
  | - install coq-relation-algebra    1.7.5
  | - install cppo                    1.6.7
  | - install elpi                    1.13.7
  | - install ocaml-compiler-libs     v0.12.3
  | - install ocaml-migrate-parsetree 2.2.0
  | - install ppx_derivers            1.2.1
  | - install ppx_deriving            5.2.1
  | - install ppxlib                  0.20.0
  | - install re                      1.9.0
  | - install result                  1.5
  | - install seq                     0.2.2
  | - install sexplib0                v0.14.0
  | - install stdlib-shims            0.3.0
```

Looks like in `mathcomp-analysis.0.3.10` the lemma `bigsetU` was renamed into `bigcup` (see [changelog](https://github.com/math-comp/analysis/blob/master/CHANGELOG)).

cc @affeldt-aist 
