### PR TITLE
Add update for coq-coqprime and new package coq-coqprime-generator

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ before_script:
   - apt-get update -qy
   - apt-get install libgtksourceview2.0-dev -y || true # gone with Debian bullseye
   - apt-get install build-essential -y # missing with Debian bullseye
-  - apt-get install unzip libgtksourceview-3.0-dev libncurses5-dev curl jq ruby bubblewrap time libgmp-dev coinor-csdp libstring-shellquote-perl libipc-system-simple-perl automake autoconf -y
+  - apt-get install unzip libgtksourceview-3.0-dev libncurses5-dev curl jq ruby bubblewrap time libgmp-dev coinor-csdp libstring-shellquote-perl libipc-system-simple-perl automake autoconf libtool -y
   - test -e $OPAM_ROOT_CACHE || scripts/opam-coq-init
   - curl -L https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux >/usr/local/bin/opam
   - chmod +x /usr/local/bin/opam

--- a/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.1/opam
+++ b/released/packages/coq-coqprime-generator/coq-coqprime-generator.1.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "thery@sophia.inria.fr"
+homepage: "https://github.com/thery/coqprime"
+bug-reports: "https://github.com/thery/coqprime/issues"
+dev-repo: "git+https://github.com/thery/coqprime.git"
+license: "LGPL-2.1-only"
+authors: ["Laurent Théry"]
+build: [
+  # cd to a subfolder in opam is tricky, so just move gencertif to the root folder
+  [ "find" "gencertif" "-type" "f" "-exec" "mv" "{}" "." ";" ]
+  [ "autoreconf" "-i" "-s" ]
+  [ "./configure" "--prefix" prefix
+    # Optiosn for finding opam local gmp-ecm
+    "CPPFLAGS=-I%{prefix}%/include"
+    "LDFLAGS=-L%{lib}%"
+    # Options for homebrew on Intel silicon (overwriting the above)
+    "CPPFLAGS=-I%{prefix}%/include -I/opt/local/include" { os-distribution = "macports" & os = "macos" }
+    "LDFLAGS=-L%{lib}% -L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    # Options for homebrew on Apple silicon (overwriting the above)
+    "CPPFLAGS=-I%{prefix}%/include -I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
+    "LDFLAGS=-L%{lib}% -L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
+    # Options for Windows cygwin
+    "--build=%{arch}%-pc-cygwin" { os = "win32" & os-distribution = "cygwinports" }
+    "--host=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }
+    "--target=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }
+  ]
+  [ make "-j" "%{jobs}%" ]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "num"
+  "conf-gmp"
+  "gmp-ecm"
+]
+synopsis: "Certificate generator for prime numbers in Coq"
+url {
+  src: "https://github.com/thery/coqprime/archive/v8.14.1.tar.gz"
+  checksum: "sha512=cd5d4ff31a2ac3039e5c49e9da627a0f4722ff7d9269bbe521531a162c0f0dfc190779eeafa8749d563c65dc787d17e9193fdd0664b273d01220272f3abb17ca"
+}

--- a/released/packages/coq-coqprime/coq-coqprime.1.1.1/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "thery@sophia.inria.fr"
+homepage: "https://github.com/thery/coqprime"
+bug-reports: "https://github.com/thery/coqprime/issues"
+dev-repo: "git+https://github.com/thery/coqprime.git"
+license: "LGPL-2.1-only"
+authors: ["Laurent Théry"]
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.13~"}
+  "coq-bignums"
+]
+synopsis: "Certifying prime numbers in Coq"
+url {
+  src: "https://github.com/thery/coqprime/archive/v8.14.1.tar.gz"
+  checksum: "sha512=cd5d4ff31a2ac3039e5c49e9da627a0f4722ff7d9269bbe521531a162c0f0dfc190779eeafa8749d563c65dc787d17e9193fdd0664b273d01220272f3abb17ca"
+}


### PR DESCRIPTION
@thery : FYI.

Note: this package existed since a while in the Coq Platform local opam patch repo, but couldn't be merged here before the gmp-ecm library was merged to the main opam repo, which just happened (https://github.com/ocaml/opam-repository/pull/20105).
