### PR TITLE
Update finmap-dev dependencies

### DIFF
--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -17,9 +17,8 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-bigenough" { (>= "1.0.0") | (= "dev") }
+  "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
 ]
 
 tags: [


### PR DESCRIPTION
Update `finmap` opam file in `extra-dev` repo to match the one in `released` repo.

* bump Coq to 8.14 and mathcomp to 1.13
* remove dependency on `bigenough` 