### PR TITLE
Update download locations for Gappa.

### DIFF
--- a/released/packages/coq-gappa/coq-gappa.1.2.1/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.2.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -24,7 +25,6 @@ authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/35538/gappalib-coq-1.2.1.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.2.1.tar.gz"
   checksum: "md5=6ccfeba7ca1ba4ea15c34390271f2877"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.3.2/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.3.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -21,10 +22,9 @@ tags: [
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
 ]
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
-synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover."
+synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/36350/gappalib-coq-1.3.2.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.3.2.tar.gz"
   checksum: "md5=d0374859edfc92f490ac291bbcea3341"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.3.3/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.3.3/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -24,7 +25,6 @@ authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/37395/gappalib-coq-1.3.3.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.3.3.tar.gz"
   checksum: "md5=0a8b1513011904d6569dc98794271bb6"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.3.4/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.3.4/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -25,7 +26,6 @@ authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/37623/gappalib-coq-1.3.4.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.3.4.tar.gz"
   checksum: "md5=9dc92d9edf82364089a6c7d20078059d"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.0/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.0/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -25,7 +26,6 @@ authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/37626/gappalib-coq-1.4.0.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.0.tar.gz"
   checksum: "md5=53421c1f38c95c7c25642f80d3f210e4"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.1/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "guillaume.melquiond@inria.fr"
 homepage: "https://gappa.gitlabpages.inria.fr/"
 dev-repo: "git+https://gitlab.inria.fr/gappa/coq.git"
+bug-reports: "https://gitlab.inria.fr/gappa/coq/issues"
 license: "LGPL 2.1"
 build: [
   ["./configure"]
@@ -25,7 +26,6 @@ authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 flags: light-uninstall
 url {
-  src:
-    "https://gforge.inria.fr/frs/download.php/file/37917/gappalib-coq-1.4.1.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.1.tar.gz"
   checksum: "md5=21d31cd457c2a96a288a8ea57fe4fa21"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.2/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.2/opam
@@ -23,6 +23,6 @@ tags: [
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 url {
-  src: "https://gforge.inria.fr/frs/download.php/file/38102/gappalib-coq-1.4.2.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.2.tar.gz"
   checksum: "sha512=60e8c9e1db5ae6d993b5b7af744bb78963ea57cff211a43f98814a1f79d05564d0f2eb6fb9fc263c34f06205f7a2a99bb988a92d1f9f6c379791225909c516e5"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.3/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.3/opam
@@ -28,6 +28,6 @@ tags: [
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 url {
-  src: "https://gforge.inria.fr/frs/download.php/file/38302/gappalib-coq-1.4.3.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.3.tar.gz"
   checksum: "sha512=1a1b45121a2e581b9f7b4060455a496567563f7b75fc88323933b4b10bfd28adc5cb2e3d15aab74ad3d354d921fde2bf534a9498bc4907737ca7aa97054af7e6"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.4/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.4/opam
@@ -31,6 +31,6 @@ tags: [
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 url {
-  src: "https://gforge.inria.fr/frs/download.php/file/38338/gappalib-coq-1.4.4.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.4.tar.gz"
   checksum: "sha512=910cb7d8f084fc93a8e59c2792093f252f1c8e9f7b63aa408c03de41dced1ff64b4cf2c9ee9610729f7885bdf42dd68c85a9a844c63781ba9fe8cfdfc5192665"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.5/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.5/opam
@@ -31,6 +31,6 @@ tags: [
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 url {
-  src: "https://gforge.inria.fr/frs/download.php/file/38380/gappalib-coq-1.4.5.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.5.tar.gz"
   checksum: "sha512=79232f0132bc888fac83c45751d1a030c7fefd4a00b3be41941baaf1b5b8057a17b7a635323b07ec0de6b1cfc502cc664a77ae7864ae5387a5cc2727831aaa61"
 }

--- a/released/packages/coq-gappa/coq-gappa.1.4.6/opam
+++ b/released/packages/coq-gappa/coq-gappa.1.4.6/opam
@@ -29,6 +29,6 @@ tags: [
 authors: [ "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
 synopsis: "A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover"
 url {
-  src: "https://gforge.inria.fr/frs/download.php/file/38386/gappalib-coq-1.4.6.tar.gz"
+  src: "https://gappa.gitlabpages.inria.fr/releases/gappalib-coq-1.4.6.tar.gz"
   checksum: "sha512=bb9c431d320d9c66998ec02ba7d459ee3f00cb7b16f89e57f3d7eb4b89cd3c9254e98e3906a8dfac31f73e5a32918ad12eaeaf7504750d3bfdce878913b745d3"
 }


### PR DESCRIPTION
Add missing field "bug-reports" along the way to please the linter.