### PR TITLE
coq-menhirlib's Makefile is incompatible with coq-native

### DIFF
--- a/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190613/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20190613" }
+  "coq-native"
 ]
 tags: [
   "date:2019-06-13"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190620/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20190620" }
+  "coq-native"
 ]
 tags: [
   "date:2019-06-20"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20190626/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190626/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20190626" }
+  "coq-native"
 ]
 tags: [
   "date:2019-06-26"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20190924/opam
@@ -24,6 +24,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20190924" }
+  "coq-native"
 ]
 tags: [
   "date:2019-09-24"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200123/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200123/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200123" }
+  "coq-native"
 ]
 tags: [
   "date:2020-01-23"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200211/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200211/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200211" }
+  "coq-native"
 ]
 tags: [
   "date:2020-02-11"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200525/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200525/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200525" }
+  "coq-native"
 ]
 tags: [
   "date:2020-05-25"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200612/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200612/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200612" }
+  "coq-native"
 ]
 tags: [
   "date:2020-06-12"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200619/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200619/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200619" }
+  "coq-native"
 ]
 tags: [
   "date:2020-06-19"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20200624/opam
@@ -25,6 +25,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20200624" }
+  "coq-native"
 ]
 tags: [
   "date:2020-06-24"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20201122/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201122/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20201122" }
+  "coq-native"
 ]
 tags: [
   "date:2020-11-22"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20201201/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201201/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20201201" }
+  "coq-native"
 ]
 tags: [
   "date:2020-12-01"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20201214/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201214/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20201214" }
+  "coq-native"
 ]
 tags: [
   "date:2020-12-14"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20201216/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20201216/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20201216" }
+  "coq-native"
 ]
 tags: [
   "date:2020-12-16"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210310/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20210310" }
+  "coq-native"
 ]
 tags: [
   "date:2021-03-10"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210419/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210419/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20210419" }
+  "coq-native"
 ]
 tags: [
   "date:2021-04-19"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210928/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210928/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20210928" }
+  "coq-native"
 ]
 tags: [
   "date:2021-09-28"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20210929/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20210929/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20210929" }
+  "coq-native"
 ]
 tags: [
   "date:2021-09-29"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20211012/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211012/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20211012" }
+  "coq-native"
 ]
 tags: [
   "date:2021-10-12"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20211125/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211125/opam
@@ -19,6 +19,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20211125" }
+  "coq-native"
 ]
 tags: [
   "date:2021-11-25"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20211128/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211128/opam
@@ -20,6 +20,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != "20211128" }
+  "coq-native"
 ]
 tags: [
   "date:2021-11-28"

--- a/released/packages/coq-menhirlib/coq-menhirlib.20211230/opam
+++ b/released/packages/coq-menhirlib/coq-menhirlib.20211230/opam
@@ -20,6 +20,7 @@ depends: [
 ]
 conflicts: [
   "menhir" { != version }
+  "coq-native"
 ]
 tags: [
   "date:2021-12-30"


### PR DESCRIPTION
As suggested by @melquiond on https://gitlab.inria.fr/fpottier/menhir/-/issues/60,  coq-menhirlib's Makefile is incompatible with coq-native (fix coming in the next release).