### PR TITLE
split gaia dev package into subpackages

### DIFF
--- a/extra-dev/packages/coq-gaia-numbers/coq-gaia-numbers.dev/opam
+++ b/extra-dev/packages/coq-gaia-numbers/coq-gaia-numbers.dev/opam
@@ -20,6 +20,9 @@ depends: [
   "coq-gaia-theory-of-sets" {= version}
   "coq-gaia-ordinals" {= version}
 ]
+conflicts: [
+  "coq-gaia"
+]
 
 tags: [
   "category:Mathematics/Arithmetic and Number Theory/Number theory"

--- a/extra-dev/packages/coq-gaia-numbers/coq-gaia-numbers.dev/opam
+++ b/extra-dev/packages/coq-gaia-numbers/coq-gaia-numbers.dev/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of the sets of numbers Z, Q, and R following Bourbaki's Elements of Mathematics in Coq"
+description: """
+Implementation of the sets of numbers Z, Q, and R following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
+  "coq-mathcomp-algebra"
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-ordinals" {= version}
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:integers"
+  "keyword:rational numbers"
+  "keyword:real numbers"  
+  "logpath:gaia.numbers"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "git+https://github.com/coq-community/gaia.git#master"
+}

--- a/extra-dev/packages/coq-gaia-ordinals/coq-gaia-ordinals.dev/opam
+++ b/extra-dev/packages/coq-gaia-ordinals/coq-gaia-ordinals.dev/opam
@@ -19,6 +19,9 @@ depends: [
   "coq-gaia-theory-of-sets" {= version}
   "coq-gaia-schutte" {= version}
 ]
+conflicts: [
+  "coq-gaia"
+]
 
 tags: [
   "category:Mathematics/Logic/Set theory"

--- a/extra-dev/packages/coq-gaia-ordinals/coq-gaia-ordinals.dev/opam
+++ b/extra-dev/packages/coq-gaia-ordinals/coq-gaia-ordinals.dev/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation and properties of ordinals in Coq using Mathematical Components"
+description: """
+Implementation and properties of ordinals and cardinals in Coq using
+the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-schutte" {= version}
+]
+
+tags: [
+  "category:Mathematics/Logic/Set theory"
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordered sets"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinals"
+  "keyword:cardinal numbers"
+  "logpath:gaia.ordinals"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "git+https://github.com/coq-community/gaia.git#master"
+}

--- a/extra-dev/packages/coq-gaia-schutte/coq-gaia-schutte.dev/opam
+++ b/extra-dev/packages/coq-gaia-schutte/coq-gaia-schutte.dev/opam
@@ -17,6 +17,9 @@ depends: [
   "coq" {>= "8.10"}
   "coq-mathcomp-ssreflect" {>= "1.12.0"}
 ]
+conflicts: [
+  "coq-gaia"
+]
 
 tags: [
   "category:Mathematics/Arithmetic and Number Theory/Number theory"

--- a/extra-dev/packages/coq-gaia-schutte/coq-gaia-schutte.dev/opam
+++ b/extra-dev/packages/coq-gaia-schutte/coq-gaia-schutte.dev/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of ordinals in Coq following Schütte and Ackermann"
+description: """
+Types for ordinal numbers in Coq using the Mathematical Components library,
+following the approaches of Schütte and Ackermann."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinals"
+  "logpath:gaia.schutte"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "git+https://github.com/coq-community/gaia.git#master"
+}

--- a/extra-dev/packages/coq-gaia-stern/coq-gaia-stern.dev/opam
+++ b/extra-dev/packages/coq-gaia-stern/coq-gaia-stern.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Properties of Fibonacci numbers and the Stern diatomic sequence in Coq"
+description: """
+Properties of Fibonacci numbers and the Stern diatomic sequence in Coq using the
+Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
+  "coq-mathcomp-algebra"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:stern-brocot"
+  "keyword:fibonacci numbers"
+  "logpath:gaia.stern"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "git+https://github.com/coq-community/gaia.git#master"
+}

--- a/extra-dev/packages/coq-gaia-stern/coq-gaia-stern.dev/opam
+++ b/extra-dev/packages/coq-gaia-stern/coq-gaia-stern.dev/opam
@@ -18,6 +18,9 @@ depends: [
   "coq-mathcomp-ssreflect" {>= "1.12.0"}
   "coq-mathcomp-algebra"
 ]
+conflicts: [
+  "coq-gaia"
+]
 
 tags: [
   "category:Mathematics/Arithmetic and Number Theory/Number theory"

--- a/extra-dev/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.dev/opam
+++ b/extra-dev/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.dev/opam
@@ -6,25 +6,23 @@ dev-repo: "git+https://github.com/coq-community/gaia.git"
 bug-reports: "https://github.com/coq-community/gaia/issues"
 license: "MIT"
 
-synopsis: "Implementation of books from Bourbaki's Elements of Mathematics in Coq"
+synopsis: "Implementation of the Theory of Sets from Bourbaki's Elements of Mathematics in Coq"
 description: """
-Implementation of books from N. Bourbaki's Elements of Mathematics
-in Coq using the Mathematical Components library, including set theory
-and number theory."""
+Implementation of the Theory of Sets following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.10" & < "8.15~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
-  "coq-mathcomp-algebra" 
+  "coq" {>= "8.10"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0"}
 ]
 
 tags: [
   "category:Mathematics/Logic/Set theory"
   "keyword:Bourbaki"
   "keyword:set theory"
-  "logpath:gaia"
+  "logpath:gaia.sets"
 ]
 authors: [
   "José Grimm"

--- a/extra-dev/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.dev/opam
+++ b/extra-dev/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.dev/opam
@@ -17,6 +17,9 @@ depends: [
   "coq" {>= "8.10"}
   "coq-mathcomp-ssreflect" {>= "1.12.0"}
 ]
+conflicts: [
+  "coq-gaia"
+]
 
 tags: [
   "category:Mathematics/Logic/Set theory"


### PR DESCRIPTION
ci-skip: coq-gaia-theory-of-sets.dev coq-gaia-schutte.dev coq-gaia-ordinals.dev