### PR TITLE
 coq-fiat-crypto-with-bedrock also conflicts with rupicola and bedrock2

### DIFF
--- a/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
+++ b/extra-dev/packages/coq-fiat-crypto-with-bedrock/coq-fiat-crypto-with-bedrock.dev/opam
@@ -25,6 +25,8 @@ depends: [
 conflict-class: [
   "coq-fiat-crypto"
   "coq-coqutil"
+  "coq-bedrock2"
+  "coq-rupicola"
 ]
 dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
 synopsis: "Cryptographic Primitive Code Generation by Fiat."


### PR DESCRIPTION
I probably have to add these conflict-classes to those packages as well