### PR TITLE
Bump MathComp to 1.14.0

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.1.0/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "coq-bignums"
   "coq-paramcoq" {>= "1.1.3"}
   "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
-  "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.14~") | = "dev")}
+  "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.15~") | = "dev")}
   "coq-mathcomp-real-closed" {(>= "1.1.2" & < "1.2~") | (= "dev")}
 ]
 

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.2.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.2.0/opam
@@ -20,7 +20,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.13" & < "8.16~")}
-  "coq-mathcomp-algebra" {(>= "1.12" & < "1.14~")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.15~")}
   "coq-mathcomp-zify" {(>= "1.1.0")}
   "coq-elpi" {(>= "1.10.1")}
 ]

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam
@@ -18,7 +18,7 @@ build: [make "-j%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:inst
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.16~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.15~") | (= "dev") }
 ]
 
 tags: [

--- a/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.5/opam
+++ b/released/packages/coq-mathcomp-multinomials/coq-mathcomp-multinomials.1.5.5/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "coq"                    {(>= "8.10" & < "8.16~") | = "dev"}
   "dune"                   {>= "2.8"}
-  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.14~") | = "dev"}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.15~") | = "dev"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}
   "coq-mathcomp-finmap"    {(>= "1.5" & < "1.6~") | = "dev"}

--- a/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
+++ b/released/packages/coq-mathcomp-real-closed/coq-mathcomp-real-closed.1.1.2/opam
@@ -18,9 +18,9 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.16~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
-  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
-  "coq-mathcomp-field" { (>= "1.12.0" & < "1.14~") | (= "dev")  }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.15~") | (= "dev")  }
+  "coq-mathcomp-algebra" { (>= "1.12.0" & < "1.15~") | (= "dev")  }
+  "coq-mathcomp-field" { (>= "1.12.0" & < "1.15~") | (= "dev")  }
   "coq-mathcomp-bigenough" {>= "1.0.0"}
 ]
 

--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.2.0+1.12+8.13/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.2.0+1.12+8.13/opam
@@ -16,7 +16,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.13" & < "8.16~")}
-  "coq-mathcomp-algebra" {(>= "1.12" & < "1.14~")}
+  "coq-mathcomp-algebra" {(>= "1.12" & < "1.15~")}
 ]
 
 tags: [


### PR DESCRIPTION
The following packages are compatible with MathComp 1.14.0
- coq-coqeal.1.1.0
- coq-mathcomp-algebra-tactics.0.2.0
- coq-mathcomp-finmap.1.5.1
- coq-mathcomp-multinomials.1.5.5
- coq-mathcomp-real-closed.1.1.2
- coq-mathcomp-zify.1.2.0+1.12+8.13
