### PR TITLE
Fix deps of coq-mathcomp-analysis.0.3.10

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.10/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.14~") | (= "dev") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.14~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-bigenough"
   "coq-hierarchy-builder" { >= "0.10.0" | (= "dev") }
 ]
 


### PR DESCRIPTION
@affeldt-aist  To fix the following issue:
```
Command
    opam list; echo; ulimit -Sv 16000000; timeout 4h opam install -y -v coq-mathcomp-analysis.0.3.10 coq.8.14.0
Return code
    7936
Duration
    2 m 55 s
Output

    # Packages matching: installed
    # Name                 # Installed # Synopsis
    base-bigarray          base
    base-threads           base
    base-unix              base
    camlp5                 7.14        Preprocessor-pretty-printer of OCaml
    conf-findutils         1           Virtual package relying on findutils
    conf-gmp               3           Virtual package relying on a GMP lib system installation
    conf-perl              1           Virtual package relying on perl
    coq                    8.14.0      Formal proof management system
    coq-elpi               1.11.2      Elpi extension language for Coq
    coq-hierarchy-builder  1.2.0       High level commands to declare and evolve a hierarchy based on packed classes
    coq-mathcomp-algebra   1.13.0      Mathematical Components Library on Algebra
    coq-mathcomp-field     1.13.0      Mathematical Components Library on Fields
    coq-mathcomp-fingroup  1.13.0      Mathematical Components Library on finite groups
    coq-mathcomp-finmap    1.5.1       Finite sets, finite maps, finitely supported functions
    coq-mathcomp-solvable  1.13.0      Mathematical Components Library on finite groups (II)
    coq-mathcomp-ssreflect 1.13.0      Small Scale Reflection
    cppo                   1.6.8       Code preprocessor like cpp for OCaml
    dune                   2.9.1       Fast, portable, and opinionated build system
    elpi                   1.13.7      ELPI - Embeddable λProlog Interpreter
    ocaml                  4.11.2      The OCaml compiler (virtual package)
    ocaml-base-compiler    4.11.2      Official release 4.11.2
    ocaml-compiler-libs    v0.12.4     OCaml compiler libraries repackaged
    ocaml-config           1           OCaml Switch Configuration
    ocamlfind              1.9.1       A library manager for OCaml
    ppx_derivers           1.2.1       Shared [@@deriving] plugin registry
    ppx_deriving           5.2.1       Type-driven code generation for OCaml
    ppxlib                 0.23.0      Standard library for ppx rewriters
    re                     1.10.3      RE is a regular expression library for OCaml
    result                 1.5         Compatibility Result module
    seq                    base        Compatibility package for OCaml's standard iterator type starting from 4.07.
    sexplib0               v0.14.0     Library containing the definition of S-expressions and some base converters
    stdlib-shims           0.3.0       Backport some of the new stdlib features to older compiler
    zarith                 1.12        Implements arithmetic and logical operations over arbitrary-precision integers
    [NOTE] Package coq is already installed (current version is 8.14.0).
    The following actions will be performed:
      - install coq-mathcomp-analysis 0.3.10
    <><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/1: [coq-mathcomp-analysis.0.3.10: http]
    [coq-mathcomp-analysis.0.3.10] downloaded from https://github.com/math-comp/analysis/archive/0.3.10.tar.gz
    Processing  1/1:
    <><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    Processing  1/2: [coq-mathcomp-analysis: make]
    + /home/bench/.opam/opam-init/hooks/sandbox.sh "build" "make" "-j4" (CWD=/home/bench/.opam/ocaml-base-compiler.4.11.2/.opam-switch/build/coq-mathcomp-analysis.0.3.10)
    - /home/bench/.opam/ocaml-base-compiler.4.11.2/bin/coq_makefile  -f _CoqProject -o Makefile.coq
    - make -f Makefile.coq 
    - make[1]: Entering directory '/home/bench/.opam/ocaml-base-compiler.4.11.2/.opam-switch/build/coq-mathcomp-analysis.0.3.10'
    - COQDEP VFILES
    - *** Warning: in file theories/altreals/realseq.v, library mathcomp.bigenough.bigenough is required and has not been found in the loadpath!
    - COQC theories/boolp.v
    - COQC theories/forms.v
    - COQC theories/altreals/xfinmap.v
    - File "./theories/forms.v", line 126, characters 0-52:
    - Warning: class_of_axiom does not respect the uniform inheritance condition
    - [uniform-inheritance,typechecker]
    - File "./theories/forms.v", line 142, characters 0-48:
    - Warning: additiver does not respect the uniform inheritance condition
    - [uniform-inheritance,typechecker]
    - File "./theories/forms.v", line 143, characters 0-45:
    - Warning: linearr does not respect the uniform inheritance condition
    - [uniform-inheritance,typechecker]
    - File "./theories/forms.v", line 144, characters 0-20:
    - Warning: Ignoring canonical projection to apply by GRing.Additive.apply in
    - additiver: redundant with additiver
    - [redundant-canonical-projection,typechecker]
    - File "./theories/forms.v", line 145, characters 0-18:
    - Warning: Ignoring canonical projection to apply by GRing.Linear.apply in
    - linearr: redundant with linearr [redundant-canonical-projection,typechecker]
    - File "./theories/forms.v", line 146, characters 0-20:
    - Warning: Ignoring canonical projection to applyr_head by GRing.Additive.apply
    - in additivel: redundant with additivel
    - [redundant-canonical-projection,typechecker]
    - File "./theories/forms.v", line 147, characters 0-18:
    - Warning: Ignoring canonical projection to applyr_head by GRing.Linear.apply
    - in linearl: redundant with linearl
    - [redundant-canonical-projection,typechecker]
    - COQC theories/classical_sets.v
    - COQC theories/nngnum.v
    - File "./theories/nngnum.v", line 88, characters 0-25:
    - Warning: Ignoring canonical projection to NngNumDef by Sub in nngnum_subType:
    - redundant with nngnum_subType [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 88, characters 0-25:
    - Warning: Ignoring canonical projection to num_of_nng by val in
    - nngnum_subType: redundant with nngnum_subType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 88, characters 0-25:
    - Warning: Ignoring canonical projection to nngnum_of by sub_sort in
    - nngnum_subType: redundant with nngnum_subType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 89, characters 0-24:
    - Warning: Ignoring canonical projection to nngnum_of by Equality.sort in
    - nngnum_eqType: redundant with nngnum_eqType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 90, characters 0-28:
    - Warning: Ignoring canonical projection to nngnum_of by Choice.sort in
    - nngnum_choiceType: redundant with nngnum_choiceType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 91, characters 0-28:
    - Warning: Ignoring canonical projection to nngnum_of by Order.POrder.sort in
    - nngnum_porderType: redundant with nngnum_porderType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 92, characters 0-29:
    - Warning: Ignoring canonical projection to nngnum_of by Order.Lattice.sort in
    - nngnum_latticeType: redundant with nngnum_latticeType
    - [redundant-canonical-projection,typechecker]
    - File "./theories/nngnum.v", line 93, characters 0-27:
    - Warning: Ignoring canonical projection to nngnum_of by Order.Total.sort in
    - nngnum_orderType: redundant with nngnum_orderType
    - [redundant-canonical-projection,typechecker]
    - COQC theories/posnum.v
    - COQC theories/prodnormedzmodule.v
    - File "./theories/prodnormedzmodule.v", line 56, characters 0-25:
    - Warning: Ignoring canonical projection to prod by Num.NormedZmodule.sort in
    - @normedZmodType: redundant with @normedZmodType
    - [redundant-canonical-projection,typechecker]
    - COQC theories/reals.v
    - COQC theories/cardinality.v
    - COQC theories/topology.v
    - COQC theories/altreals/discrete.v
    - File "./theories/topology.v", line 682, characters 0-31:
    - Warning: The default value for instance locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding instances outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Instance Foo : Bar := baz." [deprecated-instance-without-locality,deprecated]
    - File "./theories/topology.v", line 693, characters 0-32:
    - Warning: The default value for instance locality is currently "local" in a
    - section and "global" otherwise, but is scheduled to change in a future
    - release. For the time being, adding instances outside of sections without
    - specifying an explicit locality attribute is therefore deprecated. It is
    - recommended to use "export" whenever possible. Use the attributes #[local],
    - #[global] and #[export] depending on your choice. For example: "#[export]
    - Instance Foo : Bar := baz." [deprecated-instance-without-locality,deprecated]
    - COQC theories/ereal.v
    - File "./theories/ereal.v", line 118, characters 0-66:
    - Warning: real_of_extended does not respect the uniform inheritance condition
    - [uniform-inheritance,typechecker]
    - COQC theories/normedtype.v
    - COQC theories/altreals/realseq.v
    - File "./theories/altreals/realseq.v", line 8, characters 15-43:
    - Error: Cannot find a physical path bound to logical path matching suffix
    - mathcomp.bigenough.
    - 
    - make[2]: *** [Makefile.coq:763: theories/altreals/realseq.vo] Error 1
    - make[2]: *** Waiting for unfinished jobs....
    - make[1]: *** [Makefile.coq:386: all] Error 2
    - make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.11.2/.opam-switch/build/coq-mathcomp-analysis.0.3.10'
    - make: *** [Makefile.common:63: this-build] Error 2
    [ERROR] The compilation of coq-mathcomp-analysis failed at "/home/bench/.opam/opam-init/hooks/sandbox.sh build make -j4".
    #=== ERROR while compiling coq-mathcomp-analysis.0.3.10 =======================#
    # context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/bench/run/opam-coq-archive/released
    # path                 ~/.opam/ocaml-base-compiler.4.11.2/.opam-switch/build/coq-mathcomp-analysis.0.3.10
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j4
    # exit-code            2
    # env-file             ~/.opam/log/coq-mathcomp-analysis-26219-335865.env
    # output-file          ~/.opam/log/coq-mathcomp-analysis-26219-335865.out
    ### output ###
    # [...]
    # [uniform-inheritance,typechecker]
    # COQC theories/normedtype.v
    # COQC theories/altreals/realseq.v
    # File "./theories/altreals/realseq.v", line 8, characters 15-43:
    # Error: Cannot find a physical path bound to logical path matching suffix
    # mathcomp.bigenough.
    # 
    # make[2]: *** [Makefile.coq:763: theories/altreals/realseq.vo] Error 1
    # make[2]: *** Waiting for unfinished jobs....
    # make[1]: *** [Makefile.coq:386: all] Error 2
    # make[1]: Leaving directory '/home/bench/.opam/ocaml-base-compiler.4.11.2/.opam-switch/build/coq-mathcomp-analysis.0.3.10'
    # make: *** [Makefile.common:63: this-build] Error 2
    <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
    +- The following actions failed
    | - build coq-mathcomp-analysis 0.3.10
    +- 
    - No changes have been performed
    # Run eval $(opam env) to update the current shell environment
    'opam install -y -v coq-mathcomp-analysis.0.3.10 coq.8.14.0' failed.
```