### PR TITLE
Release Iris 3.6.0 and std++ 1.7.0

### DIFF
--- a/released/packages/coq-iris-heap-lang/coq-iris-heap-lang.3.6.0/opam
+++ b/released/packages/coq-iris-heap-lang/coq-iris-heap-lang.3.6.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Ralf Jung <jung@mpi-sws.org>"
+authors: "The Iris Team"
+license: "BSD-3-Clause"
+homepage: "https://iris-project.org/"
+bug-reports: "https://gitlab.mpi-sws.org/iris/iris/issues"
+dev-repo: "git+https://gitlab.mpi-sws.org/iris/iris.git"
+
+synopsis: "The canonical example language for Iris"
+description: """
+This package defines HeapLang, a concurrent lambda calculus with references, and
+uses Iris to build a program logic for HeapLang programs.
+"""
+tags: [
+  "date:2022-01-22"
+  "logpath:iris.heap_lang"
+]
+
+depends: [
+  "coq-iris" {= version}
+]
+
+build: ["./make-package" "iris_heap_lang" "-j%{jobs}%"]
+install: ["./make-package" "iris_heap_lang" "install"]
+
+url {
+  src:
+    "https://gitlab.mpi-sws.org/iris/iris/-/archive/iris-3.6.0.tar.gz"
+  checksum:
+    "sha512=6b9871a299e0e97d4cc3466e3b1c11c07af4ae2c5249f64ecdbd88d813e6382cb56bb6f041e52b5dc1a0c5f6f2f5995b1f7b5f1cdcc7be3336fccaf8fb046503"
+}

--- a/released/packages/coq-iris/coq-iris.3.6.0/opam
+++ b/released/packages/coq-iris/coq-iris.3.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Ralf Jung <jung@mpi-sws.org>"
+authors: "The Iris Team"
+license: "BSD-3-Clause"
+homepage: "https://iris-project.org/"
+bug-reports: "https://gitlab.mpi-sws.org/iris/iris/issues"
+dev-repo: "git+https://gitlab.mpi-sws.org/iris/iris.git"
+
+synopsis: "A Higher-Order Concurrent Separation Logic Framework with support for interactive proofs"
+description: """
+Iris is a framework for reasoning about the safety of concurrent programs using
+concurrent separation logic. It can be used to develop a program logic, for
+defining logical relations, and for reasoning about type systems, among other
+applications. This package includes the base logic, Iris Proof Mode (IPM) /
+MoSeL, and a general language-independent program logic; see coq-iris-heap-lang
+for an instantiation of the program logic to a particular programming language.
+"""
+tags: [
+  "date:2022-01-22"
+  "logpath:iris.prelude"
+  "logpath:iris.algebra"
+  "logpath:iris.si_logic"
+  "logpath:iris.bi"
+  "logpath:iris.proofmode"
+  "logpath:iris.base_logic"
+  "logpath:iris.program_logic"
+]
+
+depends: [
+  "coq" { (>= "8.13" & < "8.16~") | (= "dev") }
+  "coq-stdpp" { (= "1.7.0") | (= "dev") }
+]
+
+build: ["./make-package" "iris" "-j%{jobs}%"]
+install: ["./make-package" "iris" "install"]
+
+url {
+  src:
+    "https://gitlab.mpi-sws.org/iris/iris/-/archive/iris-3.6.0.tar.gz"
+  checksum:
+    "sha512=6b9871a299e0e97d4cc3466e3b1c11c07af4ae2c5249f64ecdbd88d813e6382cb56bb6f041e52b5dc1a0c5f6f2f5995b1f7b5f1cdcc7be3336fccaf8fb046503"
+}

--- a/released/packages/coq-stdpp/coq-stdpp.1.7.0/opam
+++ b/released/packages/coq-stdpp/coq-stdpp.1.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Ralf Jung <jung@mpi-sws.org>"
+authors: "The std++ team"
+license: "BSD-3-Clause"
+homepage: "https://gitlab.mpi-sws.org/iris/stdpp"
+bug-reports: "https://gitlab.mpi-sws.org/iris/stdpp/issues"
+dev-repo: "git+https://gitlab.mpi-sws.org/iris/stdpp.git"
+
+synopsis: "An extended \"Standard Library\" for Coq"
+description: """
+The key features of this library are as follows:
+
+- It provides a great number of definitions and lemmas for common data
+  structures such as lists, finite maps, finite sets, and finite multisets.
+- It uses type classes for common notations (like `∅`, `∪`, and Haskell-style
+  monad notations) so that these can be overloaded for different data structures.
+- It uses type classes to keep track of common properties of types, like it
+  having decidable equality or being countable or finite.
+- Most data structures are represented in canonical ways so that Leibniz
+  equality can be used as much as possible (for example, for maps we have
+  `m1 = m2` iff `∀ i, m1 !! i = m2 !! i`). On top of that, the library provides
+  setoid instances for most types and operations.
+- It provides various tactics for common tasks, like an ssreflect inspired
+  `done` tactic for finishing trivial goals, a simple breadth-first solver
+  `naive_solver`, an equality simplifier `simplify_eq`, a solver `solve_proper`
+  for proving compatibility of functions with respect to relations, and a solver
+  `set_solver` for goals involving set operations.
+- It is entirely dependency- and axiom-free.
+"""
+tags: [
+  "date:2022-01-22"
+  "logpath:stdpp"
+]
+
+depends: [
+  "coq" { (>= "8.11" & < "8.16~") | (= "dev") }
+]
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+
+url {
+  src:
+    "https://gitlab.mpi-sws.org/iris/stdpp/-/archive/coq-stdpp-1.7.0.tar.gz"
+  checksum:
+    "sha512=c47b049f0bc9dc0132352901098458c9a50259e91f9d39dec2cbdce74d602f3a5224dd41af228152513dea3895052eab673fc094ff4092f65a006c4bbe124694"
+}


### PR DESCRIPTION
This release is compatible with Coq 8.15, for support in the upcoming Coq platform. This PR fixes https://gitlab.mpi-sws.org/iris/iris/-/issues/443 and https://gitlab.mpi-sws.org/iris/stdpp/-/issues/129.