### PR TITLE
Add coq-coqffi.1.0.0~beta6 and coq-coqffi.1.0.0~beta7

### DIFF
--- a/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta6/opam
+++ b/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "lthms@soap.coffee"
+
+homepage: "https://github.com/coq-community/coqffi"
+dev-repo: "git+https://github.com/coq-community/coqffi.git"
+bug-reports: "https://github.com/coq-community/coqffi/issues"
+license: "MIT"
+
+synopsis: "Tool for generating Coq FFI bindings to OCaml libraries"
+description: """
+`coqffi` generates the necessary Coq boilerplate to use OCaml functions in a
+Coq development, and configures the Coq extraction mechanism accordingly."""
+
+build: [
+  ["./src-prepare.sh"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "4.12~" }
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.14~") | = "dev"}
+  "cmdliner" {>= "1.0.4"}
+  "sexplib" {>= "0.14"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:foreign function interface"
+  "keyword:extraction"
+  "keyword:OCaml"
+  "logpath:CoqFFI"
+]
+authors: [
+  "Thomas Letan"
+  "Li-yao Xia"
+  "Yann Régis-Gianas"
+  "Yannick Zakowski"
+]
+url {
+  src: "https://github.com/coq-community/coqffi/archive/1.0.0-beta6.tar.gz"
+  checksum: "sha512=41ee9d5e297557e1f4a99cd28cbd28bb1b0e5ecc7a7a3b969cf409aec1b91229c0291640ab778d021600b5ca50bcddb407e3a92846eb2944bba857fae287fcd4"
+}

--- a/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta7/opam
+++ b/released/packages/coq-coqffi/coq-coqffi.1.0.0~beta7/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "lthms@soap.coffee"
+
+homepage: "https://github.com/coq-community/coqffi"
+dev-repo: "git+https://github.com/coq-community/coqffi.git"
+bug-reports: "https://github.com/coq-community/coqffi/issues"
+license: "MIT"
+
+synopsis: "Tool for generating Coq FFI bindings to OCaml libraries"
+description: """
+`coqffi` generates the necessary Coq boilerplate to use OCaml functions in a
+Coq development, and configures the Coq extraction mechanism accordingly."""
+
+build: [
+  ["./src-prepare.sh"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "4.13~" }
+  "dune" {>= "2.5"}
+  "coq" {(>= "8.12" & < "8.14~") | = "dev"}
+  "cmdliner" {>= "1.0.4"}
+  "sexplib" {>= "0.14"}
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:foreign function interface"
+  "keyword:extraction"
+  "keyword:OCaml"
+  "logpath:CoqFFI"
+]
+authors: [
+  "Thomas Letan"
+  "Li-yao Xia"
+  "Yann Régis-Gianas"
+  "Yannick Zakowski"
+]
+url {
+  src: "https://github.com/coq-community/coqffi/archive/1.0.0-beta7.tar.gz"
+  checksum: "sha512=0f9d2893f59f8d09caec83f8476a2e7a511a7044516d639e4283b4187a86cf1563e60f1647cd12ae06e7e395bbc5dfedf5d798af3eb6baf81c0c2e482e14507b"
+}


### PR DESCRIPTION
Dear maintainers,

Here are two new releases for `coqffi`, the Coq/OCaml binding generator :tada:.
