### PR TITLE
use SPDX license identifier LGPL-2.1-only for all Equations packages

### DIFF
--- a/extra-dev/packages/coq-equations/coq-equations.0.9~beta2/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.0.9~beta2/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "mattam@mattam.org"
 homepage: "https://github.com/mattam82/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]
@@ -12,13 +12,11 @@ build: [
 install: [
   [make "install"]
 ]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Equations"]
 depends: [
   "ocaml"
   "coq" {= "8.5~beta2"}
 ]
 synopsis: "A plugin for Coq to add dependent pattern-matching"
-flags: light-uninstall
 url {
   src: "https://github.com/mattam82/Coq-Equations/archive/0.9.tar.gz"
   checksum: "md5=f560c43d9d68894892827ceee3432f70"

--- a/extra-dev/packages/coq-equations/coq-equations.1.2+8.10/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.1.2+8.10/opam
@@ -4,7 +4,7 @@ dev-repo: "git://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/extra-dev/packages/coq-equations/coq-equations.1.2.2+8.12/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.1.2.2+8.12/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.12"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/extra-dev/packages/coq-equations/coq-equations.8.7.dev/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.8.7.dev/opam
@@ -4,7 +4,7 @@ maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/extra-dev/packages/coq-equations/coq-equations.8.8.dev/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.8.8.dev/opam
@@ -4,7 +4,7 @@ maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/extra-dev/packages/coq-equations/coq-equations.dev/opam
+++ b/extra-dev/packages/coq-equations/coq-equations.dev/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.0+8.7/opam
+++ b/released/packages/coq-equations/coq-equations.1.0+8.7/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.0+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.0+8.8/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.0/opam
+++ b/released/packages/coq-equations/coq-equations.1.0/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/opam
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2+8.7/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.0~beta2/opam
+++ b/released/packages/coq-equations/coq-equations.1.0~beta2/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.1+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.1+8.8/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.2+8.10/opam
+++ b/released/packages/coq-equations/coq-equations.1.2+8.10/opam
@@ -4,7 +4,7 @@ dev-repo: "git://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.2+8.8/opam
@@ -4,7 +4,7 @@ dev-repo: "git://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2+8.9/opam
+++ b/released/packages/coq-equations/coq-equations.1.2+8.9/opam
@@ -4,7 +4,7 @@ dev-repo: "git://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.1+8.10/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.1+8.10/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.1+8.11/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.1+8.11/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.11"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.1+8.9/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.1+8.9/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.2+8.11/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.2+8.11/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.11"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.3+8.11/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.3+8.11/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.11"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.3+8.12/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.3+8.12/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.12"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.3+8.13/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.3+8.13/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.4+8.11/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.4+8.11/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.11"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.4+8.12/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.4+8.12/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git#8.12"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2.4+8.13/opam
+++ b/released/packages/coq-equations/coq-equations.1.2.4+8.13/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.2~beta+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.2~beta+8.8/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.2~beta+8.9/opam
+++ b/released/packages/coq-equations/coq-equations.1.2~beta+8.9/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]
   [make "-j%{jobs}%"]

--- a/released/packages/coq-equations/coq-equations.1.2~beta2+8.8/opam
+++ b/released/packages/coq-equations/coq-equations.1.2~beta2+8.8/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]

--- a/released/packages/coq-equations/coq-equations.1.2~beta2+8.9/opam
+++ b/released/packages/coq-equations/coq-equations.1.2~beta2+8.9/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL 2.1"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 build: [
   ["coq_makefile" "-f" "_CoqProject" "-o" "Makefile"]

--- a/released/packages/coq-equations/coq-equations.1.3+8.13/opam
+++ b/released/packages/coq-equations/coq-equations.1.3+8.13/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.3+8.14/opam
+++ b/released/packages/coq-equations/coq-equations.1.3+8.14/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.3+8.15/opam
+++ b/released/packages/coq-equations/coq-equations.1.3+8.15/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.3+8.16/opam
+++ b/released/packages/coq-equations/coq-equations.1.3+8.16/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.3~beta1+8.13/opam
+++ b/released/packages/coq-equations/coq-equations.1.3~beta1+8.13/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the

--- a/released/packages/coq-equations/coq-equations.1.3~beta2+8.13/opam
+++ b/released/packages/coq-equations/coq-equations.1.3~beta2+8.13/opam
@@ -4,7 +4,7 @@ dev-repo: "git+https://github.com/mattam82/Coq-Equations.git"
 maintainer: "matthieu.sozeau@inria.fr"
 homepage: "https://mattam82.github.io/Coq-Equations"
 bug-reports: "https://github.com/mattam82/Coq-Equations/issues"
-license: "LGPL-2.1-or-later"
+license: "LGPL-2.1-only"
 synopsis: "A function definition package for Coq"
 description: """
 Equations is a function definition plugin for Coq, that allows the


### PR DESCRIPTION
This is to have `license: "LGPL-2.1-only"` consistently for Equations packages everywhere as per https://github.com/mattam82/Coq-Equations/issues/496 and https://github.com/mattam82/Coq-Equations/pull/510

cc: @mattam82  @MSoegtropIMC 