### PR TITLE
coq-autosubst.dev: Bump for Coq 8.16

### DIFF
--- a/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
+++ b/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
@@ -19,7 +19,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.17~") | (= "dev")}
+  "coq" {>= "8.14"}
 ]
 
 tags: [

--- a/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
+++ b/extra-dev/packages/coq-autosubst/coq-autosubst.dev/opam
@@ -19,7 +19,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.11" & < "8.16~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.17~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Following the Iris repo's opam file https://gitlab.mpi-sws.org/iris/opam/-/blob/master/packages/coq-autosubst/coq-autosubst.dev/opam.