### PR TITLE
[coq.dev] Use url files instead of rewriting the opam files

### DIFF
--- a/core-dev/packages/coq-core/coq-core.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.dev/opam
@@ -57,7 +57,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
-
-url {
-  src: "git+https://github.com/coq/coq.git#master"
-}

--- a/core-dev/packages/coq-core/coq-core.dev/url
+++ b/core-dev/packages/coq-core/coq-core.dev/url
@@ -1,0 +1,1 @@
+src: "git+https://github.com/coq/coq.git#master"

--- a/core-dev/packages/coq-stdlib/coq-stdlib.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.dev/opam
@@ -54,7 +54,3 @@ build: [
 ]
 dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
-
-url {
-  src: "git+https://github.com/coq/coq.git#master"
-}

--- a/core-dev/packages/coq-stdlib/coq-stdlib.dev/url
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.dev/url
@@ -1,0 +1,1 @@
+src: "git+https://github.com/coq/coq.git#master"

--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -39,7 +39,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/coq/coq.git"
-
-url {
-  src: "git+https://github.com/coq/coq.git#master"
-}

--- a/core-dev/packages/coq/coq.dev/url
+++ b/core-dev/packages/coq/coq.dev/url
@@ -1,0 +1,1 @@
+src: "git+https://github.com/coq/coq.git#master"


### PR DESCRIPTION
Now that makes the opam files canonical w.r.t. the ones in the opam repos.

See discussion in https://github.com/coq/opam-coq-archive/pull/1923