### PR TITLE
feat: Take advantage of the coq-native package (CEP 048, item 3)

### DIFF
--- a/released/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.1.12.0/opam
+++ b/released/packages/coq-mathcomp-algebra/coq-mathcomp-algebra.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/algebra" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/algebra" "install" ]
 depends: [ "coq-mathcomp-fingroup" { = version } ]
 

--- a/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.0/opam
+++ b/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/math-comp/bigenough/issues"
 license: "CeCILL-B"
 dev-repo: "git+https://github.com/math-comp/bigenough"
 
-build: [ make "-j" "%{jobs}%" ]
+build: [ make "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/mathcomp/bigenough'" ]
 depends: [

--- a/released/packages/coq-mathcomp-character/coq-mathcomp-character.1.12.0/opam
+++ b/released/packages/coq-mathcomp-character/coq-mathcomp-character.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/character" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/character" "install" ]
 depends: [ "coq-mathcomp-field" { = version } ]
 

--- a/released/packages/coq-mathcomp-field-extra/coq-mathcomp-field-extra.1.6.1/opam
+++ b/released/packages/coq-mathcomp-field-extra/coq-mathcomp-field-extra.1.6.1/opam
@@ -7,7 +7,7 @@ homepage: "http://ssr.msr-inria.inria.fr/"
 bug-reports: "Mathematical Components <mathcomp-dev@sympa.inria.fr>"
 license: "CeCILL-B"
 
-build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/field" "install" ]
 depends: [
   "ocaml"

--- a/released/packages/coq-mathcomp-field/coq-mathcomp-field.1.12.0/opam
+++ b/released/packages/coq-mathcomp-field/coq-mathcomp-field.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/field" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/field" "install" ]
 depends: [ "coq-mathcomp-solvable" { = version } ]
 

--- a/released/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.1.12.0/opam
+++ b/released/packages/coq-mathcomp-fingroup/coq-mathcomp-fingroup.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/fingroup" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/fingroup" "install" ]
 depends: [ "coq-mathcomp-ssreflect" { = version } ]
 

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/finmap/issues"
 dev-repo: "git+https://github.com/math-comp/finmap.git"
 license: "CECILL-B"
 
-build: [ make "-j" "%{jobs}%" ]
+build: [ make "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "install" ]
 depends: [
   "coq" { (>= "8.7" & < "8.13~") }

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
@@ -14,7 +14,7 @@ types). This includes support for functions with finite support and
 multisets. The library also contains a generic order and set libary,
 which will be used to subsume notations for finite sets, eventually."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.15~") | (= "dev") }

--- a/released/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.1.12.0/opam
+++ b/released/packages/coq-mathcomp-solvable/coq-mathcomp-solvable.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/solvable" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/solvable"  "install" ]
 depends: [ "coq-mathcomp-algebra" { = version } ]
 

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.12.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.12.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/math-comp/math-comp/issues"
 dev-repo: "git+https://github.com/math-comp/math-comp.git"
 license: "CECILL-B"
 
-build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
+build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [ "coq" { (>= "8.10" & < "8.15~") } ]
 


### PR DESCRIPTION
* href: https://github.com/coq/ceps/blob/master/text/048-packaging-coq-native.md#regarding-item-3

* Only update coq-mathcomp-multinomials.dev's deps and mathcomp.1.12.0
  (some similar PRs could be opened for other deps if need be).