### PR TITLE
updating coq-libhyps-2.0.4

### DIFF
--- a/released/packages/coq-libhyps/coq-libhyps.2.0.4/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.2.0.4/opam
@@ -44,6 +44,6 @@ instantianting one, several or all premisses of a hypothesis.
 "
 
 url {
-    http: "https://github.com/Matafou/LibHyps/archive/libhyps-2.0.4.tar.gz"
-    checksum: "sha256=74462a848570a2496098898e5a5c31c7d0ece2d7e01ccda61c4220e09a59eda8"
+    http: "https://github.com/Matafou/LibHyps/archive/libhyps-2.0.4.1.tar.gz"
+    checksum: "sha256=e5e23c85d198d112e9269f59b22ef8b087b29bd8c481aad3119a701e238c3e0e"
 }


### PR DESCRIPTION
Fixing a small issue. This updates the last version instead of making a new one. As advised.