### PR TITLE
update coq-autosubst opam file

### DIFF
--- a/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
+++ b/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
@@ -19,7 +19,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.11" & < "8.15~") | (= "dev")}
+  "coq" {(>= "8.11" & < "8.16~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
I verified that autosubst builds with current Coq 8.15.dev.