### PR TITLE
fix metadata and URLs for CoqEAL 1.0.3 to 1.0.5

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.0.3/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.3/opam
@@ -1,16 +1,20 @@
 opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
-homepage: "https://github.com/CoqEAL/CoqEAL"
-bug-reports: "https://github.com/CoqEAL/CoqEAL/issues"
-dev-repo: "git+https://github.com/CoqEAL/CoqEAL.git"
 
+homepage: "https://github.com/coq-community/coqeal"
+dev-repo: "git+https://github.com/coq-community/coqeal.git"
+bug-reports: "https://github.com/coq-community/coqeal/issues"
 license: "MIT"
-build: [
-  [make "-j%{jobs}%"]
-]
-install: [
-  [make "install"]
-]
+
+synopsis: "CoqEAL - The Coq Effective Algebra Library"
+description: """
+This Coq library contains a subset of the work that was developed in the context
+of the ForMath EU FP7 project (2009-2013). It has two parts:
+- theory, which contains developments in algebra and optimized algorithms on mathcomp data structures.
+- refinements, which is a framework to ease change of data representations during a proof."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 depends: [
   "coq" {>= "8.7" & < "8.12~"}
   "coq-bignums" {>= "8.7" & < "8.12~"}
@@ -20,6 +24,7 @@ depends: [
 ]
 
 tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms"
   "keyword:effective algebra"
   "keyword:elementary divisor rings"
   "keyword:Smith normal form"
@@ -37,13 +42,7 @@ authors: [
   "Vincent Siles"
 ]
 
-synopsis: "CoqEAL - The Coq Effective Algebra Library"
-description: """
-This library contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
-- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
-- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof.
-"""
 url {
-  src: "https://github.com/CoqEAL/CoqEAL/archive/1.0.3.tar.gz"
-  checksum: "sha512=096c5aa7b99bdb00af138e474fd1423fe3a6df12e3e597135266f447fc6e4376077ce3d0cbca21f9cfa034d225a931b70efd316ca11f7e1354fa9ac27b5ec052"
+  src: "https://github.com/coq-community/coqeal/archive/refs/tags/1.0.3.tar.gz"
+  checksum: "sha512=4e11aba17157aba444338987315ed9c1c100f0b6dd543f4e03c72a39b5f7ca5f6a3c995fe1c443d474cc5e2793ad8c5de346b3561f8d1bf02c399775d6fd94e1"
 }

--- a/released/packages/coq-coqeal/coq-coqeal.1.0.4/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.4/opam
@@ -1,16 +1,20 @@
 opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
-homepage: "https://github.com/CoqEAL/CoqEAL"
-bug-reports: "https://github.com/CoqEAL/CoqEAL/issues"
-dev-repo: "git+https://github.com/CoqEAL/CoqEAL.git"
 
+homepage: "https://github.com/coq-community/coqeal"
+dev-repo: "git+https://github.com/coq-community/coqeal.git"
+bug-reports: "https://github.com/coq-community/coqeal/issues"
 license: "MIT"
-build: [
-  [make "-j%{jobs}%"]
-]
-install: [
-  [make "install"]
-]
+
+synopsis: "CoqEAL - The Coq Effective Algebra Library"
+description: """
+This Coq library contains a subset of the work that was developed in the context
+of the ForMath EU FP7 project (2009-2013). It has two parts:
+- theory, which contains developments in algebra and optimized algorithms on mathcomp data structures.
+- refinements, which is a framework to ease change of data representations during a proof."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 depends: [
   "coq" {>= "8.7" & < "8.13~"}
   "coq-bignums"
@@ -20,6 +24,7 @@ depends: [
 ]
 
 tags: [
+  "category:Computer Science/Decision Procedures and Certified Algorithms/Correctness proofs of algorithms"
   "keyword:effective algebra"
   "keyword:elementary divisor rings"
   "keyword:Smith normal form"
@@ -37,13 +42,7 @@ authors: [
   "Vincent Siles"
 ]
 
-synopsis: "CoqEAL - The Coq Effective Algebra Library"
-description: """
-This library contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
-- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
-- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof.
-"""
 url {
-  src: "https://github.com/CoqEAL/CoqEAL/archive/1.0.4.tar.gz"
-  checksum: "sha512=d3d4cdc2975dbc237c59ff23f99e3fff2fc88fc0330aaeb966025457aae4c094c8eff91b562b8f6944ff12f4db649b681e2f378543f1ed6b2747cb8e77631c1d"
+  src: "https://github.com/coq-community/coqeal/archive/refs/tags/1.0.4.tar.gz"
+  checksum: "sha512=98fbabb5014adde76c743b90bfb14b1ddedc6eecd9671f904598d92bacfd62e327b067cce6597df9e5fbab8331abf96979e3fd6137d42d37fb5ae93c8d6e6830"
 }

--- a/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
@@ -1,19 +1,19 @@
-
 opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 
-homepage: "https://github.com/CoqEAL/coqeal"
-dev-repo: "git+https://github.com/CoqEAL/coqeal.git"
-bug-reports: "https://github.com/CoqEAL/coqeal/issues"
+homepage: "https://github.com/coq-community/coqeal"
+dev-repo: "git+https://github.com/coq-community/coqeal.git"
+bug-reports: "https://github.com/coq-community/coqeal/issues"
 license: "MIT"
 
 synopsis: "CoqEAL - The Coq Effective Algebra Library"
 description: """
-This libary contains a subset of the work that was developed in the context of the ForMath european project (2009-2013). It has two parts:
-- theory (module CoqEAL_theory), which contains formal developments in algebra and optimized algorithms on mathcomp data structures.
-- refinements (module CoqEAL_refinements), which is a framework to ease change of data representation during a proof."""
+This Coq library contains a subset of the work that was developed in the context
+of the ForMath EU FP7 project (2009-2013). It has two parts:
+- theory, which contains developments in algebra and optimized algorithms on mathcomp data structures.
+- refinements, which is a framework to ease change of data representations during a proof."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.10" & < "8.14~"}
@@ -44,6 +44,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/CoqEAL/coqeal/archive/1.0.5.tar.gz"
-  checksum: "sha256=864a5e153ef27f1f608b0904966ae5fb9f6c00cc2945ab1016835e5339aed6b9"
+  src: "https://github.com/coq-community/coqeal/archive/refs/tags/1.0.5.tar.gz"
+  checksum: "sha512=0e72018c9ff740018b74d32fdc0e4e8266162e3853d5eba54afaffad0cc096978b6534e4c5c56e628f12409ca29df9347fa02fb472cb0f13709f1e1b8c23a7af"
 }


### PR DESCRIPTION
Due to the long time CI takes with changes to several packages, I will do a separate PR to update CoqEAL packages for 1.0.6 and dev.