### PR TITLE
Added coq-fiat-crypto-with-bedrock

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "BINDIR=%{bin}%" "install-standalone-ocaml"]
+install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "BINDIR=%{bin}%" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
@@ -21,7 +21,6 @@ depends: [
   "coq" {>= "8.9~"}
   "coq-coqprime"
   "coq-rewriter"
-  "coq-bedrock2"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -21,6 +21,7 @@ depends: [
   "coq" {>= "8.9~"}
   "coq-coqprime"
   "coq-rewriter"
+  "coq-bedrock2"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "standalone-ocaml"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
+depends: [
+  "ocaml" {build}
+  "ocamlfind" {build}
+  "conf-jq" {build}
+  "coq" {>= "8.9~"}
+  "coq-coqprime"
+  "coq-rewriter"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis: "Cryptographic Primitive Code Generation by Fiat."
+tags: ["logpath:Crypto"]
+url {
+  src: "git+https://github.com/mit-plv/fiat-crypto.git#master"
+}

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -13,7 +13,7 @@ license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
   [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
+install: [make "EXTERNAL_DEPENDENCIES=1" "BINDIR=%{bin}%" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
This is a version of fiat-crypto that also builds the files using bedrock.

Might need fixing, let's see how far it gets.