### PR TITLE
VerdiRaft: remove upper bound of Coq

### DIFF
--- a/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
+++ b/extra-dev/packages/coq-verdi-raft/coq-verdi-raft.dev/opam
@@ -19,7 +19,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.7" & < "8.12~") | (= "dev")}
+  "coq" {(>= "8.7")}
   "coq-verdi" {= "dev"}
   "coq-struct-tact" {= "dev"}
   "coq-cheerios" {= "dev"}


### PR DESCRIPTION
provided this package is part of Coq CI.
Tested on Coq 8.16.