### PR TITLE
Flocq 3.4.3

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.3.4.1/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.4.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {(>= "8.7" & < "8.11~") | >= "8.12"}
+  "coq" {(>= "8.7" & < "8.11~") | (>= "8.12" & < "8.15~")}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-flocq/coq-flocq.3.4.3/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.4.3/opam
@@ -11,14 +11,14 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.7" & < "8.15~"}
+  "coq" {>= "8.7"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]
 tags: [
   "keyword:floating-point arithmetic"
   "logpath:Flocq"
-  "date:2021-06-18"
+  "date:2022-01-17"
 ]
 authors: [
   "Sylvie Boldo <sylvie.boldo@inria.fr>"
@@ -26,6 +26,6 @@ authors: [
 ]
 synopsis: "A formalization of floating-point arithmetic for the Coq system"
 url {
-  src: "https://flocq.gitlabpages.inria.fr/releases/flocq-3.4.2.tar.gz"
-  checksum: "sha512=eceeebbeb3d42a6e1d279839e6d98ec453ea4ce60b55e3310e5ca44ff10ad992435fbde2c321c884ad4aa3d075a08c84c1b1a49e5160f6789a4b74f21bfcff12"
+  src: "https://flocq.gitlabpages.inria.fr/releases/flocq-3.4.3.tar.gz"
+  checksum: "sha512=10f407e91e0d601b502b2c89104a8753dfcc3d9572f0fd9d007c7692d3d6c96fd5652fb103bcf2396a64236947734ee725c01f4ba2901565f9da38667f538d5a"
 }


### PR DESCRIPTION
This pull request also puts some upper bound on previous releases.

ci-skip: coq-flocq.3.4.1 coq-flocq.3.4.2