### PR TITLE
fix: coq-mathcomp-multinomials.{1.5.3,1.5.4} conflicts with coq-native

### DIFF
--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.3/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.3/opam
@@ -15,6 +15,9 @@ depends: [
   "coq-mathcomp-bigenough" {>= "1.0" & < "1.1~"}
   "coq-mathcomp-finmap"    {>= "1.5" & < "1.6~"}
 ]
+conflicts: [
+  "coq-native"
+]
 tags: [
   "keyword:multinomials"
   "keyword:monoid algebra"

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.4/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.4/opam
@@ -14,6 +14,9 @@ depends: [
   "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}
   "coq-mathcomp-finmap"    {(>= "1.5" & < "1.6~") | = "dev"}
 ]
+conflicts: [
+  "coq-native"
+]
 tags: [
   "keyword:multinomials"
   "keyword:monoid algebra"


### PR DESCRIPTION
* This patch allows one to preemptively refuse to compile multinomials in a `coq-native` switch, otherwise multinomials' reverse deps (not multinomials itself) would raise `Unbound module NSsrMultinomials_*`.

* Don't edit coq-mathcomp-multinomials < 1.5.3 as these old versions didn't use dune.

href: https://github.com/math-comp/multinomials/issues/52