### PR TITLE
add gaia split packages for release 1.14

### DIFF
--- a/released/packages/coq-gaia-numbers/coq-gaia-numbers.1.14/opam
+++ b/released/packages/coq-gaia-numbers/coq-gaia-numbers.1.14/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of the sets of numbers Z, Q, and R following Bourbaki's Elements of Mathematics in Coq"
+description: """
+Implementation of the sets of numbers Z, Q, and R following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+  "coq-mathcomp-algebra"
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-ordinals" {= version}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:integers"
+  "keyword:rational numbers"
+  "keyword:real numbers"  
+  "logpath:gaia.numbers"
+  "date:2022-03-23"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v1.14.tar.gz"
+  checksum: "sha512=aec8b3321bba4ffeedf65f2411f0154edc729df6b64b619cfffc46db275f58d1fdfe0e1923b191a9e5b35120e1ee3cf8fae8b0a8c4600278d6061a46cf7ecc74"
+}

--- a/released/packages/coq-gaia-ordinals/coq-gaia-ordinals.1.14/opam
+++ b/released/packages/coq-gaia-ordinals/coq-gaia-ordinals.1.14/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation and properties of ordinals in Coq using Mathematical Components"
+description: """
+Implementation and properties of ordinals and cardinals in Coq using
+the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+  "coq-gaia-theory-of-sets" {= version}
+  "coq-gaia-schutte" {= version}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Logic/Set theory"
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordered sets"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinals"
+  "keyword:cardinal numbers"
+  "logpath:gaia.ordinals"
+  "date:2022-03-23"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v1.14.tar.gz"
+  checksum: "sha512=aec8b3321bba4ffeedf65f2411f0154edc729df6b64b619cfffc46db275f58d1fdfe0e1923b191a9e5b35120e1ee3cf8fae8b0a8c4600278d6061a46cf7ecc74"
+}

--- a/released/packages/coq-gaia-schutte/coq-gaia-schutte.1.14/opam
+++ b/released/packages/coq-gaia-schutte/coq-gaia-schutte.1.14/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of ordinals in Coq following Schütte and Ackermann"
+description: """
+Types for ordinal numbers in Coq using the Mathematical Components library,
+following the approaches of Schütte and Ackermann."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:ordinal arithmetic"
+  "keyword:ordinals"
+  "logpath:gaia.schutte"
+  "date:2022-03-23"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v1.14.tar.gz"
+  checksum: "sha512=aec8b3321bba4ffeedf65f2411f0154edc729df6b64b619cfffc46db275f58d1fdfe0e1923b191a9e5b35120e1ee3cf8fae8b0a8c4600278d6061a46cf7ecc74"
+}

--- a/released/packages/coq-gaia-stern/coq-gaia-stern.1.14/opam
+++ b/released/packages/coq-gaia-stern/coq-gaia-stern.1.14/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Properties of Fibonacci numbers and the Stern diatomic sequence in Coq"
+description: """
+Properties of Fibonacci numbers and the Stern diatomic sequence in Coq using the
+Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+  "coq-mathcomp-algebra"
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Arithmetic and Number Theory/Number theory"
+  "keyword:stern-brocot"
+  "keyword:fibonacci numbers"
+  "logpath:gaia.stern"
+  "date:2022-03-23"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v1.14.tar.gz"
+  checksum: "sha512=aec8b3321bba4ffeedf65f2411f0154edc729df6b64b619cfffc46db275f58d1fdfe0e1923b191a9e5b35120e1ee3cf8fae8b0a8c4600278d6061a46cf7ecc74"
+}

--- a/released/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.1.14/opam
+++ b/released/packages/coq-gaia-theory-of-sets/coq-gaia-theory-of-sets.1.14/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/gaia"
+dev-repo: "git+https://github.com/coq-community/gaia.git"
+bug-reports: "https://github.com/coq-community/gaia/issues"
+license: "MIT"
+
+synopsis: "Implementation of the Theory of Sets from Bourbaki's Elements of Mathematics in Coq"
+description: """
+Implementation of the Theory of Sets following N. Bourbaki's book series
+Elements of Mathematics in Coq using the Mathematical Components library."""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.5"}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+]
+conflicts: [
+  "coq-gaia"
+]
+
+tags: [
+  "category:Mathematics/Logic/Set theory"
+  "keyword:Bourbaki"
+  "keyword:set theory"
+  "logpath:gaia.sets"
+  "date:2022-03-23"
+]
+authors: [
+  "José Grimm"
+  "Alban Quadrat"
+  "Carlos Simpson"
+]
+
+url {
+  src: "https://github.com/coq-community/gaia/archive/v1.14.tar.gz"
+  checksum: "sha512=aec8b3321bba4ffeedf65f2411f0154edc729df6b64b619cfffc46db275f58d1fdfe0e1923b191a9e5b35120e1ee3cf8fae8b0a8c4600278d6061a46cf7ecc74"
+}


### PR DESCRIPTION
ci-skip: coq-gaia-theory-of-sets.1.14 coq-gaia-schutte.1.14 coq-gaia-ordinals.1.14