### PR TITLE
Remove the upper bound from coq-mathcomp-multinomials.dev

### DIFF
--- a/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.dev/opam
@@ -10,12 +10,12 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "coq"                    {(>= "8.10" & < "8.15~") | = "dev"}
+  "coq"                    {>= "8.10"}
   "dune"                   {>= "2.5"}
-  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | = "dev"}
+  "coq-mathcomp-ssreflect" {>= "1.12"}
   "coq-mathcomp-algebra"
-  "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}
-  "coq-mathcomp-finmap"    {(>= "1.5" & < "1.6~") | = "dev"}
+  "coq-mathcomp-bigenough" {>= "1.0"}
+  "coq-mathcomp-finmap"    {>= "1.5"}
 ]
 tags: [
   "keyword:multinomials"


### PR DESCRIPTION
The main difference is that it allows us to build coq-mathcomp-multinomials.dev using MathComp 1.13.0. See also: math-comp/multinomials#51