### PR TITLE
Package coq-menhirlib.20210928

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20210928/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210928/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20210928" }
+]
+tags: [
+  "date:2021-09-28"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210928/archive.tar.gz"
+  checksum: [
+    "md5=74ead5cb3409281bb47e0a956bcaeea0"
+    "sha512=6693b9e999d1e71fe8ac00bff3d9bf7102aa38b1c7b2bc36d93819572d1bc8ade4d0c5caa674d4680f2e2e7f2508776dec9682617301c2ae8855cb46a9380489"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20210928`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3