### PR TITLE
coq-hierarchy-builder: adjust .dev package to latest release package

### DIFF
--- a/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
+++ b/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
@@ -10,7 +10,7 @@ build: [ [ make "build"]
          [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" { (>= "1.11.0" & < "1.13~") | = "dev" } ]
+depends: [ "coq-elpi" {>= "1.11.0"} ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """

--- a/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
+++ b/extra-dev/packages/coq-hierarchy-builder/coq-hierarchy-builder.dev/opam
@@ -6,13 +6,20 @@ homepage: "https://github.com/math-comp/hierarchy-builder"
 bug-reports: "https://github.com/math-comp/hierarchy-builder/issues"
 dev-repo: "git+https://github.com/math-comp/hierarchy-builder"
 
-build: [ make "build"]
-install: [ make "install"]
-depends: [ "coq-elpi" {= "dev"} ]
-synopsis: "Hierarchy Builder"
+build: [ [ make "build"]
+         [ make "test-suite" ] {with-test}
+       ]
+install: [ make "install" ]
+depends: [ "coq-elpi" { (>= "1.11.0" & < "1.13~") | = "dev" } ]
+conflicts: [ "coq-hierarchy-builder-shim" ]
+synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """
-High level commands to declare and evolve a hierarchy based on packed classes.
+Hierarchy Builder is a high level language to build hierarchies of algebraic structures and make these
+hierarchies evolve without breaking user code. The key concepts are the ones of factory, builder
+and abbreviation that let the hierarchy developer describe an actual interface for their library.
+Behind that interface the developer can provide appropriate code to ensure retro compatibility.
 """
+tags: [ "logpath:HB" ]
 url {
   src: "git+https://github.com/math-comp/hierarchy-builder.git#coq-master"
 }


### PR DESCRIPTION
This PR does mostly editorial changes to the coq-hierarchy-builder .dev package. It minimizes the differences between the latest release and the dev package.