### PR TITLE
SimpleIO: require Coq >= 8.11

### DIFF
--- a/extra-dev/packages/coq-simple-io/coq-simple-io.dev/opam
+++ b/extra-dev/packages/coq-simple-io/coq-simple-io.dev/opam
@@ -11,7 +11,7 @@ install: [make "install"]
 run-test: [make "test"]
 depends: [
   "ocaml"
-  "coq" {>= "8.8"}
+  "coq" {>= "8.11~"}
   "coq-ext-lib" {>= "0.10.0"}
   "ocamlbuild" {with-test & >= "0.9.0"}
   "ocamlfind"


### PR DESCRIPTION
per Lysxia/coq-simple-io#28

Expect build failure fixed by Lysxia/coq-simple-io#29, but should be ready to merge now.