### PR TITLE
fix: only coq-mathcomp-ssreflect.1.15.0 is compatible with coq.dev

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.13.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.13.0/opam
@@ -8,7 +8,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.11" & < "8.16~") | (= "dev"))} ]
+depends: [ "coq" { (>= "8.11" & < "8.16~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.14.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.14.0/opam
@@ -8,7 +8,7 @@ license: "CECILL-B"
 
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" "COQEXTRAFLAGS+=-native-compiler yes" {coq-native:installed & coq:version < "8.13~" } ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
-depends: [ "coq" { ((>= "8.11" & < "8.16~") | (= "dev"))} ]
+depends: [ "coq" { (>= "8.11" & < "8.16~") } ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]


### PR DESCRIPTION
Cc @gares @palmskog 

This tiny PR could actually have been already applied in #2045 then #2212,
as per the "mathcomp-stable / coq.dev release workflow" documented first in:
* https://github.com/coq/opam-coq-archive/pull/779 
> …
> 3. Release a new version of mathcomp (say, coq-mathcomp-ssreflect.1.n.1) compatible with coq.dev
> 4. Open a new PR targeting coq-released in this repo that simultaneously:
>    * removes `"coq" {= "dev"}` in coq-mathcomp-ssreflect.1.n.0
>    * adds coq-mathcomp-ssreflect.1.n.1 that allows `"coq" {= "dev"}`
> …

(see also https://github.com/math-comp/math-comp/issues/773 )