### PR TITLE
3 packages from gitlab.inria.fr/charguer/cfml2/-/archive/20220112/archive.tar.gz

### DIFF
--- a/released/packages/coq-cfml-basis/coq-cfml-basis.20220112/opam
+++ b/released/packages/coq-cfml-basis/coq-cfml-basis.20220112/opam
@@ -1,0 +1,46 @@
+
+opam-version: "2.0"
+maintainer: "arthur.chargueraud@inria.fr"
+
+homepage: "https://gitlab.inria.fr/charguer/cfml2"
+dev-repo: "git+https://gitlab.inria.fr/charguer/cfml2.git"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml2/-/issues"
+license: "CC-BY-4.0"
+
+synopsis: "The CFML Basis library"
+description: """
+This library provides theoretical foundations for the CFML tool.
+"""
+
+build: [
+  [make "-C" "lib/coq" "-j%{jobs}%"]
+]
+
+install: [
+  [make "-C" "lib/coq" "install"]
+]
+
+depends: [
+  "coq"     { >= "8.13" }
+  "coq-tlc" { >= "20211215"}
+]
+
+tags: [
+  "date:"
+  "logpath:CFML"
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "keyword:program verification"
+  "keyword:separation logic"
+  "keyword:weakest precondition"
+]
+authors: [
+  "Arthur Charguéraud"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/charguer/cfml2/-/archive/20220112/archive.tar.gz"
+  checksum: [
+    "md5=4bd2f2c9e59a5ba2894aed81c766ef09"
+    "sha512=08778c62243ffe8646377d8e00a7bae3e5a4ee52e6e37410a1e86f39a869f9e07c486df18ae50ba334898e6946355dbb9064aebbfaa89f536ce2672cbe93ae25"
+  ]
+}

--- a/released/packages/coq-cfml-stdlib/coq-cfml-stdlib.20220112/opam
+++ b/released/packages/coq-cfml-stdlib/coq-cfml-stdlib.20220112/opam
@@ -1,0 +1,41 @@
+
+opam-version: "2.0"
+maintainer: "arthur.chargueraud@inria.fr"
+
+homepage: "https://gitlab.inria.fr/charguer/cfml2"
+dev-repo: "git+https://gitlab.inria.fr/charguer/cfml2.git"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml2/-/issues"
+license: "CC-BY-4.0"
+
+synopsis: "The CFML standard library"
+description: """
+CFML is a program verification system for OCaml.
+"""
+
+build: [make "-C" "lib/stdlib" "-j%{jobs}%"]
+install: [make "-C" "lib/stdlib" "install"]
+depends: [
+  "coq" { >= "8.13" }
+  "cfml" { = version }
+  "coq-cfml-basis" { = version }
+]
+
+tags: [
+  "date:"
+  "logpath:CFML.Stdlib"
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "keyword:program verification"
+  "keyword:separation logic"
+  "keyword:weakest precondition"
+]
+authors: [
+  "Arthur Charguéraud"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/charguer/cfml2/-/archive/20220112/archive.tar.gz"
+  checksum: [
+    "md5=4bd2f2c9e59a5ba2894aed81c766ef09"
+    "sha512=08778c62243ffe8646377d8e00a7bae3e5a4ee52e6e37410a1e86f39a869f9e07c486df18ae50ba334898e6946355dbb9064aebbfaa89f536ce2672cbe93ae25"
+  ]
+}

--- a/released/packages/coq-cfml/coq-cfml.20220112/opam
+++ b/released/packages/coq-cfml/coq-cfml.20220112/opam
@@ -1,0 +1,40 @@
+
+opam-version: "2.0"
+maintainer: "arthur.chargueraud@inria.fr"
+
+homepage: "https://gitlab.inria.fr/charguer/cfml2"
+dev-repo: "git+https://gitlab.inria.fr/charguer/cfml2.git"
+bug-reports: "https://gitlab.inria.fr/charguer/cfml2/-/issues"
+license: "CC-BY-4.0"
+
+synopsis: "The CFML program verification system"
+description: """
+CFML is a program verification system for OCaml.
+This is a meta-package that installs CFML and its Coq libraries.
+"""
+
+depends: [
+  "cfml" { = version }
+  "coq-cfml-basis" { = version }
+  "coq-cfml-stdlib" { = version }
+]
+
+tags: [
+  "date:"
+  "logpath:CFML"
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "keyword:program verification"
+  "keyword:separation logic"
+  "keyword:weakest precondition"
+]
+authors: [
+  "Arthur Charguéraud"
+]
+url {
+  src:
+    "https://gitlab.inria.fr/charguer/cfml2/-/archive/20220112/archive.tar.gz"
+  checksum: [
+    "md5=4bd2f2c9e59a5ba2894aed81c766ef09"
+    "sha512=08778c62243ffe8646377d8e00a7bae3e5a4ee52e6e37410a1e86f39a869f9e07c486df18ae50ba334898e6946355dbb9064aebbfaa89f536ce2672cbe93ae25"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`coq-cfml.20220112`: The CFML program verification system
-`coq-cfml-basis.20220112`: The CFML Basis library
-`coq-cfml-stdlib.20220112`: The CFML standard library



---
* Homepage: https://gitlab.inria.fr/charguer/cfml2
* Source repo: git+https://gitlab.inria.fr/charguer/cfml2.git
* Bug tracker: https://gitlab.inria.fr/charguer/cfml2/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0