### PR TITLE
Fix Coq version for coq-of-ocaml.1.2.1

### DIFF
--- a/released/packages/coq-of-ocaml/coq-of-ocaml.1.2.1/opam
+++ b/released/packages/coq-of-ocaml/coq-of-ocaml.1.2.1/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "-C" "OCaml" "install"]
 depends: [
   "conf-ruby" {build}
-  "coq" {>= "8.5"}
+  "coq" {>= "8.5" & < "8.14~"}
   "ocaml" {>= "4.05.0" & < "4.06.0"}
   "ocamlbuild" {build}
   "smart-print"


### PR DESCRIPTION
Error log: https://coq-bench.github.io/clean/Linux-x86_64-4.05.0-2.0.1/released/8.14.0/of-ocaml/1.2.1.html