### PR TITLE
core-dev/coq packages: add conflict against nnp to 8.15* and dev

### DIFF
--- a/core-dev/packages/coq/coq.8.15+rc1/opam
+++ b/core-dev/packages/coq/coq.8.15+rc1/opam
@@ -27,6 +27,10 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
 build: [
   [
     "./configure"

--- a/core-dev/packages/coq/coq.8.15.dev/opam
+++ b/core-dev/packages/coq/coq.8.15.dev/opam
@@ -27,6 +27,10 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
 build: [
   [
     "./configure"

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -27,6 +27,10 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
 build: [
   [
     "./configure"


### PR DESCRIPTION
Backported from opam-repository.