### PR TITLE
Reduce resource consumption for continuous integration.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+stages:
+  - lint
+  - build
+
 image: buildpack-deps:stable-scm
 
 variables:
@@ -25,11 +29,8 @@ before_script:
   - chmod +x /usr/local/bin/opam
   - set -o pipefail
 
-.opam-lint:
-  script:
-    - scripts/opam-coq-list-pr-files | xargs scripts/opam-coq-lint
-
 .opam-build:
+  stage: build
   script: |
     PR=${CI_BUILD_REF_NAME##pr-};
     echo "Github PR number: $PR";
@@ -43,7 +44,11 @@ before_script:
       - log/
     expire_in: 1 week
 
-.opam-json:
+# Json
+json-data:
+  stage: build
+  variables:
+    COMPILER: "4.11.2"
   script: |
     . scripts/opam-coq-setup-root
     mkdir -p log; > log/log.json
@@ -55,28 +60,17 @@ before_script:
     name: "$CI_JOB_NAME"
     paths:
       - coq-packages.json
-    expire_in: 1 year
-
-# Json
-json-data:
-  extends: .opam-json
-  variables:
-    COMPILER: "4.11.2"
+    expire_in: 1 week
 
 # Lint
-opam-lint:4.13.1:
-  extends: .opam-lint
+opam-lint:
+  stage: lint
   variables:
-    COMPILER: "4.13.1"
+    COMPILER: "4.11.2"
+  script:
+    - scripts/opam-coq-list-pr-files | xargs scripts/opam-coq-lint
 
 # Build
-opam-build:4.05.0:
-  extends: .opam-build
-  variables:
-    COMPILER: "4.05.0"
-  except:
-    - web
-
 opam-build:4.07.1:
   extends: .opam-build
   variables:
@@ -84,24 +78,10 @@ opam-build:4.07.1:
   except:
     - web
 
-opam-build:4.09.0:
-  extends: .opam-build
-  variables:
-    COMPILER: "4.09.0"
-  except:
-    - web
-
 opam-build:4.11.2:
   extends: .opam-build
   variables:
     COMPILER: "4.11.2"
-  except:
-    - web
-
-opam-build:4.13.1:
-  extends: .opam-build
-  variables:
-    COMPILER: "4.13.1"
   except:
     - web
 

--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.15.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.1.15.0/opam
@@ -10,7 +10,12 @@ build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [ "coq" {>= "8.13" & < "8.17~"} ]
 
-tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]
+tags: [
+  "keyword:small scale reflection"
+  "keyword:mathematical components"
+  "keyword:odd order theorem"
+  "logpath:mathcomp.ssreflect"
+]
 authors: [ "Jeremy Avigad <>" "Andrea Asperti <>" "Stephane Le Roux <>" "Yves Bertot <>" "Laurence Rideau <>" "Enrico Tassi <>" "Ioana Pasca <>" "Georges Gonthier <>" "Sidi Ould Biha <>" "Cyril Cohen <>" "Francois Garillot <>" "Alexey Solovyev <>" "Russell O'Connor <>" "Laurent Théry <>" "Assia Mahboubi <>" ]
 
 synopsis: "Small Scale Reflection"

--- a/scripts/opam-coq-lint
+++ b/scripts/opam-coq-lint
@@ -9,7 +9,7 @@ while [ ! -z "$1" ]; do
   */opam)
     echo Linting $1
     # 21: incorrect opam version
-    opam lint --warn=-21 $1
+    opam lint --warn=-21 --check-upstream $1
     echo
   ;;
   *)


### PR DESCRIPTION
This commit splits the setup into two stages. During the first stage, only `opam lint` is run, and `--check-upstream` is passed to it. Indeed, there is no point in starting a bunch of runners if the opam files are broken and/or the upstream tarball is not available.

The traditional build happens during second stage. This commit removes half of the tested OCaml compilers. The remaining ones are 4.07.1, 4.11.2, 4.14.0, and any.

Finally, the json artifact is set to expire after one week rather than one year. Since the one corresponding to the top of master is kept indefinitely, there is no point in keeping the other artifacts around for a long time.