### PR TITLE
Bumping mathcomp to 1.13

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
@@ -15,11 +15,11 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.11" & < "8.15~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-fingroup" { (>= "1.12.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.14~") | (= "dev") }
+  "coq-mathcomp-fingroup" { (>= "1.12.0" & < "1.14~") | (= "dev") }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.14~") | (= "dev") }
+  "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.14~") | (= "dev") }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.14~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-hierarchy-builder" { >= "0.10.0" | (= "dev") }
 ]

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
@@ -18,7 +18,7 @@ build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:inst
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.13~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
   "coq-mathcomp-bigenough" {>= "1.0.0"}
 ]
 

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.4/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.4/opam
@@ -9,7 +9,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "coq"                    {(>= "8.10" & < "8.15~") | = "dev"}
   "dune"                   {>= "2.5"}
-  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | = "dev"}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.14~") | = "dev"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}
   "coq-mathcomp-finmap"    {(>= "1.5" & < "1.6~") | = "dev"}

--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
@@ -18,9 +18,9 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
-  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
-  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
   "coq-mathcomp-bigenough" {>= "1.0.0"}
 ]
 

--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.1.0+1.12+8.13/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.1.0+1.12+8.13/opam
@@ -16,7 +16,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.13" & < "8.15~")}
-  "coq-mathcomp-algebra" {(>= "1.12" & < "1.13~")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.14~")}
 ]
 
 tags: [


### PR DESCRIPTION
Bumping mathcomp to 1.13 in last releases of analysis, finmap,
multinomials, real-closed and zify.