### PR TITLE
coq-paco.4.1.2 does not support Coq 8.11 due to use of export annotation

### DIFF
--- a/released/packages/coq-paco/coq-paco.4.1.2/opam
+++ b/released/packages/coq-paco/coq-paco.4.1.2/opam
@@ -15,7 +15,7 @@ license: "BSD-3-Clause"
 build: [make "-C" "src" "all" "-j%{jobs}%"]
 install: [make "-C" "src" "-f" "Makefile.coq" "install"]
 depends: [
-  "coq" {>= "8.11" & < "8.15~"}
+  "coq" {>= "8.12" & < "8.15~"}
 ]
 tags: [
   "date:2021-12-13"


### PR DESCRIPTION
See example failure: https://coq-bench.github.io/clean/Linux-x86_64-4.11.2-2.0.7/released/8.11.2/paco/4.1.2.html