### PR TITLE
Package coq-menhirlib.20210929

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20210929/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210929/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != "20210929" }
+]
+tags: [
+  "date:2021-09-29"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20210929/archive.tar.gz"
+  checksum: [
+    "md5=437b8a568c9bb0df35b4482439c2520b"
+    "sha512=6a3cb084d1b2868022b4cb94484801aa7eaea13cfe2788b0da4407693229a6ce699cb282d9fd972476cf29551c259daa40f355dcdc1e545e47573a458a84c9dd"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20210929`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.0.3