### PR TITLE
adds a new release for coq-dpdgraph and coq 8.16

### DIFF
--- a/extra-dev/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
+++ b/extra-dev/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
@@ -38,5 +38,5 @@ authors: [
 
 url {
   src: "https://github.com/coq-community/coq-dpdgraph/releases/download/v1.0%2B8.16/coq-dpdgraph-1.0-8.16.tgz"
-  checksum: "sha512=c994128902910a8ea124de956913363e2725d094145b48822edfd627e158f3b4e692f5f6eab2df51a1339393daaad099fad94b7f635082c8dae3f53bd7010924"
+  checksum: "sha512=6ed4db949867b3a7761f9ed09213613fe32d04b5d13d15ffbad6fb2b1a24dd5ccebade61f6c288e95b578c355ccc6977b485c3630764703d09b6fc6d29a3a446"
 }

--- a/extra-dev/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
+++ b/extra-dev/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/coq-dpdgraph"
+dev-repo: "git+https://github.com/coq-community/coq-dpdgraph.git"
+bug-reports: "https://github.com/coq-community/coq-dpdgraph/issues"
+license: "LGPL-2.1-only"
+
+synopsis: "Compute dependencies between Coq objects (definitions, theorems) and produce graphs"
+description: """
+Coq plugin that extracts the dependencies between Coq objects,
+and produces files with dependency information. Includes tools
+to visualize dependency graphs and find unused definitions."""
+
+build: [
+  ["./configure"]
+  [make "-j%{jobs}%" "WARN_ERR="]
+]
+install: [make "install" "BINDIR=%{bin}%"]
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "coq" {>= "8.16" & < "8.17~"}
+  "ocamlgraph" 
+]
+
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:dependency graph"
+  "keyword:dependency analysis"
+  "logpath:dpdgraph"
+  "date:2022-01-21"
+]
+authors: [
+  "Anne Pacalet"
+  "Yves Bertot"
+  "Olivier Pons"
+]
+
+url {
+  src: "https://github.com/coq-community/coq-dpdgraph/releases/download/v1.0%2B8.16/coq-dpdgraph-1.0-8.16.tgz"
+  checksum: "sha512=c994128902910a8ea124de956913363e2725d094145b48822edfd627e158f3b4e692f5f6eab2df51a1339393daaad099fad94b7f635082c8dae3f53bd7010924"
+}


### PR DESCRIPTION
I understood that the opam package should be placed in extra-dev until coq 8.16 is officially released.
