### PR TITLE
release(Qcert) coq-qcert version 2.1.1

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.2.1.1/opam
+++ b/released/packages/coq-qcert/coq-qcert.2.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Verified compiler for data-centric languages"
+description: """
+This is the Coq library for Q*cert, a platform for implementing and verifying data languages and compilers. It includes abstract syntax and semantics for several source query languages (OQL, SQL), for intermediate database representations (nested relational algebra and calculus), and correctness proofs for part of the compilation to JavaScript and Java.
+"""
+
+maintainer: "Jerome Simeon <jeromesimeon@me.com>"
+authors: [ "Josh Auerbach <>" "Martin Hirzel <>" "Louis Mandel <>" "Avi Shinnar <>" "Jerome Simeon <>" ]
+
+license: "Apache-2.0"
+homepage: "https://querycert.github.io"
+bug-reports: "https://github.com/querycert/qcert/issues"
+dev-repo: "git+https://github.com/querycert/qcert"
+
+build: [
+  [make "configure"]
+  [make "-j" jobs name]
+  ["dune" "build" "-j" jobs "-p" name]
+]
+install: [
+  [make "install-coqdev"]
+]
+depends: [
+  "ocaml" {>= "4.09.1"}
+  "ocamlfind"
+  "dune"
+  "coq" {>= "8.11.0" & < "8.13~"}
+  "coq-jsast" {>= "2.0.0"}
+  "menhir"
+  "base64"
+  "uri"
+  "calendar"
+]
+
+tags: [ "keyword:databases" "keyword:queries" "keyword:relational" "keyword:compiler" "date:2022-03-08" "logpath:Qcert" ]
+
+url {
+  src: "https://github.com/querycert/qcert/archive/v2.1.1.tar.gz"
+  checksum: "351f5ae9b1380e6a0f673a21b483e6b2"
+}


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <Jerome.Simeon@docusign.com>

Release `2.1.1` of Q*cert (https://github.com/querycert/qcert)

### Changes

- Code cleanup, removing `admit`s
