### PR TITLE
Fix coq-itauto.8.13 deps with Coq 8.14

### DIFF
--- a/released/packages/coq-itauto/coq-itauto.8.13/opam
+++ b/released/packages/coq-itauto/coq-itauto.8.13/opam
@@ -15,7 +15,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Cdcl"]
 depends: [
   "ocaml" {>= "4.9~"}
-  "coq" {>= "8.13.~" }
+  "coq" {>= "8.13.~" & < "8.14~"}
   "ocamlbuild" {build }
 ]
 depopts: [ "ocamlformat" {build} ]


### PR DESCRIPTION
Error https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.14.0/itauto/8.13.html @fajb 
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-itauto.8.13 coq.8.14.0
Return code
    7936
Duration
    4 m 48 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-gmp            3           Virtual package relying on a GMP lib system installation
    coq                 8.14.0      Formal proof management system
    dune                2.9.1       Fast, portable, and opinionated build system
    ocaml               4.09.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.09.1      Official release 4.09.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlbuild          0.14.0      OCamlbuild is a build system with builtin rules to easily build most OCaml projects.
    ocamlfind           1.9.1       A library manager for OCaml
    zarith              1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-itauto 8.13
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-itauto.8.13: http]
    [coq-itauto.8.13] downloaded from https://gitlab.inria.fr/fbesson/itauto/-/archive/8.13/itauto-8.13.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-itauto: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-itauto.8.13)
    - coq_makefile -f _CoqProject -o CoqMakefile
    - make -f CoqMakefile theories/Prover.vo COQBIN= 
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-itauto.8.13'
    - COQDEP VFILES
    - COQC theories/Coqlib.v
    - COQC theories/PatriciaR.v
    - COQC theories/KeyInt.v
    - File "./theories/KeyInt.v", line 14, characters 33-43:
    - Warning: Notation Int63.of_Z is deprecated since 8.14.
    - Use Uint63.of_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 20, characters 10-25:
    - Warning: Notation Int63.of_Z_spec is deprecated since 8.14.
    - Use Uint63.of_Z_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 20, characters 10-25:
    - Warning: Notation Int63.of_Z_spec is deprecated since 8.14.
    - Use Uint63.of_Z_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 20, characters 10-25:
    - Warning: Notation Int63.of_Z_spec is deprecated since 8.14.
    - Use Uint63.of_Z_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 22, characters 0-4:
    - Warning: The default value for instance locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding instances outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Instance Foo : Bar := baz." [deprecated-instance-without-locality,deprecated]
    - File "./theories/KeyInt.v", line 56, characters 29-39:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 56, characters 29-39:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 57, characters 31-41:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 57, characters 31-41:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 58, characters 15-24:
    - Warning: Notation Int63.leb is deprecated since 8.14. Use Uint63.leb instead.
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 58, characters 15-24:
    - Warning: Notation Int63.leb is deprecated since 8.14. Use Uint63.leb instead.
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 60, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 60, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 60, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 61, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 61, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 61, characters 15-26:
    - Warning: Notation Int63.bit_M is deprecated since 8.14.
    - Use Uint63.bit_M instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 64, characters 37-47:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 64, characters 37-47:
    - Warning: Notation Int63.to_Z is deprecated since 8.14.
    - Use Uint63.to_Z instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 161, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 161, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 161, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 169, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 169, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 169, characters 14-27:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 227, characters 52-71:
    - Warning: Notation "_ << _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 227, characters 52-71:
    - Warning: Notation "_ << _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 258, characters 31-43:
    - Warning: Notation "_ - _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 258, characters 32-38:
    - Warning: Notation "_ << _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 287, characters 12-16:
    - Warning: Notation bitE is deprecated since 8.14. Use Uint63.bitE instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 287, characters 12-16:
    - Warning: Notation bitE is deprecated since 8.14. Use Uint63.bitE instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 287, characters 12-16:
    - Warning: Notation bitE is deprecated since 8.14. Use Uint63.bitE instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 288, characters 12-20:
    - Warning: Notation sub_spec is deprecated since 8.14.
    - Use Uint63.sub_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 288, characters 12-20:
    - Warning: Notation sub_spec is deprecated since 8.14.
    - Use Uint63.sub_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 288, characters 12-20:
    - Warning: Notation sub_spec is deprecated since 8.14.
    - Use Uint63.sub_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 289, characters 12-20:
    - Warning: Notation lsl_spec is deprecated since 8.14.
    - Use Uint63.lsl_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 289, characters 12-20:
    - Warning: Notation lsl_spec is deprecated since 8.14.
    - Use Uint63.lsl_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 289, characters 12-20:
    - Warning: Notation lsl_spec is deprecated since 8.14.
    - Use Uint63.lsl_spec instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 290, characters 15-21:
    - Warning: Notation "φ _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 290, characters 34-40:
    - Warning: Notation "φ _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 291, characters 14-18:
    - Warning: Notation to_Z is deprecated since 8.14. Use Uint63.to_Z instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 290, characters 15-21:
    - Warning: Notation "φ _" is deprecated since 8.14.
    - Use the uint63_scope instead. [
    [...] truncated
    cated]
    - File "./theories/KeyInt.v", line 865, characters 18-21:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 865, characters 18-21:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 870, characters 18-25:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 870, characters 18-25:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 870, characters 18-25:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 871, characters 21-33:
    - Warning: Notation "_ ≤? _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 871, characters 28-33:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 871, characters 21-33:
    - Warning: Notation "_ ≤? _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 871, characters 28-33:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 876, characters 22-26:
    - Warning: Notation to_Z is deprecated since 8.14. Use Uint63.to_Z instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 876, characters 22-26:
    - Warning: Notation to_Z is deprecated since 8.14. Use Uint63.to_Z instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 878, characters 31-35:
    - Warning: Notation to_Z is deprecated since 8.14. Use Uint63.to_Z instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 878, characters 31-35:
    - Warning: Notation to_Z is deprecated since 8.14. Use Uint63.to_Z instead
    - [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 888, characters 38-52:
    - Warning: Notation "_ land _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 930, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 930, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 930, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 931, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 931, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 931, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 952, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 952, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 952, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 953, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 953, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 953, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 988, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 988, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 988, characters 12-19:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 989, characters 13-20:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 989, characters 13-20:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 989, characters 13-20:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 989, characters 13-20:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 989, characters 13-20:
    - Warning: Notation bit_lsl is deprecated since 8.14.
    - Use Uint63.bit_lsl instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 991, characters 13-20:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 991, characters 13-20:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 991, characters 13-20:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 991, characters 13-20:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 991, characters 13-20:
    - Warning: Notation bit_lsr is deprecated since 8.14.
    - Use Uint63.bit_lsr instead [deprecated-syntactic-definition,deprecated]
    - File "./theories/KeyInt.v", line 995, characters 21-75:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 995, characters 21-75:
    - Warning: Notation "_ + _" is deprecated since 8.14.
    - Use the uint63_scope instead. [deprecated-notation,deprecated]
    - File "./theories/KeyInt.v", line 995, characters 21-33:
    - Error:
    - In environment
    - k : int
    - m : nat
    - H : forall p : nat, (p < m)%nat -> testbit k p = false
    - H0 : testbit k m = true
    - p : nat
    - H1 : (p > m)%nat
    - H2 : (63 <= p)%nat -> False
    - MSMALL : (m < 63)%nat
    - H3 : (int_of_nat p - (int_of_nat m + 1)
    -       ≤? int_of_nat m + 1 + (int_of_nat p - (int_of_nat m + 1)))%int63 = true
    - H4 : (int_of_nat p <? int_of_nat m)%int63 || (63 ≤? int_of_nat p)%int63 =
    -      false
    - H5 : (int_of_nat p <? int_of_nat m + 1)%int63 || (63 ≤? int_of_nat p)%int63 =
    -      false
    - The term "int_of_nat m" has type "int" while it is expected to have type "Z".
    - 
    - make[1]: *** [CoqMakefile:763: theories/KeyInt.vo] Error 1
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-itauto.8.13'
    - make: *** [Makefile:17: theories/Prover.vo] Error 2
    [ERROR] The compilation of coq-itauto failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make".
    #=== ERROR while compiling coq-itauto.8.13 ====================================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-itauto.8.13
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/coq-itauto-29414-335865.env
    # output-file          ~/.opam/log/coq-itauto-29414-335865.out
    ### output ###
    # [...]
    # MSMALL : (m < 63)%nat
    # H3 : (int_of_nat p - (int_of_nat m + 1)
    #       ≤? int_of_nat m + 1 + (int_of_nat p - (int_of_nat m + 1)))%int63 = true
    # H4 : (int_of_nat p <? int_of_nat m)%int63 || (63 ≤? int_of_nat p)%int63 =
    #      false
    # H5 : (int_of_nat p <? int_of_nat m + 1)%int63 || (63 ≤? int_of_nat p)%int63 =
    #      false
    # The term "int_of_nat m" has type "int" while it is expected to have type "Z".
    # 
    # make[1]: *** [CoqMakefile:763: theories/KeyInt.vo] Error 1
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-itauto.8.13'
    # make: *** [Makefile:17: theories/Prover.vo] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-itauto 8.13
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-itauto.8.13 coq.8.14.0' failed.
    The middle of the output is truncated (maximum 20000 characters)

```