### PR TITLE
Fix dep for coq-mathcomp-analysis 3.1 - 3.4 with bigenough

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.1/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.1/opam
@@ -20,6 +20,7 @@ install: [
 ]
 depends: [
   "coq" {(>= "8.10" & < "8.12~") | (= "dev")}
+  "coq-mathcomp-bigenough"   {(>= "1.0.0")}
   "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~")}
   "coq-mathcomp-finmap"      {(>= "1.5.0" & < "1.6~")}
 ]

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.2/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.2/opam
@@ -20,6 +20,7 @@ install: [
 ]
 depends: [
   "coq" { ((>= "8.10" & < "8.13~") | = "dev") }
+  "coq-mathcomp-bigenough"   {(>= "1.0.0")}
   "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~")}
   "coq-mathcomp-finmap"      {(>= "1.5.0" & < "1.6~")}
 ]

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.3/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.3/opam
@@ -20,6 +20,7 @@ install: [
 ]
 depends: [
   "coq" { ((>= "8.10" & < "8.13~") | = "dev") }
+  "coq-mathcomp-bigenough"   {(>= "1.0.0")}
   "coq-mathcomp-field"       {(>= "1.11.0" & < "1.12~")}
   "coq-mathcomp-finmap"      {(>= "1.5.0" & < "1.6~")}
 ]

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.4/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.3.4/opam
@@ -17,6 +17,7 @@ install: [make "install"]
 depends: [
   "coq" { (>= "8.11" & < "8.13~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.12~") }
+  "coq-mathcomp-bigenough"   {(>= "1.0.0")}
   "coq-mathcomp-fingroup" { (>= "1.11.0" & < "1.12~") }
   "coq-mathcomp-algebra" { (>= "1.11.0" & < "1.12~") }
   "coq-mathcomp-solvable" { (>= "1.11.0" & < "1.12~") }


### PR DESCRIPTION
Follow-up of https://github.com/coq/opam-coq-archive/pull/1955 @affeldt-aist It seems other versions of mathcomp-analysis have the same issue. See the errors in the https://coq.zulipchat.com/#narrow/stream/237656-Coq-devs.20.26.20plugin.20devs/topic/coq-bench.20for.20opam channel.