### PR TITLE
Package coq-cfml-basis.20211215

### DIFF
--- a/released/packages/coq-cfml-basis/coq-cfml-basis.20211215/opam
+++ b/released/packages/coq-cfml-basis/coq-cfml-basis.20211215/opam
@@ -1,0 +1,46 @@
+
+opam-version: "2.0"
+maintainer: "arthur.chargueraud@inria.fr"
+
+homepage: "https://gitlab.inria.fr/charguer/cfml2"
+dev-repo: "git+https://gitlab.inria.fr/charguer/cfml2.git"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml2/-/issues"
+license: "MIT"
+
+synopsis: "The CFML Basis library"
+description: """
+This library provides theoretical foundations for the CFML tool.
+"""
+
+build: [
+  [make "-C" "lib/coq" "-j%{jobs}%"]
+]
+
+install: [
+  [make "-C" "lib/coq" "install"]
+]
+
+depends: [
+  "coq"     { >= "8.13" }
+  "coq-tlc" { >= "20211215"}
+]
+
+tags: [
+  "date:"
+  "logpath:CFML"
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "keyword:program verification"
+  "keyword:separation logic"
+  "keyword:weakest precondition"
+]
+authors: [
+  "Arthur Charguéraud"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/charguer/cfml2/-/archive/20211215/archive.tar.gz"
+  checksum: [
+    "md5=a226702bd996bed8f1714e5808cedc67"
+    "sha512=9c39954a25305f1253ef5bc2902ddfc086f211228d0aebe9001783bc273faedc36a1011891f0e9a533bdee7d39e89ceda0ed34b62d9b94921d2451df780f749c"
+  ]
+}


### PR DESCRIPTION
### `coq-cfml-basis.20211215`
The CFML Basis library
This library provides theoretical foundations for the CFML tool.



---
* Homepage: https://gitlab.inria.fr/charguer/cfml2
* Source repo: git+https://gitlab.inria.fr/charguer/cfml2.git
* Bug tracker: https://gitlab.inria.fr/charguer/cfml2/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0