### PR TITLE
Bump fiat-crypto deps

### DIFF
--- a/extra-dev/packages/coq-coqutil/coq-coqutil.dev/opam
+++ b/extra-dev/packages/coq-coqutil/coq-coqutil.dev/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.9~"}
+  "coq" {>= "8.11~"}
 ]
 dev-repo: "git+https://github.com/mit-plv/coqutil.git"
 synopsis: "Coq library for tactics, basic definitions, sets, maps"

--- a/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto/coq-fiat-crypto.dev/opam
@@ -18,9 +18,10 @@ depends: [
   "ocaml" {build}
   "ocamlfind" {build}
   "conf-jq" {build}
-  "coq" {>= "8.9~"}
+  "coq" {>= "8.11~"}
   "coq-coqprime"
   "coq-rewriter"
+  "coq-coqutil"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."


### PR DESCRIPTION
As of mit-plv/fiat-crypto#1024, fiat-crypto will no longer build with
Coq < 8.11, and will depend on coq-coqutil.  Additionally, coq-coqutil
has not built with Coq < 8.11 for a while, so let's update the version
constraint there at the same time.