### PR TITLE
require coqide-server in coqide.dev

### DIFF
--- a/core-dev/packages/coqide/coqide.dev/opam
+++ b/core-dev/packages/coqide/coqide.dev/opam
@@ -14,6 +14,7 @@ using the Coq proof assistant.
 
 depends: [
   "coq" {= version}
+  "coqide-server" {= version}
   "ocamlfind" {build}
   "dune" {>= "2.5.1"}
   "conf-findutils" {build}


### PR DESCRIPTION
Without the `coqide-server` dep being installed, it appears we don't get a `coqide` binary from `coqide.dev`. Should also be necessary at runtime.