### PR TITLE
Release coq-fiat-crypto.0.0.15 for coq platform

### DIFF
--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.15/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.15/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind" {build}
   "coq" {>= "8.15~"}
   "coq-coqprime" {>= "1.2.0"}
-  "coq-rewriter" {= "0.0.5"}
+  "coq-rewriter" {= "0.0.6"}
   "coq-rupicola" {= "0.0.5"}
   "coq-bedrock2-compiler" {= "0.0.2"}
 ]

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.15/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.15/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "coq" "standalone-ocaml"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build & >= "4.08~"}
+  "ocamlfind" {build}
+  "coq" {>= "8.15~"}
+  "coq-coqprime" {>= "1.2.0"}
+  "coq-rewriter" {= "0.0.5"}
+  "coq-rupicola" {= "0.0.5"}
+  "coq-bedrock2-compiler" {= "0.0.2"}
+]
+conflict-class: [
+  "coq-fiat-crypto"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis: "Cryptographic Primitive Code Generation by Fiat"
+description: """
+Coq code and proofs for a command-line binary that can synthesize proven-correct
+big-integer modular field arithmetic operations for cryptography.
+Target languages include C, Rust, Zig, Go, and bedrock2.
+"""
+tags: ["logpath:Crypto"]
+url {
+  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.0.15.tar.gz"
+  checksum: "sha512=0f761a739ca97dff99792e766516e122ee141670f3a28eaca2735f8a7fc6d924e16dccff2cf18b362c44e3cff7f73e407d2b8b33f7786cac96a9c425cca11b8e"
+}

--- a/released/packages/coq-rewriter/coq-rewriter.0.0.6/opam
+++ b/released/packages/coq-rewriter/coq-rewriter.0.0.6/opam
@@ -20,6 +20,6 @@ dev-repo: "git+https://github.com/mit-plv/rewriter.git"
 synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"
 tags: ["logpath:Rewriter"]
 url {
-  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.5.tar.gz"
-  checksum: "sha512=26652a8d6f292ce24495bb877b12111626b81027d60ab6526c233555bf09df778b438c757c4df1d7cd98db9e79d5d30e0419a1e57b917c05208ecc22bc75a748"
+  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.6.tar.gz"
+  checksum: "sha512=ef79eaddad52c5e4e3eb1a4e10cd5e5aa9b670de35179a65110f21f2d3e4a566e6ae71053dd9a71d494875b1fc9bbcd7361ebac2170d036f7788bb6234e402f5"
 }


### PR DESCRIPTION
Mostly for the Coq Platform (cf https://github.com/coq/platform/issues/178)

On top of #2337