### PR TITLE
Fix coq-fourcolor.1.2.3 deps with Coq 8.14

### DIFF
--- a/released/packages/coq-fourcolor/coq-fourcolor.1.2.3/opam
+++ b/released/packages/coq-fourcolor/coq-fourcolor.1.2.3/opam
@@ -7,7 +7,10 @@ license: "CECILL-B"
 
 build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
-depends: [ "coq-mathcomp-algebra" { >= "1.12.0" & < "1.13" } ]
+depends: [
+  "coq" { < "8.14" }
+  "coq-mathcomp-algebra" { >= "1.12.0" & < "1.13" }
+]
 
 tags: [ "keyword:Four color theorem" "keyword:small scale reflection" "keyword:mathematical components" ]
 authors: [ "Georges Gonthier" ]


### PR DESCRIPTION
Not compatible with Coq 8.14 https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.14.0/fourcolor/1.2.3.html
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-fourcolor.1.2.3 coq.8.14.0
Return code
    7936
Duration
    17 s
Output

    # Packages matching: installed
    # Name                 # Installed # Synopsis
    base-bigarray          base
    base-threads           base
    base-unix              base
    conf-findutils         1           Virtual package relying on findutils
    conf-gmp               3           Virtual package relying on a GMP lib system installation
    coq                    8.14.0      Formal proof management system
    coq-mathcomp-algebra   1.12.0      Mathematical Components Library on Algebra
    coq-mathcomp-fingroup  1.12.0      Mathematical Components Library on finite groups
    coq-mathcomp-ssreflect 1.12.0      Small Scale Reflection
    dune                   2.9.1       Fast, portable, and opinionated build system
    ocaml                  4.09.1      The OCaml compiler (virtual package)
    ocaml-base-compiler    4.09.1      Official release 4.09.1
    ocaml-config           1           OCaml Switch Configuration
    ocamlfind              1.9.1       A library manager for OCaml
    zarith                 1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-fourcolor 1.2.3
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-fourcolor.1.2.3: http]
    [coq-fourcolor.1.2.3] downloaded from https://github.com/math-comp/fourcolor/archive/v1.2.3.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-fourcolor: make 4]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j" "4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-fourcolor.1.2.3)
    - coq_makefile -f _CoqProject -o Makefile.coq
    - make --no-print-directory -f Makefile.coq 
    - COQDEP VFILES
    - COQC theories/real.v
    - COQC theories/hypermap.v
    - COQC theories/color.v
    - COQC theories/dyck.v
    - File "./theories/real.v", line 212, characters 55-59:
    - Error: Syntax error: '.' expected after [gallina] (in [vernac_aux]).
    - 
    - make[2]: *** [Makefile.coq:763: theories/real.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - make[1]: *** [Makefile.coq:386: all] Error 2
    - make: *** [Makefile:15: invoke-coqmakefile] Error 2
    [ERROR] The compilation of coq-fourcolor failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j 4".
    #=== ERROR while compiling coq-fourcolor.1.2.3 ================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-fourcolor.1.2.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j 4
    # exit-code            2
    # env-file             ~/.opam/log/coq-fourcolor-23169-335865.env
    # output-file          ~/.opam/log/coq-fourcolor-23169-335865.out
    ### output ###
    # [...]
    # COQDEP VFILES
    # COQC theories/real.v
    # COQC theories/hypermap.v
    # COQC theories/color.v
    # COQC theories/dyck.v
    # File "./theories/real.v", line 212, characters 55-59:
    # Error: Syntax error: '.' expected after [gallina] (in [vernac_aux]).
    # 
    # make[2]: *** [Makefile.coq:763: theories/real.vo] Error 1
    # make[2]: *** Waiting for unfinished jobs....
    # make[1]: *** [Makefile.coq:386: all] Error 2
    # make: *** [Makefile:15: invoke-coqmakefile] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-fourcolor 1.2.3
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-fourcolor.1.2.3 coq.8.14.0' failed.
```
@CohenCyril 