### PR TITLE
Fix changed tar ball hashes for current coq-hammer packages

### DIFF
--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.12/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.12/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.12.tar.gz"
   checksum: "sha512=10f7bbf5b03101fda47953fc53981b46b5f368558ce4efa8944b0fa67f220c94f4dd21068a1bcaf0ceb771ba9e94c8c6558c8863720157e27407133c43bf0282"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.14/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.14/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.14.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.14.tar.gz"
   checksum: "sha512=68c6e6a2054ce9dd3d87cb61e667f638e7b9fb2b5ec9571427d9fac59d0901cbfa4e57c59edb3a8bc52c2626985fca6edbac42caf2acdc5858fb6e13f15afcea"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.15/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.15/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.15.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.15.tar.gz"
   checksum: "sha512=0277150c2fd570400693ee1a3e4b2f253fbf7cc4b9997a803bb5e0e3e633352eb8cca2f3e8b1c47e49b9994b73c6f744f31e9e81eac665d1bf7ed4054ef39512"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.12/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.12/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.12.tar.gz"
   checksum: "sha512=10f7bbf5b03101fda47953fc53981b46b5f368558ce4efa8944b0fa67f220c94f4dd21068a1bcaf0ceb771ba9e94c8c6558c8863720157e27407133c43bf0282"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.14/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.14/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.14.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.14.tar.gz"
   checksum: "sha512=68c6e6a2054ce9dd3d87cb61e667f638e7b9fb2b5ec9571427d9fac59d0901cbfa4e57c59edb3a8bc52c2626985fca6edbac42caf2acdc5858fb6e13f15afcea"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.15/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.15/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.15.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.15.tar.gz"
   checksum: "sha512=0277150c2fd570400693ee1a3e4b2f253fbf7cc4b9997a803bb5e0e3e633352eb8cca2f3e8b1c47e49b9994b73c6f744f31e9e81eac665d1bf7ed4054ef39512"
 }


### PR DESCRIPTION
This PR fixes the tar ball hashes for coq-hammer.

@palmskog : this breaks all build of Coq Platform