### PR TITLE
coq-metacoq-template: Fix line ending issues with generated code on Windows

### DIFF
--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/files/0001-Fix-line-ending-issues-with-generated-code-on-Window.patch
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/files/0001-Fix-line-ending-issues-with-generated-code-on-Window.patch
@@ -1,0 +1,29 @@
+From 838930ef5983c0e19bd9e12ddb5b12cf5b367c8e Mon Sep 17 00:00:00 2001
+From: Michael Soegtrop <7895506+MSoegtropIMC@users.noreply.github.com>
+Date: Fri, 30 Sep 2022 09:15:08 +0200
+Subject: [PATCH] Fix line ending issues with generated code on Windows
+
+---
+ template-coq/update_plugin.sh | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/template-coq/update_plugin.sh b/template-coq/update_plugin.sh
+index 9b3d2a5f..1842cfde 100755
+--- a/template-coq/update_plugin.sh
++++ b/template-coq/update_plugin.sh
+@@ -12,6 +12,12 @@ then
+     echo "Renaming files to camelCase"
+     (cd gen-src; ./to-lower.sh)
+     rm -f gen-src/*.d gen-src/*.cm*
++    echo "Prepare line endings for patching (for Windows)"
++    for f in gen-src/*.ml*
++    do
++      tr -d '\r' < "$f" > tmp
++      mv -f tmp $f
++    done
+     # Fix an extraction bug: wrong type annotation on eq_equivalence
+     patch -N -p0 < extraction.patch
+     patch -N -p0 < specFloat.patch
+-- 
+2.37.3
+

--- a/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/opam
+++ b/released/packages/coq-metacoq-template/coq-metacoq-template.1.1+8.16/opam
@@ -18,6 +18,9 @@ authors: ["Abhishek Anand <aa755@cs.cornell.edu>"
           "Théo Winterhalter <theo.winterhalter@inria.fr>"
 ]
 license: "MIT"
+patches: [
+  "0001-Fix-line-ending-issues-with-generated-code-on-Window.patch"
+]
 build: [
   ["bash" "./configure.sh"]
   [make "-j" "%{jobs}%" "template-coq"]


### PR DESCRIPTION
This PR adds as opam patch a fix for MetaCoq for Windows.

It is agreed on with the maintainers [here](https://github.com/MetaCoq/metacoq/pull/765) to handle this fix as opam level patch to the existing tag.

@mattam82 : FYI
