### PR TITLE
Add packages for CompCert 3.10 and VST 2.9

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.10/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.10/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+available: os != "macos"
+build: [
+  ["./configure"
+  "ia32-linux" {os = "linux"}
+  "ia32-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "ia32-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 32 bit CompCert on 64 bit MinGW with cygwin build host
+  "-toolprefix"     {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  "i686-pc-cygwin-" {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  # The 32 bit CompCert is a variant which is installed in a non standard folder
+  "-prefix" "%{prefix}%/variants/compcert32"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert32/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.16~"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "3.1.0" & < "4~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (32 bit)"
+description: "This package installs the 32 bit version of CompCert.
+For coexistence with the 64 bit version, the files are installed in:
+%{prefix}%/variants/compcert32/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert32/lib/compcert  (C library)
+%{lib}%/coq-variant/compcert32/compcert (Coq library)
+Please note that the coq module path is compcert and not compcert32,
+so the files cannot be directly Required as compcert32.
+Instead -Q or -R options must be used to bind the compcert32 folder
+to the module path compcert. This is more convenient if one development
+supports both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert32.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert32"
+  "date:2021-11-19"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.10.tar.gz"
+  checksum: "sha512=93687fb36cdfb247d47404c8d41d84ba96d006dd3a535646337a477fd5517c7487ff1d66e83bccceb47ba2d18b187c1bbdc55b2eff00373a8a120edfc80ef11a"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.10/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.10/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Jacques-Henri Jourdan <jacques-Henri.jourdan@normalesup.org>"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure"
+  "amd64-linux" {os = "linux"}
+  "amd64-macosx" {os = "macos"}
+  "amd64-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 64 bit CompCert on 32 bit MinGW with cygwin build host
+  "-toolprefix"        {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "x86_64-pc-cygwin-"  {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "-prefix" "%{prefix}%"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.16~"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "3.1.0" & < "4~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (64 bit)"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2021-11-19"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.10.tar.gz"
+  checksum: "sha512=93687fb36cdfb247d47404c8d41d84ba96d006dd3a535646337a477fd5517c7487ff1d66e83bccceb47ba2d18b187c1bbdc55b2eff00373a8a120edfc80ef11a"
+}

--- a/released/packages/coq-vst-32/coq-vst-32.2.9/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "Sandrine Blazy"
+  "Qinxiang Cao"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Josiah Dodds"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Aquinas Hobor"
+  "Jean-Marie Madiot"
+  "William Mansky"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+build: [
+  [make "-j%{jobs}%" "IGNORECOQVERSION=true" "BITSIZE=32"]
+]
+install: [
+  [make "install" "IGNORECOQVERSION=true" "BITSIZE=32"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12" & < "8.16~"}
+  "coq-compcert-32" {= "3.10"}
+  "coq-flocq" {>= "3.2.1"}
+]
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2021-06-01"
+]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/archive/refs/tags/v2.9.tar.gz"
+  checksum: "sha512=497f4c702b1a52cb1a23a71aee31c68a78e75d5cab2d41da58f2426ca78b43171fab808105b2dde57bdca98a41bcd2953065819e5a2f8e5183635ba709a6a536"
+}

--- a/released/packages/coq-vst/coq-vst.2.9/opam
+++ b/released/packages/coq-vst/coq-vst.2.9/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "Sandrine Blazy"
+  "Qinxiang Cao"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Josiah Dodds"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Aquinas Hobor"
+  "Jean-Marie Madiot"
+  "William Mansky"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+build: [
+  [make "-j%{jobs}%" "IGNORECOQVERSION=true" "BITSIZE=64"]
+]
+install: [
+  [make "install" "IGNORECOQVERSION=true" "BITSIZE=64"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.12" & < "8.16~"}
+  "coq-compcert" {= "3.10"}
+  "coq-flocq" {>= "3.2.1"}
+]
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2021-06-01"
+]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/archive/refs/tags/v2.9.tar.gz"
+  checksum: "sha512=497f4c702b1a52cb1a23a71aee31c68a78e75d5cab2d41da58f2426ca78b43171fab808105b2dde57bdca98a41bcd2953065819e5a2f8e5183635ba709a6a536"
+}


### PR DESCRIPTION
This PR adds opam packages for
- CompCert 3.10
- VST 2.9

This has been agreed on with the authors / maintainers.

FYI: @xavierleroy @andrew-appel

CC: https://github.com/AbsInt/CompCert/issues/426
CC: https://github.com/PrincetonUniversity/VST/issues/539
CC: https://github.com/coq/platform/issues/193