### PR TITLE
add-actuary-2.4

### DIFF
--- a/released/packages/coq-actuary/coq-actuary.2.4/opam
+++ b/released/packages/coq-actuary/coq-actuary.2.4/opam
@@ -16,7 +16,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.13"}
-  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.14~"}
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.15~"}
   "coq-coquelicot" {>= "3.1.0"}
 ]
 

--- a/released/packages/coq-actuary/coq-actuary.2.4/opam
+++ b/released/packages/coq-actuary/coq-actuary.2.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/Yosuke-Ito-345/Actuary"
+dev-repo: "git+https://github.com/Yosuke-Ito-345/Actuary.git"
+bug-reports: "https://github.com/Yosuke-Ito-345/Actuary/issues"
+license: "MIT"
+
+synopsis: "Formalization of actuarial mathematics in Coq"
+description: """
+This package formalizes basic actuarial mathematics using Coq and
+the Mathematical Components and Coquelicot libraries. This includes
+the theory of interest, life tables, annuities, and reserves."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.13"}
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.14~"}
+  "coq-coquelicot" {>= "3.1.0"}
+]
+
+tags: [  
+  "category:Mathematics/Real Calculus and Topology"
+  "keyword:present value"
+  "keyword:life tables"
+  "keyword:annuities"
+  "keyword:reserves"
+  "keyword:actuarial mathematics"
+  "logpath:Actuary"
+  "date:2022-07-08"
+]
+authors: [
+  "Yosuke Ito"
+]
+
+url {
+  src: "https://github.com/Yosuke-Ito-345/Actuary/archive/v2.4.tar.gz"
+  checksum: "sha512=76d2074c41221ba5f28aa50e7def52f46b1583c0850e716526a4962da468c2062e8a4f9bcc6cdd005910129a9b45cc5efd95c41db1a084786b90b24ece38c728"
+}


### PR DESCRIPTION
@palmskog Hello Karl, I send pull request for adding `coq-actuary-2.4`, since I have submitted the peer-reviewed paper to the Institute of Actuaries of Japan. This paper is added to the repository `Actuary/doc`. The publication will be around the end of October 2022. I planned to make the release of `v2.4` after the paper is published, but I could not wait because `mathcomp-1.15.0` is incompatible with the current `coq-actuary` package. I will modify `coq-actuary` after `coq-actuary-2.4` is registered on `opam-coq-archive`. If you have any problem, please let me know.