### PR TITLE
Build more of fiat-crypto in coq-fiat-crypto-with-bedrock

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "coq-without-bedrock2" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "coq" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
+install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,16 +11,22 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "coq" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "BINDIR=%{bin}%" "install-standalone-ocaml"]
+install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
   "conf-jq" {build}
-  "coq" {>= "8.9~"}
+  "coq" {>= "8.11~"}
   "coq-coqprime"
   "coq-rewriter"
+  "coq-coqutil"
+]
+conflicts: [
+  "coq-fiat-crypto"
+  "coq-bedrock2"
+  "coq-rupicola"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "coq" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "coq" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
@@ -21,7 +21,6 @@ depends: [
   "coq" {>= "8.11~"}
   "coq-coqprime"
   "coq-rewriter"
-  "coq-coqutil"
 ]
 conflict-class: [
   "coq-fiat-crypto"

--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -11,9 +11,9 @@ homepage: "https://github.com/mit-plv/fiat-crypto"
 bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
 license: "MIT OR Apache-2.0 OR BSD-1-Clause"
 build: [
-  [make "-j%{jobs}%" "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "coq" "standalone-ocaml"]
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "coq-without-bedrock2" "standalone-ocaml"]
 ]
-install: [make "EXTERNAL_REWRITER=1" "EXTERNAL_COQPRIME=1" "EXTERNAL_COQUTIL=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_BEDROCK2=1" "BINDIR=%{bin}%" "install-without-bedrock2" "install-standalone-ocaml"]
 depends: [
   "ocaml" {build}
   "ocamlfind" {build}
@@ -23,10 +23,8 @@ depends: [
   "coq-rewriter"
   "coq-coqutil"
 ]
-conflicts: [
+conflict-class: [
   "coq-fiat-crypto"
-  "coq-bedrock2"
-  "coq-rupicola"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."


### PR DESCRIPTION
We also base it on coq-coqutil rather than using the bundled one (hopefully bedrock2 and rupicola are set up to work with this, if not I may have to fix things or revert this), and we now mark a conflict with packages that we end up overwriting the install of.