### PR TITLE
Package coq-haskell.1.0.0

### DIFF
--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -14,7 +14,7 @@ algorithms in Coq. It provides a collection of definitions and notations to
 make Gallina more familiar to Haskellers.
 """
 
-build: [make "-j%{jobs}%"]
+build: [make]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}

--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -1,6 +1,5 @@
 opam-version: "2.0"
 maintainer: "johnw@newartisans.com"
-version: "1.0.0"
 
 homepage: "https://github.com/jwiegley/coq-haskell"
 dev-repo: "git+https://github.com/jwiegley/coq-haskell.git"

--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -31,6 +31,7 @@ authors: [
 
 tags: [
   "keyword:haskell"
+  "category:Computer Science/Data Types and Data Structures"
   "date:2022-03-29"
   "logpath:Hask"
 ]

--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "johnw@newartisans.com"
+version: "1.0.0"
+
+homepage: "https://github.com/jwiegley/coq-haskell"
+dev-repo: "git+https://github.com/jwiegley/coq-haskell.git"
+bug-reports: "https://github.com/jwiegley/coq-haskell/issues"
+license: "BSD-3-Clause"
+
+synopsis: "A library to provide Haskell-familiar constructions in Coq"
+description: """
+This library is designed for Haskell users who are either using Coq to build
+code intended for extraction to Haskell, or who wish to prototype/prove their
+algorithms in Coq. It provides a collection of definitions and notations to
+make Gallina more familiar to Haskellers.
+"""
+
+build: [make "JOBS=%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
+]
+
+url {
+  src: "https://github.com/jwiegley/coq-haskell/archive/refs/tags/1.0.tar.gz"
+  checksum: "sha256=64b6958f4eca641b933977a047272dea00ef5ceff33206da66f10fe792dbf3f2"
+}
+
+authors: [
+  "John Wiegley"
+]
+
+tags: [
+  "keyword:haskell"
+  "category:Miscellaneous/Coq Extensions"
+  "date:2022-03-29"
+  "logpath:Hask"
+]

--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -32,7 +32,6 @@ authors: [
 
 tags: [
   "keyword:haskell"
-  "category:Miscellaneous/Coq Extensions"
   "date:2022-03-29"
   "logpath:Hask"
 ]

--- a/released/packages/coq-haskell/coq-haskell.1.0.0/opam
+++ b/released/packages/coq-haskell/coq-haskell.1.0.0/opam
@@ -14,7 +14,7 @@ algorithms in Coq. It provides a collection of definitions and notations to
 make Gallina more familiar to Haskellers.
 """
 
-build: [make "JOBS=%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {(>= "8.10" & < "8.16~") | (= "dev")}


### PR DESCRIPTION
This library is designed for Haskell users who are either using Coq to build code intended for extraction to Haskell, or who wish to prototype/prove their algorithms in Coq. It provides a collection of definitions and notations to make Gallina more familiar to Haskellers.

I need this in Coq OPAM because it is used by a few other packages that I'd like to build with OPAM.