### PR TITLE
Add coq-mathcomp-algebra-tactics 0.1.0 and dev

### DIFF
--- a/extra-dev/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.dev/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "sakaguchi@coins.tsukuba.ac.jp"
+
+homepage: "https://github.com/math-comp/algebra-tactics"
+dev-repo: "git+https://github.com/math-comp/algebra-tactics.git"
+bug-reports: "https://github.com/math-comp/algebra-tactics/issues"
+license: "CECILL-B"
+
+synopsis: "Ring and field tactics for Mathematical Components"
+description: """
+This library provides `ring` and `field` tactics for Mathematical Components,
+that work with any `comRingType` and `fieldType` instances, respectively.
+Their instance resolution is done through canonical structure inference.
+Therefore, they work with abstract rings and do not require `Add Ring` and
+`Add Field` commands. Another key feature of this library is that they
+automatically push down ring morphisms and additive functions to leaves of
+ring/field expressions before normalization to the Horner form."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-zify" {(>= "1.1.0") | (= "dev")}
+  "coq-elpi" {(>= "1.10.1") | (= "dev")}
+]
+
+tags: [
+  "logpath:mathcomp.algebra_tactics"
+]
+authors: [
+  "Kazuhiko Sakaguchi"
+]
+url {
+  src: "git+https://github.com/math-comp/algebra-tactics.git#master"
+}

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.1.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "sakaguchi@coins.tsukuba.ac.jp"
+
+homepage: "https://github.com/math-comp/algebra-tactics"
+dev-repo: "git+https://github.com/math-comp/algebra-tactics.git"
+bug-reports: "https://github.com/math-comp/algebra-tactics/issues"
+license: "CECILL-B"
+
+synopsis: "Ring and field tactics for Mathematical Components"
+description: """
+This library provides `ring` and `field` tactics for Mathematical Components,
+that work with any `comRingType` and `fieldType` instances, respectively.
+Their instance resolution is done through canonical structure inference.
+Therefore, they work with abstract rings and do not require `Add Ring` and
+`Add Field` commands. Another key feature of this library is that they
+automatically push down ring morphisms and additive functions to leaves of
+ring/field expressions before normalization to the Horner form."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.13" & < "8.15~")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~")}
+  "coq-mathcomp-zify" {(>= "1.1.0")}
+  "coq-elpi" {(>= "1.10.1")}
+]
+
+tags: [
+  "logpath:mathcomp.algebra_tactics"
+]
+authors: [
+  "Kazuhiko Sakaguchi"
+]
+url {
+  src: "https://github.com/math-comp/algebra-tactics/archive/refs/tags/0.1.0.tar.gz"
+  checksum: "sha256=aca9d33fec72a9e2fb37ccbc91c492ceae9b75d3cdce37ddd9a224ea3cef0f3f"
+}


### PR DESCRIPTION
This is the first release of [Algebra Tactics](https://github.com/math-comp/algebra-tactics), which provides `ring` and `field` tactics for Mathematical Components.