### PR TITLE
fix coq-stdpp 1.6 and Iris 3.5 build when OCAMLRUNPARAM is set

### DIFF
--- a/released/packages/coq-stdpp/coq-stdpp.1.6.0/files/ocamlrunparam.patch
+++ b/released/packages/coq-stdpp/coq-stdpp.1.6.0/files/ocamlrunparam.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile.coq.local b/Makefile.coq.local
+index 7dea713..a5fe96a 100644
+--- a/Makefile.coq.local
++++ b/Makefile.coq.local
+@@ -35,6 +35,7 @@ tests/.coqdeps.d: $(TESTFILES)
+ # Main test script (comments out-of-line because macOS otherwise barfs?!?)
+ # - Determine reference file (`REF`).
+ # - Print user-visible status line.
++# - unset env vars that change Coq's output
+ # - Dump Coq output into a temporary file.
+ # - Run `sed -i` on that file in a way that works on macOS.
+ # - Either compare the result with the reference file, or move it over the reference file.
+@@ -47,6 +48,7 @@ $(TESTFILES:.v=.vo): %.vo: %.v $(if $(MAKE_REF),,%.ref) $(NORMALIZER)
+ 	  fi && \
+ 	  echo "COQTEST$(if $(MAKE_REF), [make ref],) $< (ref: $$REF)" && \
+ 	  TMPFILE="$$(mktemp)" && \
++	  unset OCAMLRUNPARAM && \
+ 	  $(TIMER) $(COQ_TEST) $(COQFLAGS) $(COQLIBS) -load-vernac-source $< > "$$TMPFILE" && \
+ 	  sed -f $(NORMALIZER) "$$TMPFILE" > "$$TMPFILE".new && \
+ 	  mv "$$TMPFILE".new "$$TMPFILE" && \

--- a/released/packages/coq-stdpp/coq-stdpp.1.6.0/opam
+++ b/released/packages/coq-stdpp/coq-stdpp.1.6.0/opam
@@ -36,6 +36,7 @@ depends: [
   "coq" { (>= "8.10.2" & < "8.15~") | (= "dev") }
 ]
 
+patches: ["ocamlrunparam.patch"]
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 


### PR DESCRIPTION
This fixes https://gitlab.mpi-sws.org/iris/stdpp/-/issues/126 for the latest released versions of std++ and Iris. Two users can into this (that I know of), so this is probably worth porting to the opam repository.