### PR TITLE
Release coq-mathcomp-algebra-tactics.0.3.0

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.3.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "sakaguchi@coins.tsukuba.ac.jp"
+
+homepage: "https://github.com/math-comp/algebra-tactics"
+dev-repo: "git+https://github.com/math-comp/algebra-tactics.git"
+bug-reports: "https://github.com/math-comp/algebra-tactics/issues"
+license: "CECILL-B"
+
+synopsis: "Ring and field tactics for Mathematical Components"
+description: """
+This library provides `ring` and `field` tactics for Mathematical Components,
+that work with any `comRingType` and `fieldType` instances, respectively.
+Their instance resolution is done through canonical structure inference.
+Therefore, they work with abstract rings and do not require `Add Ring` and
+`Add Field` commands. Another key feature of this library is that they
+automatically push down ring morphisms and additive functions to leaves of
+ring/field expressions before normalization to the Horner form."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.13" & < "8.16~")}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.15~")}
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-zify" {(>= "1.1.0")}
+  "coq-elpi" {(>= "1.10.1")}
+]
+
+tags: [
+  "logpath:mathcomp.algebra_tactics"
+]
+authors: [
+  "Kazuhiko Sakaguchi"
+]
+url {
+  src: "https://github.com/math-comp/algebra-tactics/archive/refs/tags/0.3.0.tar.gz"
+  checksum: "sha256=5539bedd4ec15bdccfd52412c618d63b7e69447189bf23289f5169d9e23a8dcc"
+}


### PR DESCRIPTION
This release should be compatible with [Coq-Elpi 1.13](https://github.com/LPCIC/coq-elpi/pull/339), which has not been released yet. It is probably better to re-run CI jobs after the release of Coq-Elpi.