### PR TITLE
Package coq-menhirlib.20211215

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20211215/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211215/opam
@@ -1,0 +1,35 @@
+
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != version }
+]
+tags: [
+  "date:2021-12-15"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20211215/archive.tar.gz"
+  checksum: [
+    "md5=2cd0a956353298daf528d2a0bb03db72"
+    "sha512=fb98dd0db72fe8aee3b94597b29bd036df9f90509a62641926c06b279ef262617a5b06818ef2cad53fc8bf603170be158b75f2ed7c83822a8b52f78638e9ee68"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20211215`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0