### PR TITLE
add package for Equations 1.3 for 8.14 in extra-dev

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.1.3+8.14/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.1.3+8.14/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+authors: [ "Matthieu Sozeau <matthieu.sozeau@inria.fr>" "Cyprien Mangin <cyprien.mangin@m4x.org>" ]
+dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
+maintainer: "matthieu.sozeau@inria.fr"
+homepage: "https://mattam82.github.io/Coq-Equations"
+bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
+license: "LGPL-2.1-or-later"
+synopsis: "A function definition package for Coq"
+description: """
+Equations is a function definition plugin for Coq, that allows the
+definition of functions by dependent pattern-matching and well-founded,
+mutual or nested structural recursion and compiles them into core
+terms. It automatically derives the clauses equations, the graph of the
+function and its associated elimination principle.
+"""
+tags: [
+  "keyword:dependent pattern-matching"
+  "keyword:functional elimination"
+  "category:Miscellaneous/Coq Extensions"
+  "logpath:Equations"
+]
+build: [
+  ["./configure.sh"] # "--enable-hott" {coq-hott:installed}
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+run-test: [
+  [make "test-suite"]
+]
+depends: [
+  "coq" {>= "8.14" & < "8.15~"}
+  "ocamlfind" {build}
+]
+#depopts: [
+#  "coq-hott" {= "8.14"}
+#]
+url {
+  src: "https://github.com/mattam82/Coq-Equations/archive/refs/tags/v1.3-8.14.tar.gz"
+  checksum: "sha512=dabd632e5e7407d58585da6cdb94ad1dc83deb495be0f784a2e12fa637314380e91cd8fdf9b296c99b4f8185b0b0bb1fce4e0b280a82f47540204f794e1473a9"
+}


### PR DESCRIPTION
cc: @mattam82 

This is to enable testing the (many) packages that depend on Equations with 8.14, by making a package available in `extra-dev` and thus the `8.14` Docker image.