### PR TITLE
Fix tarball URLs for remaining coq-hammer packages

### DIFF
--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.10/opam
@@ -43,6 +43,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1.1-coq8.10.tar.gz"
   checksum: "sha512=c9fd9c1a997775f515850fad54edceac6572d365f1e7cc043e448d6e5c9903ccb1bea2020fbbfda3983616f9ae4181a384b933f97731a487ee5cfba7cc1543d1"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.9/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.1.1+8.9/opam
@@ -40,6 +40,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1.1-coq8.9.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1.1-coq8.9.tar.gz"
   checksum: "sha256=4f167c5fa8cc8a26c81a0efb6f7c360acf4f15151d3d53f8d0c8ab654c8dd814"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2+8.10/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2-coq8.10.tar.gz"
   checksum: "sha512=74b1a014f4e1e62148e25d46a4b2c376b927a3481ef52ce853d43f526164bbffd0bf2184653ba13e638d9321635ceec85e7c7b34e08dfa362c5e7a9588dc4b96"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2+8.11/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2+8.11/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2-coq8.11.tar.gz"
   checksum: "sha512=f533eeb42fcad00447c174839dbc1c7882e14167e87275121c9a0ccc7dba7f25da4589caf53e26d816e8e06cc3de2d91b0a2ef9133b6371a8318ac037c4a0792"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2.1+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2.1+8.10/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2.1-coq8.10.tar.gz"
   checksum: "sha512=22081122b39ee1099e79ef82f1afc1895350475fd255cdc51d3a47851184decd0bff7975b9effcd39ca9b55bb381e06cf649ad2d460dd31eec537eca44f2a6e1"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2.1+8.11/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.2.1+8.11/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2.1-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2.1-coq8.11.tar.gz"
   checksum: "sha512=7ef5f5e68cc2645ef093dc63d1531cc9696afeabdd540b24c6955fa994417b85925c15856e56cfb41eea9424278cf3ee2fd899f9c84f04d8f8630165b188b666"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.10/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.10.tar.gz"
   checksum: "sha512=b0b725a1a8d4a470f49d72be8b156a7ecf9f2694c1228483d6eebfcef89c262128e5694010c54039449b4fe6b4b36f1184deb45cc0b7dc109aaa8dfef2f293fc"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.11/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.11/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.11.tar.gz"
   checksum: "sha512=f50e39145b772c38cc19b1be7d1d66bd3b1bee6cb685ea897165eaa89fa0b5a746e4ec97a774429ccf2cf9bd10d272331d1b4e2a4b9247080df4ef7fb9600a1d"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.12/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3+8.12/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.12.tar.gz"
   checksum: "sha512=666ea825c122319e398efb7287f429ebfb5d35611b4cabe4b88732ffb5c265ef348b53d5046c958831ac0b7a759b44ce1ca04220ca68b1915accfd23435b479c"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.10/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.10.tar.gz"
   checksum: "sha512=f2e945e0fbeebf9af11476b1abb3e59382b31a7b22ea7f3013fca419ed1ba8d2c9399c2f1b435f1c1808c228e361fd8448b8a5b0774e1ce39884447956318250"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.11/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.11/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.11.tar.gz"
   checksum: "sha512=5e5d01b0f2b19268b038e89cebd41103442987cd11a81b6b615553167444f2081e92bebd483e464ff3d47f080784f1104858ad170fc188124a066b55a1fea722"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.12/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.12/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.12.tar.gz"
   checksum: "sha512=8b55bf002636614d87f80dd12b7ce2831be28c3de1aef36eb94daf57effa9c815fdcd270b382473628ee9f17bf0d7a66a6c9c524b31d50ccc977ddd395d3188e"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.13/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.1+8.13/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.13.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.13.tar.gz"
   checksum: "sha512=68f0471fbf12be87e850a91ceaff1a6799319d62cc5cf48fca04bcb5be5d800813bad9e325036d6d13673d79a4b353f14d8f164034c577ee0da91d32e9a444ad"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.10/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.10/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.10.tar.gz"
   checksum: "sha512=8d38188b1a20d70b5c9e530db99b70b2d529a4d86bc43f6ed03ceba98882e7a57cce491791549b94bf52f2ae157bd711310b360f8c0ae51bb2105a0bdf39b4e8"
 }

--- a/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.11/opam
+++ b/released/packages/coq-hammer-tactics/coq-hammer-tactics.1.3.2+8.11/opam
@@ -41,6 +41,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.11.tar.gz"
   checksum: "sha512=0429b17d0d118ea85aa9be1c15cd205527b8ea4d7ea3e92dcaf7deb52d039dd9a3c6941f0a289c718c62ae6545dce68464ffb2d46196c0093d2960f1def83168"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.8+8.7/opam
@@ -24,6 +24,6 @@ authors: [
 ]
 synopsis: "Automation for Dependent Type Theory"
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.0.8-coq8.7.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.0.8-coq8.7.tar.gz"
   checksum: "md5=01267d1ade74dd431ba15cee21c87217"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.0/opam
@@ -27,6 +27,6 @@ authors: [
 ]
 synopsis: "Automation for Dependent Type Theory"
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.0.9-coq8.8.0.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.0.9-coq8.8.0.tar.gz"
   checksum: "md5=b39e959d96bf366773424e71f21b69e1"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.0.9+8.8.1/opam
@@ -27,6 +27,6 @@ authors: [
 ]
 synopsis: "Automation for Dependent Type Theory"
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.0.9-coq8.8.1.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.0.9-coq8.8.1.tar.gz"
   checksum: "md5=525fffc2e9e07ec87e12ced8104c33b1"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.1+8.8/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.1+8.8/opam
