### PR TITLE
Update coq-coqprime.1.0.6 for Coq 8.14

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.0.6/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.0.6/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12~"}
+  "coq" {>= "8.12~" & < "8.14~"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
Not compatible with Coq 8.14 as seen here https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.14.0/coqprime/1.0.6.html @thery  :
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-coqprime.1.0.6 coq.8.14.0
Return code
    7936
Duration
    36 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-gmp            3           Virtual package relying on a GMP lib system installation
    coq                 8.14.0      Formal proof management system
    coq-bignums         8.14.0      Bignums, the Coq library of arbitrary large numbers
    dune                2.9.1       Fast, portable, and opinionated build system
    ocaml               4.09.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.09.1      Official release 4.09.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    zarith              1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-coqprime 1.0.6
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-coqprime.1.0.6: http]
    [coq-coqprime.1.0.6] downloaded from https://github.com/thery/coqprime/archive/v8.12.zip
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-coqprime: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-coqprime.1.0.6)
    - /home/bench/.opam/ocaml-base-compiler.4.09.1/bin//coq_makefile -f _CoqProject -o Makefile.coq
    - COQDEP VFILES
    - COQC src/Coqprime/Tactic/Tactic.v
    - COQC src/Coqprime/N/NatAux.v
    - COQC src/Coqprime/Z/ZCmisc.v
    - COQC src/Coqprime/Z/Zmod.v
    - COQC src/Coqprime/Z/Ppow.v
    - COQC src/Coqprime/num/Bits.v
    - File "./src/Coqprime/Z/ZCmisc.v", line 31, characters 0-85:
    - Warning: The default value for rewriting hint locality is currently "local"
    - in a section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding rewriting hints outside of sections
    - without specifying an explicit locality attribute is therefore deprecated. It
    - is recommended to use "export" whenever possible. Use the attributes
    - #[local], #[global] and #[export] depending on your choice. For example:
    - "#[export] Hint Rewrite foo : bar."
    - [deprecated-hint-rewrite-without-locality,deprecated]
    - File "./src/Coqprime/Z/ZCmisc.v", line 46, characters 0-44:
    - Warning: The default value for rewriting hint locality is currently "local"
    - in a section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding rewriting hints outside of sections
    - without specifying an explicit locality attribute is therefore deprecated. It
    - is recommended to use "export" whenever possible. Use the attributes
    - #[local], #[global] and #[export] depending on your choice. For example:
    - "#[export] Hint Rewrite foo : bar."
    - [deprecated-hint-rewrite-without-locality,deprecated]
    - COQC src/Coqprime/num/montgomery.v
    - COQC src/Coqprime/List/ListAux.v
    - COQC src/Coqprime/Z/ZCAux.v
    - COQC src/Coqprime/Z/Pmod.v
    -      = 1740564225 :: 343969132 :: 6812243 :: nil
    -      : number
    -      = 0 :: 1 :: nil
    -      : number
    -      = 31415926535897932384626433%Z
    -      : Z
    - COQC src/Coqprime/List/Permutation.v
    - File "./src/Coqprime/Z/ZCAux.v", line 188, characters 0-9:
    - Error: No product even after head-reduction.
    - 
    - File "./src/Coqprime/List/Permutation.v", line 428, characters 0-37:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - File "./src/Coqprime/List/Permutation.v", line 429, characters 0-37:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - File "./src/Coqprime/List/Permutation.v", line 430, characters 0-41:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - File "./src/Coqprime/List/Permutation.v", line 431, characters 0-41:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - File "./src/Coqprime/List/Permutation.v", line 452, characters 0-36:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - make[1]: *** [Makefile.coq:763: src/Coqprime/Z/ZCAux.vo] Error 1
    - make[1]: *** Waiting for unfinished jobs....
    - File "./src/Coqprime/Z/Pmod.v", line 505, characters 0-68:
    - Warning: The default value for rewriting hint locality is currently "local"
    - in a section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding rewriting hints outside of sections
    - without specifying an explicit locality attribute is therefore deprecated. It
    - is recommended to use "export" whenever possible. Use the attributes
    - #[local], #[global] and #[export] depending on your choice. For example:
    - "#[export] Hint Rewrite foo : bar."
    - [deprecated-hint-rewrite-without-locality,deprecated]
    - make: *** [Makefile.coq:386: all] Error 2
    [ERROR] The compilation of coq-coqprime failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-coqprime.1.0.6 =================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-coqprime.1.0.6
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-coqprime-16243-865888.env
    # output-file          ~/.opam/log/coq-coqprime-16243-865888.out
    ### output ###
    # [...]
    # make[1]: *** [Makefile.coq:763: src/Coqprime/Z/ZCAux.vo] Error 1
    # make[1]: *** Waiting for unfinished jobs....
    # File "./src/Coqprime/Z/Pmod.v", line 505, characters 0-68:
    # Warning: The default value for rewriting hint locality is currently "local"
    # in a section and "global" otherwise, but is scheduled to change in a future
    # release. For the time being, adding rewriting hints outside of sections
    # without specifying an explicit locality attribute is therefore deprecated. It
    # is recommended to use "export" whenever possible. Use the attributes
    # #[local], #[global] and #[export] depending on your choice. For example:
    # "#[export] Hint Rewrite foo : bar."
    # [deprecated-hint-rewrite-without-locality,deprecated]
    # make: *** [Makefile.coq:386: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-coqprime 1.0.6
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-coqprime.1.0.6 coq.8.14.0' failed.
```