### PR TITLE
Added updated package for coq-mtac2

### DIFF
--- a/released/packages/coq-mtac2/coq-mtac2.1.4+8.14/opam
+++ b/released/packages/coq-mtac2/coq-mtac2.1.4+8.14/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "beta.ziliani@gmail.com"
+homepage: "https://github.com/Mtac2/Mtac2"
+dev-repo: "git+https://github.com/Mtac2/Mtac2.git"
+bug-reports: "https://github.com/Mtac2/Mtac2/issues"
+authors: ["Beta Ziliani <beta.ziliani@gmail.com>" "Jan-Oliver Kaiser <janno@mpi-sws.org>" "Robbert Krebbers <mail@robbertkrebbers.nl>" "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>" "Derek Dreyer <dreyer@mpi-sws.org>"]
+license: "MIT"
+build: [
+  ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.14" & < "8.15~"}
+  "coq-unicoq" {>= "1.5" & < "2~"}
+]
+synopsis: "Mtac2: Typed Tactics for Coq"
+tags: [
+  "logpath:Mtac2"
+  "date:2021-09-24"
+]
+url {
+  src: "https://github.com/Mtac2/Mtac2/archive/v1.4-coq8.14.tar.gz"
+  checksum: "sha512=9d4dd7176a6ceeca1cbe5f2490bc6d17c1a2f8653cbfd4251d42f7dad0c23dfb7383a131a2ca2beae10cbad0e50c4ee24a5e40775dd128260ca583962ea55c83"
+}


### PR DESCRIPTION
This PR adds an updated opam package for Mtac2 as discussed here:

https://github.com/Mtac2/Mtac2/issues/344