### PR TITLE
Fix Coq version for coq-io-system.2.1.0

### DIFF
--- a/released/packages/coq-io-system/coq-io-system.2.1.0/opam
+++ b/released/packages/coq-io-system/coq-io-system.2.1.0/opam
@@ -14,7 +14,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.4pl4"}
+  "coq" {>= "8.4pl4" & < "8.15~"}
   "coq-function-ninjas"
   "coq-list-string" {>= "2.0.0"}
   "coq-io" {>= "2.1.0" & < "3.0.0"}


### PR DESCRIPTION
Error on https://coq-bench.github.io/clean/Linux-x86_64-4.09.1-2.0.6/released/8.15.0/io-system/2.1.0.html