### PR TITLE
Interval 4.5.2

### DIFF
--- a/released/packages/coq-interval/coq-interval.4.5.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.5.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.8" & < "8.16~"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
   "coq-mathcomp-ssreflect" {>= "1.6"}

--- a/released/packages/coq-interval/coq-interval.4.5.1/opam
+++ b/released/packages/coq-interval/coq-interval.4.5.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.8" & < "8.16~"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
   "coq-mathcomp-ssreflect" {>= "1.6"}

--- a/released/packages/coq-interval/coq-interval.4.5.2/opam
+++ b/released/packages/coq-interval/coq-interval.4.5.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8" & < "8.16~"}
+  "coq" {>= "8.8"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
   "coq-mathcomp-ssreflect" {>= "1.6"}
@@ -28,7 +28,7 @@ tags: [
   "category:Mathematics/Real Calculus and Topology"
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
   "logpath:Interval"
-  "date:2022-01-15"
+  "date:2022-08-25"
 ]
 authors: [
   "Guillaume Melquiond <guillaume.melquiond@inria.fr>"
@@ -38,6 +38,6 @@ authors: [
 ]
 synopsis: "A Coq tactic for proving bounds on real-valued expressions automatically"
 url {
-  src: "https://coqinterval.gitlabpages.inria.fr/releases/interval-4.4.0.tar.gz"
-  checksum: "sha512=47b56fb496a8ca39e2b0cafbea30bd769674ca35d9140b17dc48f18d87903a70a11efd49f9235a675923e9f5e1b0d86db6931b1ffd32ab1a25dc16c9fc7e4dee"
+  src: "https://coqinterval.gitlabpages.inria.fr/releases/interval-4.5.2.tar.gz"
+  checksum: "sha512=74be5915cb242f3a9fecab6a60d33169ddf20a21dd4479258fe869e59d77e212ec08890864d2adfcc9d27c132a9839b50d88e3d8ba8f791adba4dcc3c067b903"
 }


### PR DESCRIPTION
This commit also puts an upper bound on the version of Coq for the previous releases.

ci-skip: coq-interval.4.4.0 coq-interval.4.5.0 coq-interval.4.5.1