### PR TITLE
Fix Coq Hammer 1.3.2-coq8.13 link

### DIFF
--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.13/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.13/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.13.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.13.tar.gz"
   checksum: "sha512=977d343cefbd2d75c180614efe19026fc68d1b8ac35cb0a07267279823e14c9c0632cf2554ff038d73b263fb005b7d0936d9e6d0a601bb19904e92b4ae624d50"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.13/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.13/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.13.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.13.tar.gz"
   checksum: "sha512=977d343cefbd2d75c180614efe19026fc68d1b8ac35cb0a07267279823e14c9c0632cf2554ff038d73b263fb005b7d0936d9e6d0a601bb19904e92b4ae624d50"
 }


### PR DESCRIPTION
I do not know why but the previous link got broken (maybe a bug on the Github side?). For the record, here is the error with the previous link:
```
the given path has multiple possibilities: #<Git::Ref:0x00007fc35f0930b0>, #<Git::Ref:0x00007fc35f091d50>
```