### PR TITLE
add coqide-server as a dependency of coq.dev

### DIFF
--- a/core-dev/packages/coq/coq.dev/opam
+++ b/core-dev/packages/coq/coq.dev/opam
@@ -23,6 +23,7 @@ depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
   "coq-stdlib" {= version}
+  "coqide-server" {= version}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
To synchronize with https://github.com/coq/coq/pull/16549

This makes VsCoq work out-of-the-box again.

cc: @ejgallego @mattam82 