### PR TITLE
Bump Coq compatibility bounds for pocklington.

### DIFF
--- a/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
+++ b/released/packages/coq-pocklington/coq-pocklington.8.12.0/opam
@@ -14,7 +14,7 @@ large natural numbers. Includes a formal proof of Fermat's little theorem."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.7" & < "8.15~"}
+  "coq" {>= "8.7" & < "8.17~"}
 ]
 
 tags: [


### PR DESCRIPTION
According to our CI, this release should be compatible with Coq 8.16 and 8.17.