### PR TITLE
Fix coq-waterproof.1.0.0 dep for Coq 8.14

### DIFF
--- a/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
+++ b/released/packages/coq-waterproof/coq-waterproof.1.0.0/opam
@@ -18,7 +18,7 @@ authors: [
 license: "LGPL 3.0"
 
 depends: [
-  "coq" {>= "8.12"}
+  "coq" {>= "8.12" & < "8.14"}
 ]
 
 build: [


### PR DESCRIPTION
Error: https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.14.0/waterproof/1.0.0.html
```

Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-waterproof.1.0.0 coq.8.14.0
Return code
    7936
Duration
    15 s
Output

    # Packages matching: installed
    # Name              # Installed # Synopsis
    base-bigarray       base
    base-threads        base
    base-unix           base
    conf-findutils      1           Virtual package relying on findutils
    conf-gmp            3           Virtual package relying on a GMP lib system installation
    coq                 8.14.0      Formal proof management system
    dune                2.9.1       Fast, portable, and opinionated build system
    ocaml               4.09.1      The OCaml compiler (virtual package)
    ocaml-base-compiler 4.09.1      Official release 4.09.1
    ocaml-config        1           OCaml Switch Configuration
    ocamlfind           1.9.1       A library manager for OCaml
    zarith              1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-waterproof 1.0.0
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-waterproof.1.0.0: http]
    [coq-waterproof.1.0.0] downloaded from https://github.com/impermeable/coq-waterproof/archive/1.0.0.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-waterproof: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-waterproof.1.0.0)
    - coq_makefile -f _CoqProject -o CoqMakefile
    - make --no-print-directory -f CoqMakefile 
    - COQDEP VFILES
    - *** Warning: in file waterproof/notations/notations.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/tactics/automation_databases/decidability_db.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/tactics/rewrite_inequalities.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/contradiction_tactics/basic_contradiction.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/tactics/forward_reasoning/forward_reasoning_aux.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/tactics/forward_reasoning/we_conclude_that.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/contradiction_tactics/basic_contradiction.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/tactics/rewrite_inequalities.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/test/test_tactics/test_choose_such_that.v, library Omega is required and has not been found in the loadpath!
    - *** Warning: in file waterproof/test/test_tactics/test_sets_tactics/test_sets_automation_tactics.v, library Omega is required and has not been found in the loadpath!
    - COQC waterproof/auxiliary.v
    - COQC waterproof/definitions/set_definitions.v
    - COQC waterproof/string_auxiliary.v
    - COQC waterproof/tactics/automation_databases/decidability_db.v
    - COQC waterproof/tactics/because.v
    - COQC waterproof/tactics/choose.v
    - COQC waterproof/tactics/choose_such_that.v
    - COQC waterproof/tactics/sets_tactics/sets_automation_tactics.v
    - COQC waterproof/tactics/unfold.v
    - COQC waterproof/tactics/we_need_to_show.v
    - File "./waterproof/tactics/automation_databases/decidability_db.v", line 47, characters 15-20:
    - Error: Unable to locate library Omega.
    - 
    - make[2]: *** [CoqMakefile:762: waterproof/tactics/automation_databases/decidability_db.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - File "./waterproof/tactics/sets_tactics/sets_automation_tactics.v", line 32, characters 0-62:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - File "./waterproof/tactics/sets_tactics/sets_automation_tactics.v", line 134, characters 0-70:
    - Warning: The default value for hint locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding hints outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    - make[1]: *** [CoqMakefile:386: all] Error 2
    - make: *** [Makefile:12: invoke-coqmakefile] Error 2
    [ERROR] The compilation of coq-waterproof failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-waterproof.1.0.0 ===============================#
    # context              2.0.6 | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.09.1/.opam-switch/build/coq-waterproof.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-waterproof-3177-335865.env
    # output-file          ~/.opam/log/coq-waterproof-3177-335865.out
    ### output ###
    # [...]
    # #[global] and #[export] depending on your choice. For example: "#[export]
    # Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    # File "./waterproof/tactics/sets_tactics/sets_automation_tactics.v", line 134, characters 0-70:
    # Warning: The default value for hint locality is currently "local" in a
    # section and "global" otherwise, but is scheduled to change in a future
    # release. For the time being, adding hints outside of sections without
    # specifying an explicit locality attribute is therefore deprecated. It is
    # recommended to use "export" whenever possible. Use the attributes #[local],
    # #[global] and #[export] depending on your choice. For example: "#[export]
    # Hint Unfold foo : bar." [deprecated-hint-without-locality,deprecated]
    # make[1]: *** [CoqMakefile:386: all] Error 2
    # make: *** [Makefile:12: invoke-coqmakefile] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-waterproof 1.0.0
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-waterproof.1.0.0 coq.8.14.0' failed.

```
@jim-portegies