### PR TITLE
Add opam packages for CompCert 3.11

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.11/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.11/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Michael Soegtrop"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+available: os != "macos"
+build: [
+  ["./configure"
+  "ia32-linux" {os = "linux"}
+  "ia32-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "ia32-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 32 bit CompCert on 64 bit MinGW with cygwin build host
+  "-toolprefix"     {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  "i686-pc-cygwin-" {os = "win32" & os-distribution = "cygwinports" & arch = "x86_64"}
+  # The 32 bit CompCert is a variant which is installed in a non standard folder
+  "-prefix" "%{prefix}%/variants/compcert32"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq-variant/compcert32/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.16~"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (32 bit)"
+description: "This package installs the 32 bit version of CompCert.
+For coexistence with the 64 bit version, the files are installed in:
+%{prefix}%/variants/compcert32/bin  (ccomp and clightgen binaries)
+%{prefix}%/variants/compcert32/lib/compcert  (C library)
+%{lib}%/coq-variant/compcert32/compcert (Coq library)
+Please note that the coq module path is compcert and not compcert32,
+so the files cannot be directly Required as compcert32.
+Instead -Q or -R options must be used to bind the compcert32 folder
+to the module path compcert. This is more convenient if one development
+supports both 32 and 64 bit versions. Otherwise all files would have to
+be duplicated with module paths compcert and compcert32.
+Please also note that the binary folder is usually not in the path."
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert32"
+  "date:2022-06-27"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.11.tar.gz"
+  checksum: "sha512=02240113c7ad9155b76a99ea73c454a70cffa9efbaf92bbb70bc6d4901a2b1f36082713ea64b315b15384bca6a11459e6d2313701156bd16bdf2ad1ec10d67aa"
+}

--- a/released/packages/coq-compcert/coq-compcert.3.11/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.11/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+authors: "Xavier Leroy <xavier.leroy@inria.fr>"
+maintainer: "Michael Soegtrop"
+homepage: "http://compcert.inria.fr/"
+dev-repo: "git+https://github.com/AbsInt/CompCert.git"
+bug-reports: "https://github.com/AbsInt/CompCert/issues"
+license: "INRIA Non-Commercial License Agreement"
+build: [
+  ["./configure"
+  "amd64-linux"  {os = "linux" & arch = "x86_64"}
+  "amd64-macosx" {os = "macos" & arch = "x86_64"}
+  "arm64-linux"  {os = "linux" & (arch = "arm64" | arch = "aarch64")}
+  "arm64-macosx" {os = "macos" & (arch = "arm64" | arch = "aarch64")}
+  "amd64-cygwin" {os = "cygwin"}
+  # This is for building a MinGW CompCert with cygwin host and cygwin target
+  "amd64-cygwin" {os = "win32" & os-distribution = "cygwinports"}
+  # This is for building a 64 bit CompCert on 32 bit MinGW with cygwin build host
+  "-toolprefix"        {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "x86_64-pc-cygwin-"  {os = "win32" & os-distribution = "cygwinports" & arch = "i686"}
+  "-prefix" "%{prefix}%"
+  "-install-coqdev"
+  "-clightgen"
+  "-use-external-Flocq"
+  "-use-external-MenhirLib"
+  "-coqdevdir" "%{lib}%/coq/user-contrib/compcert"
+  "-ignore-coq-version"]
+  [make "-j%{jobs}%" {ocaml:version >= "4.06"}]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "coq" {>= "8.9.0" & < "8.16~"}
+  "menhir" {>= "20190626" }
+  "ocaml" {>= "4.05.0"}
+  "coq-flocq" {>= "4.1.0" & < "5~"}
+  "coq-menhirlib" {>= "20190626"}
+]
+synopsis: "The CompCert C compiler (64 bit)"
+tags: [
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "keyword:compiler"
+  "logpath:compcert"
+  "date:2022-06-27"
+]
+url {
+  src: "https://github.com/AbsInt/CompCert/archive/v3.11.tar.gz"
+  checksum: "sha512=02240113c7ad9155b76a99ea73c454a70cffa9efbaf92bbb70bc6d4901a2b1f36082713ea64b315b15384bca6a11459e6d2313701156bd16bdf2ad1ec10d67aa"
+}


### PR DESCRIPTION
This PR adds opam packages for CompCert 3.11.

I left the Coq upper bound at 8.16~ since I did not test if it works with 8.16 - I will relax the limit after testing in a separate PR.

I put in myself as maintainer as discussed in the [3.10 PR](https://github.com/coq/opam-coq-archive/pull/2047)

@xavierleroy @jhjourdan : FYI

@palmskog : what is the common way to put in a github account as maintainer contact?

ci-skip: coq-compcert.3.11
