### PR TITLE
Fix the coq-elpi.dev -> elpi dependency

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
@@ -10,7 +10,7 @@ build: [ make "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN=" ]
 install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
 
 depends: [
-  "elpi" {>= "1.12.0" }
+  "elpi" {>= "1.14.0" & < "1.15.0~"}
   "coq" {= "dev"}
 ]
 synopsis: "Elpi extension language for Coq"


### PR DESCRIPTION
`coq-elpi.dev` is compatible with Elpi >= 1.14, but not with Elpi 1.15. @gares