### PR TITLE
build json using opam and findlib (ditch dune and nix)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,26 @@ before_script:
       - log/
     expire_in: 1 week
 
+.opam-json:
+  script: |
+    . scripts/opam-coq-setup-root
+    mkdir -p log; > log/log.json
+    setup_root $OPAM_ROOT_CACHE log/log.json
+    opam install -y opam-core.2.1.0 opam-file-format.2.1.3 ppx_deriving_yojson.3.6.1
+    ocamlfind opt -package opam-file-format,opam-core,ppx_deriving_yojson,str -linkpkg scripts/archive2web.ml -o scripts/archive2web
+    scripts/archive2web released extra-dev > coq-packages.json
+  artifacts:
+    name: "json-data"
+    paths:
+      - coq-packages.json
+    expire_in: 1 year
+
+# Json
+opam-json:4.11.2:
+  extends: .opam-json
+  variables:
+    COMPILER: "4.11.2"
+
 # Lint
 opam-lint:4.13.1:
   extends: .opam-lint
@@ -150,14 +170,14 @@ opam-build-no-timeout:any:
     - no-timeout
 
 # JSON data
-json-data:
-  image: nixos/nix:2.3.12
-  cache: {}
-  before_script: []
-  script:
-    - nix-shell --run "dune exec --profile=release -- archive2web released extra-dev > coq-packages.json"
-  artifacts:
-    name: "$CI_JOB_NAME"
-    paths:
-      - coq-packages.json
-    expire_in: 1 year
+# json-data:
+#   image: nixos/nix:2.3.12
+#   cache: {}
+#   before_script: []
+#   script:
+#     - nix-shell --run "dune exec --profile=release -- archive2web released extra-dev > coq-packages.json"
+#   artifacts:
+#     name: "$CI_JOB_NAME"
+#     paths:
+#       - coq-packages.json
+#     expire_in: 1 year

--- a/scripts/archive2web.ml
+++ b/scripts/archive2web.ml
@@ -119,13 +119,13 @@ let omap o f =
   | Some x -> Some (f x)
   | None -> None
 
-let extract_package_version_data ~suite ~version opam_file =
+let extract_package_version_data ~suite ~version ~package_file opam_file =
   let tags = find_var_str_list "tags" opam_file in
   let date =
     match filtermap (has_prefix "date:") tags with
     | [] -> None
     | [x] -> Some x
-    | x :: _ -> warning "multiple date tag"; Some x in
+    | x :: _ -> warning (Printf.sprintf "multiple date tag in %s" package_file); Some x in
   let homepage = find_var_str "homepage" opam_file in
   let description = find_var_str "description" opam_file in
   let description = match description with
@@ -159,9 +159,9 @@ let extract_package_version_data ~suite ~version opam_file =
 
 let do_one_package_version root pname version =
   let pdir = pname ^ "." ^ version in
-  let package_file s = root / "packages" / pname / pdir / s in
-  let { OpamParserTypes.FullPos.file_contents; _ } = OpamParser.FullPos.file (package_file "opam") in
-  extract_package_version_data ~suite:root ~version (List.map (fun x -> x.pelem) file_contents)
+  let package_file = root / "packages" / pname / pdir / "opam" in
+  let { OpamParserTypes.FullPos.file_contents; _ } = OpamParser.FullPos.file package_file in
+  extract_package_version_data ~suite:root ~version ~package_file (List.map (fun x -> x.pelem) file_contents)
 
 let merge_package_versions p1 p2 =
   { versions = p1.versions @ p2.versions;

--- a/scripts/opam-coq-install-remove
+++ b/scripts/opam-coq-install-remove
@@ -6,6 +6,8 @@
 set -e
 #set -x
 
+. scripts/opam-coq-setup-root
+
 CACHE=$1
 shift
 declare -A SKIP
@@ -14,21 +16,6 @@ while [ $1 != "--" ]; do
 	shift
 done
 shift # for --
-
-function setup_root() {
-  echo .Initializing opam root
-  rm -rf $OPAM_ROOT_DIR
-  tar xzf $CACHE -C /
-  eval $(opam env --root=$OPAM_ROOT_DIR --set-root)
-  opam update default >> $1
-  echo .Add released repo
-  opam repo add released --all-switches file://$PWD/released >> $1
-  opam config list
-  opam switch list
-  opam pin list
-  opam list
-  which ocamlc
-}
 
 RC=0
 FAILURES=
@@ -52,7 +39,7 @@ while [ ! -z "$1" ]; do
         else
           echo Testing $1
           > $LOG
-          setup_root $LOG
+          setup_root $CACHE $LOG
           case "$PKG_VERSION_DIR" in
             *core-dev*)
               echo Add dev repos

--- a/scripts/opam-coq-setup-root
+++ b/scripts/opam-coq-setup-root
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# usage:
+#   setup_root cache-file.tgz logfile.log
+
+function setup_root() {
+  local CACHE="$1"
+  local LOG="$2"
+
+  echo .Initializing opam root
+  rm -rf $OPAM_ROOT_DIR
+  tar xzf $CACHE -C /
+  eval $(opam env --root=$OPAM_ROOT_DIR --set-root)
+  opam update default >> $1
+  echo .Add released repo
+  opam repo add released --all-switches file://$PWD/released >> $LOG
+  opam config list
+  opam switch list
+  opam pin list
+  opam list
+  which ocamlc
+}


### PR DESCRIPTION
Apparently dune does not like itself. We build using findlib and we install specific versions of the dependencies of archive2web using opam.

fix #1995 