### PR TITLE
coq-mathcomp-finmap >= 1.5.1 and coq-mathcomp-real-closed >= 1.1.2 are compatible with Coq 8.15+rc1

### DIFF
--- a/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.dev/opam
@@ -17,8 +17,8 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.11.0"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.dev/opam
@@ -17,11 +17,11 @@ order theory of real closed field, through quantifier elimination."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
-  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
-  "coq-mathcomp-field" { (>= "1.12.0" & < "1.13~") | (= "dev")  }
-  "coq-mathcomp-bigenough" { (>= "1.0.0") | (= "dev")  }
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
+  "coq-mathcomp-algebra" {>= "1.12.0"}
+  "coq-mathcomp-field" {>= "1.12.0"}
+  "coq-mathcomp-bigenough" {>= "1.0.0"}
 ]
 tags: [
   "keyword:real closed field"

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
@@ -17,7 +17,7 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
+  "coq" { (>= "8.10" & < "8.16~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
 ]
 

--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
@@ -17,7 +17,7 @@ order theory of real closed field, through quantifier elimination."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.15~") | (= "dev") }
+  "coq" { (>= "8.10" & < "8.16~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
   "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
   "coq-mathcomp-field" { (>= "1.12.0" & < "1.14~") | (= "dev")  }


### PR DESCRIPTION
I tested those combinations of packages in my OPAM switch. See also:
- math-comp/finmap#92
- math-comp/real-closed#39

cc: @CohenCyril