### PR TITLE
Autosubst supports Coq 8.14 and apparently 8.15(-rc)

### DIFF
--- a/released/packages/coq-autosubst/coq-autosubst.1.7/opam
+++ b/released/packages/coq-autosubst/coq-autosubst.1.7/opam
@@ -19,7 +19,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Just tested by installing Autosubst on both, and porting dot-iris to Coq 8.14/8.15 with Autosubst 1.7.

I'll note that on 8.15, the `cbn` tactic (that Autosubst relies on) appears to have changed behavior somewhat, but the Autosubst tactics themselves still appear to work correctly at first sight. This might warrant further investigation, but I'm not sure it's a reason to to delay the bump.