### PR TITLE
release(Qcert): coq-qcert version 2.2.0

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.2.2.0/opam
+++ b/released/packages/coq-qcert/coq-qcert.2.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Verified compiler for data-centric languages"
+description: """
+This is the Coq library for Q*cert, a platform for implementing and verifying data languages and compilers. It includes abstract syntax and semantics for several source query languages (OQL, SQL), for intermediate database representations (nested relational algebra and calculus), and correctness proofs for part of the compilation to JavaScript, Java and WASM.
+"""
+
+maintainer: "Jerome Simeon <jeromesimeon@me.com>"
+authors: [ "Josh Auerbach <>" "Martin Hirzel <>" "Louis Mandel <>" "Avi Shinnar <>" "Jerome Simeon <>" ]
+
+license: "Apache-2.0"
+homepage: "https://querycert.github.io"
+bug-reports: "https://github.com/querycert/qcert/issues"
+dev-repo: "git+https://github.com/querycert/qcert"
+
+build: [
+  [make "configure"]
+  [make "-j" jobs name]
+  ["dune" "build" "-j" jobs "-p" name]
+]
+install: [
+  [make "install-coqdev"]
+]
+depends: [
+  "ocaml" {>= "4.09.1"}
+  "ocamlfind"
+  "dune"
+  "coq" {>= "8.11.2"}
+  "coq-jsast" {>= "2.0.0"}
+  "menhir"
+  "base64"
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "uri"
+  "wasm" {= "1.0.1"}
+  "calendar"
+]
+
+tags: [ "keyword:databases" "keyword:queries" "keyword:relational" "keyword:compiler" "date:2020-08-22" "logpath:Qcert" ]
+
+url {
+  src: "https://github.com/querycert/qcert/archive/refs/tags/v2.2.0.tar.gz"
+  checksum: "1dd98e96ba80da9a0e45a295354b1acb"
+}


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Q*cert Release 2.2.0

- New experimental WASM backend
- Portability fixes for Coq 8.13 through 8.15

Release notes at: https://github.com/querycert/qcert/releases/tag/v2.2.0