### PR TITLE
coq-reglang.1.1.2 is compatible with MathComp 1.13.0

### DIFF
--- a/released/packages/coq-reglang/coq-reglang.1.1.2/opam
+++ b/released/packages/coq-reglang/coq-reglang.1.1.2/opam
@@ -15,11 +15,11 @@ automata (deterministic, nondeterministic, one-way, two-way),
 regular expressions, and the logic WS1S. It also contains various
 decidability results and closure properties of regular languages."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.10" & < "8.15~"}
-  "coq-mathcomp-ssreflect" {>= "1.9" & < "1.13~"}
+  "coq-mathcomp-ssreflect" {>= "1.9" & < "1.14~"}
 ]
 
 tags: [
@@ -30,6 +30,7 @@ tags: [
   "keyword:two-way automata"
   "keyword:monadic second-order logic"
   "logpath:RegLang"
+  "date:2020-12-14"
 ]
 authors: [
   "Christian Doczkal"


### PR DESCRIPTION
cc: @chdoc 