### PR TITLE
Move coq-elpi.1.12.0 from extra-dev to released to support Coq 8.15.0

### DIFF
--- a/released/packages/coq-elpi/coq-elpi.1.12.0/opam
+++ b/released/packages/coq-elpi/coq-elpi.1.12.0/opam
@@ -1,6 +1,4 @@
 opam-version: "2.0"
-name: "coq-elpi"
-version: "dev"
 maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
 authors: [ "Enrico Tassi" ]
 license: "LGPL-2.1-or-later"


### PR DESCRIPTION
Hierarchy builder was updated in #2020, but this dependency was forgotten.

Also drop `dev` version number, and redundant name.