### PR TITLE
Make Hierarchy-builder compilable with Coq 8.15

### DIFF
--- a/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.2.0/opam
+++ b/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.2.0/opam
@@ -7,10 +7,9 @@ bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
 dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
 
 build: [ [ make "build"]
-         [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" { (>= "1.11.0" & < "1.12~") | = "dev" } ]
+depends: [ "coq-elpi" { (>= "1.11.0" & < "1.13~") | = "dev" } ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """


### PR DESCRIPTION
Coq-elpi 1.12.0 was released recently, is compatible with Coq 8.15 and
HB 1.2.0 seems to compile fine with it, so bumping the constraint on
coq-elpi.