### PR TITLE
Package coq-quickchick.1.5.1

### DIFF
--- a/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "llamp@seas.upenn.edu"
+synopsis: "Randomized Property-Based Testing Plugin for Coq"
+
+homepage: "https://github.com/QuickChick/QuickChick"
+dev-repo: "git+https://github.com/QuickChick/QuickChick.git"
+bug-reports: "https://github.com/QuickChick/QuickChick/issues"
+license: "MIT"
+
+build: [ make "-j" jobs ]
+install: [
+  [make "-j" jobs "install" ]
+  [make "-j" jobs "tests"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "coq" {>= "8.11"}
+  "coq-ext-lib"
+  "coq-mathcomp-ssreflect"
+  "ocamlbuild"
+  "ocamlfind"
+  "menhir" {build}
+  "coq-simple-io"
+]
+
+authors: [
+  "Leonidas Lampropoulos <>"
+  "Zoe Paraskevopoulou <>"
+  "Maxime Denes <>"
+  "Catalin Hritcu <>"
+  "Benjamin Pierce <>"
+  "Li-yao Xia <>"
+  "Arthur Azevedo de Amorim <>"
+  "Yishuai Li <>"
+  "Antal Spector-Zabusky <>"
+]
+
+tags: [
+  "keyword:extraction"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:QuickChick"
+]
+url {
+  src: "https://github.com/QuickChick/QuickChick/archive/v1.5.1.tar.gz"
+  checksum: [
+    "md5=c30f9df9cec8ca99b52883330fc87ab5"
+    "sha512=5ade0d3d44b64aa44b8ba67e3f097b74a75c41599cfd46dd1b8953fca356138d383273ff26bc6cf1a81db2d9d06384e78613981c1f9f9c137dba7e94d7d69ca7"
+  ]
+}

--- a/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml" {>= "4.07"}
-  "coq" {>= "8.11"}
+  "coq" {>= "8.11" < "8.15~"}
   "coq-ext-lib"
   "coq-mathcomp-ssreflect"
   "ocamlbuild"

--- a/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
+++ b/released/packages/coq-quickchick/coq-quickchick.1.5.1/opam
@@ -10,7 +10,6 @@ license: "MIT"
 build: [ make "-j" jobs ]
 install: [
   [make "-j" jobs "install" ]
-  [make "-j" jobs "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.07"}


### PR DESCRIPTION
### `coq-quickchick.1.5.1`
Randomized Property-Based Testing Plugin for Coq



---
* Homepage: https://github.com/QuickChick/QuickChick
* Source repo: git+https://github.com/QuickChick/QuickChick.git
* Bug tracker: https://github.com/QuickChick/QuickChick/issues

---
:camel: Pull-request generated by opam-publish v2.1.0