### PR TITLE
Update the download urls for coq-cfml

### DIFF
--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 url {
   src:
-    "https://gitlab.inria.fr/charguer/cfml/repository/20180525/archive.tar.gz"
-  checksum: "md5=84981a5ed6dcd6d4bfc355a263fdc5bd"
+    "https://gitlab.inria.fr/charguer/cfml/-/archive/20180525/cfml-20180525.tar.gz"
+  checksum: "sha512=2c8055bcdcfb7f9b7e7aa50e20603d7f69a2abb42f6ba4fe5758b756ef0481e3fc588c29d0f68f1c04561448609f3bfa65ca616da2717f2947eb572f952630d1"
 }

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 url {
   src:
-    "https://gitlab.inria.fr/charguer/cfml/repository/20181201/archive.tar.gz"
-  checksum: "md5=0fd573617610a512381b58fe26a0edf6"
+    "https://gitlab.inria.fr/charguer/cfml/-/archive/20181201/cfml-20181201.tar.gz"
+  checksum: "sha512=0fb91b41f8783fc4be594cf01f9099a071818b65c28f42f80673bf551cacf8de49e1bfe03e5248b7941b031862274088b906d3b8fa8bca307b4b67f089d07daf"
 }


### PR DESCRIPTION
@charguer I know these versions are quite old but I am still updating the download links. The current ones do not work (at least without having an Inria GitLab account, as it redirects to the login page). Changing to sha checksums also.