### PR TITLE
Constrain jsast to 2.0.0 in qcert

### DIFF
--- a/released/packages/coq-qcert/coq-qcert.2.1.0/opam
+++ b/released/packages/coq-qcert/coq-qcert.2.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlfind"
   "dune"
   "coq" {>= "8.11.0" & < "8.13~"}
-  "coq-jsast" {>= "2.0.0"}
+  "coq-jsast" {= "2.0.0"}
   "menhir"
   "base64"
   "uri"


### PR DESCRIPTION
This appears to be the only compatible version

Note: This is not my package.