### PR TITLE
Enable Coq 8.14 for coq-math-classes.8.13.0

### DIFF
--- a/released/packages/coq-math-classes/coq-math-classes.8.13.0/opam
+++ b/released/packages/coq-math-classes/coq-math-classes.8.13.0/opam
@@ -29,7 +29,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.11" & < "8.14~"}
+  "coq" {>= "8.11" & < "8.15~"}
   "coq-bignums" 
 ]
 


### PR DESCRIPTION
This PR enabled Coq 8.14 in coq-match-classes.8.13. It is tested to be compatible and there is no intention to publish a 8.14 tag as discussed here:

https://github.com/coq-community/math-classes/issues/108
