### PR TITLE
Bump dependency lower bound in coq-paco.dev

### DIFF
--- a/extra-dev/packages/coq-paco/coq-paco.dev/opam
+++ b/extra-dev/packages/coq-paco/coq-paco.dev/opam
@@ -19,7 +19,7 @@ install: [
 remove: ["rm" "-r" "-f" "%{lib}%/coq/user-contrib/Paco"]
 depends: [
   "ocaml"
-  "coq" {(>= "8.5.dev")}
+  "coq" {(>= "8.11")}
 ]
 synopsis: "Coq library implementing parameterized coinduction"
 tags: [


### PR DESCRIPTION
Synchronizing with the latest release

https://github.com/coq/opam-coq-archive/blob/bee621f7e9b914c22b38aaec11db658a76d914a6/released/packages/coq-paco/coq-paco.4.1.2/opam#L18