### PR TITLE
fix bigenough dependency from 0.3.5 to 0.3.9

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.5/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.5/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
   "coq-hierarchy-builder" { (>= "0.10.0" & < "1.1.0") }
 ]
 

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.6/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.6/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
   "coq-hierarchy-builder" { (>= "0.10.0" & < "1.1.0") | (= "dev") }
 ]
 

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.7/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.7/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
   "coq-hierarchy-builder" { >= "0.10.0" | (= "dev") }
 ]
 

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.8/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.8/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
   "coq-hierarchy-builder" { >= "0.10.0" | (= "dev") }
 ]
 

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.9/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.9/opam
@@ -21,6 +21,7 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-bigenough" { (>= "1.0.0") }
   "coq-hierarchy-builder" { >= "0.10.0" | (= "dev") }
 ]
 


### PR DESCRIPTION
just add an explicit dependency to bigenough for releases requiring finmap >= 1.5.1