### PR TITLE
Fix coq-semantics.8.11.1 deps with Coq 8.14

### DIFF
--- a/released/packages/coq-semantics/coq-semantics.8.11.1/opam
+++ b/released/packages/coq-semantics/coq-semantics.8.11.1/opam
@@ -24,7 +24,7 @@ also provided in Coq, but there are no proofs associated.
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.10"}
+  "coq" {>= "8.10" & < "8.14"}
   "ocamlbuild" {build}
 ]
 


### PR DESCRIPTION
The build error: https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.14.0/semantics/8.11.1.html @k4rtik 
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-semantics.8.11.1 coq.8.14.0
Return code
    7936
Duration
    14 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-gmp            3           Virtual package relying on a GMP lib system installation
    coq                 8.14.0      Formal proof management system
    dune                2.9.1       Fast, portable, and opinionated build system
    ocaml               4.09.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.09.1      Official release 4.09.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlbuild          0.14.0      OCamlbuild is a build system with builtin rules to easily build most OCaml projects.
    ocamlfind           1.9.1       A library manager for OCaml
    zarith              1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-semantics 8.11.1
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-semantics.8.11.1: http]
    [coq-semantics.8.11.1] downloaded from https://github.com/coq-community/semantics/archive/v8.11.1.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-semantics: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1)
    - coq_makefile -f _CoqProject -o Makefile.coq
    - make -f Makefile.coq Makefile
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1'
    - COQDEP VFILES
    - *** Warning: in file context_sqrt.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file function_cpo.v, library Omega is required and has not been found in the loadpath!
    - make[1]: Nothing to be done for 'Makefile'.
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1'
    - make -f Makefile.coq all
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1'
    - COQC syntax.v
    - COQC function_cpo.v
    - COQC intervals.v
    - COQC context_sqrt.v
    - File "./context_sqrt.v", line 1, characters 22-27:
    - Error: Unable to locate library Omega.
    - 
    - make[2]: *** [Makefile.coq:763: context_sqrt.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - File "./function_cpo.v", line 2, characters 27-32:
    - Error: Unable to locate library Omega.
    - 
    - make[2]: *** [Makefile.coq:763: function_cpo.vo] Error 1
    - File "./intervals.v", line 28, characters 4-5:
    - Warning: Unused variable a catches more than one case.
    - [unused-pattern-matching-variable,pattern-matching]
    - File "./intervals.v", line 39, characters 12-13:
    - Warning: Unused variable a catches more than one case.
    - [unused-pattern-matching-variable,pattern-matching]
    - File "./intervals.v", line 55, characters 0-5:
    - Error: The reference omega was not found in the current environment.
    - 
    - make[2]: *** [Makefile.coq:763: intervals.vo] Error 1
    - make[1]: *** [Makefile.coq:386: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1'
    - make: *** [Makefile:2: all] Error 2
    [ERROR] The compilation of coq-semantics failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-semantics.8.11.1 ===============================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-semantics-19049-0a5907.env
    # output-file          ~/.opam/log/coq-semantics-19049-0a5907.out
    ### output ###
    # [...]
    # Warning: Unused variable a catches more than one case.
    # [unused-pattern-matching-variable,pattern-matching]
    # File "./intervals.v", line 39, characters 12-13:
    # Warning: Unused variable a catches more than one case.
    # [unused-pattern-matching-variable,pattern-matching]
    # File "./intervals.v", line 55, characters 0-5:
    # Error: The reference omega was not found in the current environment.
    # 
    # make[2]: *** [Makefile.coq:763: intervals.vo] Error 1
    # make[1]: *** [Makefile.coq:386: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-semantics.8.11.1'
    # make: *** [Makefile:2: all] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-semantics 8.11.1
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-semantics.8.11.1 coq.8.14.0' failed.

```