### PR TITLE
Fix coq-mathcomp-multinomials.dev according to math-comp/multinomials#45

### DIFF
--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
@@ -1,14 +1,16 @@
 opam-version: "2.0"
-name: "coq-mathcomp-multinomials"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/math-comp/multinomials"
 bug-reports: "https://github.com/math-comp/multinomials/issues"
 dev-repo: "git+https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
-build: [ "dune" "build" "-p" name "-j" jobs ]
+build: [
+  [ "bash" "./configure" ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
 depends: [
-  "coq"                    {(>= "8.10" & < "8.14~") | = "dev"}
+  "coq"                    {(>= "8.10" & < "8.15~") | = "dev"}
   "dune"                   {>= "2.5"}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | = "dev"}
   "coq-mathcomp-algebra"

--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [
-  [ "bash" "./configure" ]
+  [ "./configure" ]
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [


### PR DESCRIPTION
Currently, .vo files are missing in the installation.