### PR TITLE
Constrain coq-switch to 8.13

### DIFF
--- a/released/packages/coq-switch/coq-switch.1.0.5/opam
+++ b/released/packages/coq-switch/coq-switch.1.0.5/opam
@@ -12,7 +12,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {>= "8.13.0"}
+  "coq" {>= "8.13.0" & < "8.14~"}
   "coq-metacoq-template" {>= "1.0~beta2+8.13"}
 ]
 tags: [


### PR DESCRIPTION
`coq-switch` is not compatible with Coq versions 8.14 and 8.15.

Note: this is not my package.