### PR TITLE
coq-vst(-32): fix issue that nothing is installed for Coq 8.15.1

### DIFF
--- a/released/packages/coq-vst-32/coq-vst-32.2.9.1/files/0001-Fix-issue-that-make-install-does-not-install-anythin.patch
+++ b/released/packages/coq-vst-32/coq-vst-32.2.9.1/files/0001-Fix-issue-that-make-install-does-not-install-anythin.patch
@@ -1,0 +1,26 @@
+From f02581beaf736ccaa323d8fa2e80a8cc1b87e6ea Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Fri, 25 Mar 2022 19:48:05 +0100
+Subject: [PATCH] Fix issue that make install does not install anything if Coq
+ version does not match and IGNORECOQVERSION is given
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index b56e79a21..ec9a3422e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -637,7 +637,7 @@ endif
+ 
+ PROGS64_FILES=$(V64_ORDINARY)
+ 
+-INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) MAKE=$(MAKE) util/calc_install_files $(PROGSDIR))
++INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) IGNORECOQVERSION=$(IGNORECOQVERSION) MAKE=$(MAKE) util/calc_install_files $(PROGSDIR))
+ INSTALL_FILES_VO=$(patsubst %.v,%.vo,$(INSTALL_FILES_SRC))
+ INSTALL_FILES=$(sort $(INSTALL_FILES_SRC) $(INSTALL_FILES_VO))
+ 
+-- 
+2.33.0
+

--- a/released/packages/coq-vst-32/coq-vst-32.2.9.1/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.9.1/opam
@@ -26,6 +26,7 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 # test or install commands are changed, this needs to be reviewed!
 license: "BSD-2-Clause"
 
+patches: [ "0001-Fix-issue-that-make-install-does-not-install-anythin.patch" ]
 build: [
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "BITSIZE=32"]
 ]

--- a/released/packages/coq-vst/coq-vst.2.9.1/files/0001-Fix-issue-that-make-install-does-not-install-anythin.patch
+++ b/released/packages/coq-vst/coq-vst.2.9.1/files/0001-Fix-issue-that-make-install-does-not-install-anythin.patch
@@ -1,0 +1,26 @@
+From f02581beaf736ccaa323d8fa2e80a8cc1b87e6ea Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Fri, 25 Mar 2022 19:48:05 +0100
+Subject: [PATCH] Fix issue that make install does not install anything if Coq
+ version does not match and IGNORECOQVERSION is given
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index b56e79a21..ec9a3422e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -637,7 +637,7 @@ endif
+ 
+ PROGS64_FILES=$(V64_ORDINARY)
+ 
+-INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) MAKE=$(MAKE) util/calc_install_files $(PROGSDIR))
++INSTALL_FILES_SRC=$(shell COMPCERT=$(COMPCERT) COMPCERT_INST_DIR=$(COMPCERT_INST_DIR) BITSIZE=$(BITSIZE) ARCH=$(ARCH) IGNORECOQVERSION=$(IGNORECOQVERSION) MAKE=$(MAKE) util/calc_install_files $(PROGSDIR))
+ INSTALL_FILES_VO=$(patsubst %.v,%.vo,$(INSTALL_FILES_SRC))
+ INSTALL_FILES=$(sort $(INSTALL_FILES_SRC) $(INSTALL_FILES_VO))
+ 
+-- 
+2.33.0
+

--- a/released/packages/coq-vst/coq-vst.2.9.1/opam
+++ b/released/packages/coq-vst/coq-vst.2.9.1/opam
@@ -26,6 +26,7 @@ bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
 # test or install commands are changed, this needs to be reviewed!
 license: "BSD-2-Clause"
 
+patches: [ "0001-Fix-issue-that-make-install-does-not-install-anythin.patch" ]
 build: [
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "BITSIZE=64"]
 ]


### PR DESCRIPTION
VST has a bug that nothing is installed if the Coq version is not explicitly supported in the makefile and IGNORECOQVERSION is given. So 8.15.0 did work, but 8.15.1 didn't.

See also: https://github.com/PrincetonUniversity/VST/pull/559