### PR TITLE
Fix Coq version for coq-mi-cho-coq.0.1

### DIFF
--- a/released/packages/coq-mi-cho-coq/coq-mi-cho-coq.0.1/opam
+++ b/released/packages/coq-mi-cho-coq/coq-mi-cho-coq.0.1/opam
@@ -16,7 +16,7 @@ install: [
   make "install"
 ]
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.8" & < "8.12"}
   "coq-menhirlib" {>= "20190626"}
   "coq-ott" {>= "0.29"}
   "menhir"


### PR DESCRIPTION
The error message: https://coq-bench.github.io/clean/Linux-x86_64-4.14.0-2.0.10/released/8.15.1/mi-cho-coq/0.1.html This is due to a new release of `coq-ott` enabling the package to (wrongly) install for new Coq versions.