### PR TITLE
coq-libhyps 2.0.3 (license change only).

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.2.0.3/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.2.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Pierre.Courtieu@lecnam.net"
+synopsis: "Hypotheses manipulation library"
+
+homepage: "https://github.com/Matafou/LibHyps"
+dev-repo: "git+https://github.com/Matafou/LibHyps.git"
+bug-reports: "https://github.com/Matafou/LibHyps/issues"
+doc: "https://github.com/Matafou/LibHyps/blob/master/Demo/demo.v"
+license: "MIT"
+
+build: [
+  ["./configure.sh"]
+  [make "-j%{jobs}%"]
+]
+
+install: [make "install"]
+
+depends: [
+  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+]
+
+tags: [
+  "keyword:proof environment manipulation"
+  "keyword:forward reasoning"
+  "keyword:hypothesis naming"
+  "category:Miscellaneous/Coq Tactics Library"
+  "logpath:LibHyps"
+  "date:2021-09-27"
+]
+
+authors: [
+ "Pierre Courtieu"
+]
+
+description: "
+This library defines a set of tactics to manipulate hypothesis
+individually or by group. In particular it allows applying a tactic on
+each hypothesis of a goal, or only on *new* hypothesis after some
+tactic. Examples of manipulations: automatic renaming, subst, revert,
+or any tactic expecting a hypothesis name as argument.
+
+It also provides the especialize tactic to ease forward reasoning by
+instantianting one, several or all premisses of a hypothesis.
+"
+
+url {
+    http: "https://github.com/Matafou/LibHyps/archive/libhyps-2.0.3.tar.gz"
+    checksum: "sha256=fedbcd2aa43b52a9e3e3619512a8d27801640a8a847d9e92d2036294b8f43878"
+}


### PR DESCRIPTION
This is a license only change: Switching the package to MIT license.