### PR TITLE
release(JsAst) coq-jsast version 3.0.0

### DIFF
--- a/released/packages/coq-jsast/coq-jsast.3.0.0/opam
+++ b/released/packages/coq-jsast/coq-jsast.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A minimal JavaScript syntax tree carved out of the JsCert project"
+description: """
+A minimal JavaScript syntax tree carved out of the JsCert project, with additional support for let bindings and using native floats.
+"""
+
+maintainer: "Jerome Simeon <jeromesimeon@me.com>"
+authors: [
+    "Martin Bodin <>"
+    "Arthur Charguéraud <>"
+    "Daniele Filaretti <>"
+    "Philippa Gardner <>"
+    "Sergio Maffeis <>"
+    "Daiva Naudziuniene <>"
+    "Alan Schmitt <>"
+    "Gareth Smith <>"
+    "Josh Auerbach <>"
+    "Martin Hirzel <>"
+    "Louis Mandel <>"
+    "Avi Shinnar <>"
+    "Jerome Simeon <>"
+]
+
+license: "BSD-2-Clause"
+homepage: "https://github.com/querycert/jsast"
+bug-reports: "https://github.com/querycert/jsast/issues"
+dev-repo: "git+https://github.com/querycert/jsast/tree/JsAst"
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" { >= "8.11.2" }
+]
+
+tags: [ "keyword:javascript" "keyword:compiler" "date:2020-07-29" "logpath:JsAst" ]
+
+url {
+  src: "https://github.com/querycert/jsast/archive/v3.0.0.tar.gz"
+  checksum: "md5=576cff412f88bbee327323014e07ec42"
+}


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

Extensions to JsAst:
- Simple toplevel module
- BigInt literals

Release notes at: https://github.com/querycert/jsast/releases/tag/v3.0.0