@@ -30,6 +30,6 @@ authors: [
 ]
 synopsis: "Automation for Dependent Type Theory"
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1-coq8.8.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1-coq8.8.tar.gz"
   checksum: "md5=10158c5f3d545b8ed924758106d1fa09"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.1+8.9/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.1+8.9/opam
@@ -31,6 +31,6 @@ authors: [
 ]
 synopsis: "Automation for Dependent Type Theory"
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1-coq8.9.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1-coq8.9.tar.gz"
   checksum: "md5=76a72dd942b2f6d4f6392b0a9f44af02"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.1.1+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.1.1+8.10/opam
@@ -40,6 +40,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1.1-coq8.10.tar.gz"
   checksum: "sha512=c9fd9c1a997775f515850fad54edceac6572d365f1e7cc043e448d6e5c9903ccb1bea2020fbbfda3983616f9ae4181a384b933f97731a487ee5cfba7cc1543d1"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.1.1+8.9/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.1.1+8.9/opam
@@ -37,6 +37,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.1.1-coq8.9.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.1.1-coq8.9.tar.gz"
   checksum: "sha256=4f167c5fa8cc8a26c81a0efb6f7c360acf4f15151d3d53f8d0c8ab654c8dd814"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.2+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.2+8.10/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2-coq8.10.tar.gz"
   checksum: "sha512=74b1a014f4e1e62148e25d46a4b2c376b927a3481ef52ce853d43f526164bbffd0bf2184653ba13e638d9321635ceec85e7c7b34e08dfa362c5e7a9588dc4b96"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.2+8.11/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.2+8.11/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2-coq8.11.tar.gz"
   checksum: "sha512=f533eeb42fcad00447c174839dbc1c7882e14167e87275121c9a0ccc7dba7f25da4589caf53e26d816e8e06cc3de2d91b0a2ef9133b6371a8318ac037c4a0792"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.2.1+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.2.1+8.10/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2.1-coq8.10.tar.gz"
   checksum: "sha512=22081122b39ee1099e79ef82f1afc1895350475fd255cdc51d3a47851184decd0bff7975b9effcd39ca9b55bb381e06cf649ad2d460dd31eec537eca44f2a6e1"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.2.1+8.11/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.2.1+8.11/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.2.1-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.2.1-coq8.11.tar.gz"
   checksum: "sha512=7ef5f5e68cc2645ef093dc63d1531cc9696afeabdd540b24c6955fa994417b85925c15856e56cfb41eea9424278cf3ee2fd899f9c84f04d8f8630165b188b666"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3+8.10/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.10.tar.gz"
   checksum: "sha512=b0b725a1a8d4a470f49d72be8b156a7ecf9f2694c1228483d6eebfcef89c262128e5694010c54039449b4fe6b4b36f1184deb45cc0b7dc109aaa8dfef2f293fc"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3+8.11/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3+8.11/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.11.tar.gz"
   checksum: "sha512=f50e39145b772c38cc19b1be7d1d66bd3b1bee6cb685ea897165eaa89fa0b5a746e4ec97a774429ccf2cf9bd10d272331d1b4e2a4b9247080df4ef7fb9600a1d"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3+8.12/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3+8.12/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3-coq8.12.tar.gz"
   checksum: "sha512=666ea825c122319e398efb7287f429ebfb5d35611b4cabe4b88732ffb5c265ef348b53d5046c958831ac0b7a759b44ce1ca04220ca68b1915accfd23435b479c"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.1+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.1+8.10/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.10.tar.gz"
   checksum: "sha512=f2e945e0fbeebf9af11476b1abb3e59382b31a7b22ea7f3013fca419ed1ba8d2c9399c2f1b435f1c1808c228e361fd8448b8a5b0774e1ce39884447956318250"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.1+8.11/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.1+8.11/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.11.tar.gz"
   checksum: "sha512=5e5d01b0f2b19268b038e89cebd41103442987cd11a81b6b615553167444f2081e92bebd483e464ff3d47f080784f1104858ad170fc188124a066b55a1fea722"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.1+8.12/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.1+8.12/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.12.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.12.tar.gz"
   checksum: "sha512=8b55bf002636614d87f80dd12b7ce2831be28c3de1aef36eb94daf57effa9c815fdcd270b382473628ee9f17bf0d7a66a6c9c524b31d50ccc977ddd395d3188e"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.1+8.13/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.1+8.13/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.1-coq8.13.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.1-coq8.13.tar.gz"
   checksum: "sha512=68f0471fbf12be87e850a91ceaff1a6799319d62cc5cf48fca04bcb5be5d800813bad9e325036d6d13673d79a4b353f14d8f164034c577ee0da91d32e9a444ad"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.10/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.10/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.10.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.10.tar.gz"
   checksum: "sha512=8d38188b1a20d70b5c9e530db99b70b2d529a4d86bc43f6ed03ceba98882e7a57cce491791549b94bf52f2ae157bd711310b360f8c0ae51bb2105a0bdf39b4e8"
 }

--- a/released/packages/coq-hammer/coq-hammer.1.3.2+8.11/opam
+++ b/released/packages/coq-hammer/coq-hammer.1.3.2+8.11/opam
@@ -39,6 +39,6 @@ authors: [
 ]
 
 url {
-  src: "https://github.com/lukaszcz/coqhammer/archive/v1.3.2-coq8.11.tar.gz"
+  src: "https://github.com/lukaszcz/coqhammer/archive/refs/tags/v1.3.2-coq8.11.tar.gz"
   checksum: "sha512=0429b17d0d118ea85aa9be1c15cd205527b8ea4d7ea3e92dcaf7deb52d039dd9a3c6941f0a289c718c62ae6545dce68464ffb2d46196c0093d2960f1def83168"
 }


### PR DESCRIPTION
Since @gares was so quick with merging, here is another PR for the remaining versions of Coq Hammer.