### PR TITLE
Add coq-category-theory.dev to extra-dev

### DIFF
--- a/extra-dev/packages/coq-category-theory/coq-category-theory.dev/opam
+++ b/extra-dev/packages/coq-category-theory/coq-category-theory.dev/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "johnw@newartisans.com"
+
+homepage: "https://github.com/jwiegley/category-theory"
+dev-repo: "git+https://github.com/jwiegley/category-theory.git"
+bug-reports: "https://github.com/jwiegley/category-theory/issues"
+license: "BSD-3-Clause"
+
+synopsis: "An axiom-free formalization of category theory in Coq"
+description: """
+An axiom-free formalization of category theory in Coq for personal study and
+practical work.
+"""
+
+build: [make "JOBS=%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.10"}
+  # "coq-equations" {(>= "1.2" & < "1.3~") | (= "dev")}
+]
+
+tags: [
+  "logpath:Category"
+]
+authors: [
+  "John Wiegley"
+]
+url {
+  src: "git+https://github.com/jwiegley/category-theory.git#master"
+}


### PR DESCRIPTION
The opam file is mostly copied from https://github.com/jwiegley/category-theory, with some changes such as the addition of an `url` field. The reason for adding the package to the coq opam archive is that it would be beneficial to track the development in Coq's benchmarking suite and the Coq maintainers have requested an opam package to that end. (See https://github.com/coq/coq/pull/15543)