### PR TITLE
Try to fix coq-cfml.

### DIFF
--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -19,5 +19,5 @@ depends: [
 url {
   src:
     "https://gitlab.inria.fr/charguer/cfml/-/archive/20180525/archive.tar.gz"
-  checksum: "sha512=2c8055bcdcfb7f9b7e7aa50e20603d7f69a2abb42f6ba4fe5758b756ef0481e3fc588c29d0f68f1c04561448609f3bfa65ca616da2717f2947eb572f952630d1"
+  checksum: "sha512=ee6c62a7b7885aa9b443da97fb1b1d20e30d383d59ff2affebca7f35880c3396549b6e7c4547087e9d6eef5185b77ecf1adc78e94ced20c7c6c052db68a5caf5"
 }

--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -7,7 +7,8 @@ bug-reports: "https://gitlab.inria.fr/charguer/cfml/issues"
 license: "CeCILL-B"
 dev-repo: "git+https://gitlab.inria.fr/charguer/cfml.git"
 build: [make "-j%{jobs}%"]
-install: [make "install"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
   "ocamlbuild" {build}

--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -8,7 +8,6 @@ license: "CeCILL-B"
 dev-repo: "git+https://gitlab.inria.fr/charguer/cfml.git"
 build: [make "-j%{jobs}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
   "ocamlbuild" {build}
@@ -20,5 +19,5 @@ depends: [
 url {
   src:
     "https://gitlab.inria.fr/charguer/cfml/-/archive/20180525/archive.tar.gz"
-  checksum: "md5=84981a5ed6dcd6d4bfc355a263fdc5bd"
+  checksum: "sha512=2c8055bcdcfb7f9b7e7aa50e20603d7f69a2abb42f6ba4fe5758b756ef0481e3fc588c29d0f68f1c04561448609f3bfa65ca616da2717f2947eb572f952630d1"
 }

--- a/released/packages/coq-cfml/coq-cfml.20180525/opam
+++ b/released/packages/coq-cfml/coq-cfml.20180525/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 url {
   src:
-    "https://gitlab.inria.fr/charguer/cfml/repository/20180525/archive.tar.gz"
+    "https://gitlab.inria.fr/charguer/cfml/-/archive/20180525/archive.tar.gz"
   checksum: "md5=84981a5ed6dcd6d4bfc355a263fdc5bd"
 }

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -7,7 +7,6 @@ license: "CeCILL-B"
 dev-repo: "git+https://gitlab.inria.fr/charguer/cfml.git"
 build: [make "-j%{jobs}%"]
 install: [make "install" "PREFIX=%{prefix}%"]
-remove: [make "uninstall" "PREFIX=%{prefix}%"]
 synopsis: "A tool for proving OCaml programs in Separation Logic"
 depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
@@ -20,5 +19,5 @@ depends: [
 url {
   src:
     "https://gitlab.inria.fr/charguer/cfml/-/archive/20181201/archive.tar.gz"
-  checksum: "md5=5476890fb7922fe2ce264c8af4bd26bc"
+  checksum: "sha512=0fb91b41f8783fc4be594cf01f9099a071818b65c28f42f80673bf551cacf8de49e1bfe03e5248b7941b031862274088b906d3b8fa8bca307b4b67f089d07daf"
 }

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -19,5 +19,5 @@ depends: [
 url {
   src:
     "https://gitlab.inria.fr/charguer/cfml/-/archive/20181201/archive.tar.gz"
-  checksum: "sha512=0fb91b41f8783fc4be594cf01f9099a071818b65c28f42f80673bf551cacf8de49e1bfe03e5248b7941b031862274088b906d3b8fa8bca307b4b67f089d07daf"
+  checksum: "sha512=a8fc7142a21263b38db4178246eb03ab6b3d888f591e9ac2621a45b26d63bcfd0ef9f4d10277a3c82e0f5ad0ea2c7784e7da16526504b78f0ce60eb9713ace68"
 }

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 url {
   src:
-    "https://gitlab.inria.fr/charguer/cfml/repository/20181201/archive.tar.gz"
-  checksum: "md5=0fd573617610a512381b58fe26a0edf6"
+    "https://gitlab.inria.fr/charguer/cfml/-/archive/20181201/archive.tar.gz"
+  checksum: "md5=5476890fb7922fe2ce264c8af4bd26bc"
 }

--- a/released/packages/coq-cfml/coq-cfml.20181201/opam
+++ b/released/packages/coq-cfml/coq-cfml.20181201/opam
@@ -6,7 +6,8 @@ bug-reports: "https://gitlab.inria.fr/charguer/cfml/issues"
 license: "CeCILL-B"
 dev-repo: "git+https://gitlab.inria.fr/charguer/cfml.git"
 build: [make "-j%{jobs}%"]
-install: [make "install"]
+install: [make "install" "PREFIX=%{prefix}%"]
+remove: [make "uninstall" "PREFIX=%{prefix}%"]
 synopsis: "A tool for proving OCaml programs in Separation Logic"
 depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}


### PR DESCRIPTION
Hi Guillaume & Karl, thanks for pointing out that these packages are broken. Here is an attempt to repair the URLs and the installation instructions. We will also be preparing a new release of CFML in the coming days or weeks.