### PR TITLE
Add an upper bound on released coq-flocq

### DIFF
--- a/released/packages/coq-flocq/coq-flocq.3.4.3/opam
+++ b/released/packages/coq-flocq/coq-flocq.3.4.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.7"}
+  "coq" {>= "8.7" & < "8.16~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]

--- a/released/packages/coq-flocq/coq-flocq.4.0.0/opam
+++ b/released/packages/coq-flocq/coq-flocq.4.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.12"}
+  "coq" {>= "8.12" & < "8.16~"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})
 ]


### PR DESCRIPTION
Due to https://github.com/coq/coq/pull/15754
those package will not be compatible with Coq 8.16.