### PR TITLE
Package coq-menhirlib.20211223

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20211223/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211223/opam
@@ -1,0 +1,35 @@
+
+opam-version: "2.0"
+synopsis: "A support library for verified Coq parsers produced by Menhir"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "Jacques-Henri Jourdan <jacques-henri.jourdan@lri.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/coq-menhirlib"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
+bug-reports: "https://gitlab.inria.fr/fpottier/menhir/-/issues"
+license: "LGPL-3.0-or-later"
+build: [
+  [make "-C" "coq-menhirlib" "-j%{jobs}%"]
+]
+install: [
+  [make "-C" "coq-menhirlib" "install"]
+]
+depends: [
+  "coq" { >= "8.7" }
+]
+conflicts: [
+  "menhir" { != version }
+]
+tags: [
+  "date:2021-12-23"
+  "logpath:MenhirLib"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/menhir/-/archive/20211223/archive.tar.gz"
+  checksum: [
+    "md5=61dc9623e1e06aa03cba417868c46a92"
+    "sha512=508ed6ff7e969b6616bfa22019ef8a1c15ed56064d203868ab7934f04344a57d05fd7b06a5dbc4cef695072cc685f37e1717a1ce47c0b5d2c0127b5f1a19c37d"
+  ]
+}


### PR DESCRIPTION
### `coq-menhirlib.20211223`
A support library for verified Coq parsers produced by Menhir



---
* Homepage: https://gitlab.inria.fr/fpottier/coq-menhirlib
* Source repo: git+https://gitlab.inria.fr/fpottier/menhir.git
* Bug tracker: https://gitlab.inria.fr/fpottier/menhir/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0