### PR TITLE
CertiCoq 0.9 beta release for Coq 8.14

### DIFF
--- a/released/packages/coq-certicoq/coq-certicoq.0.9~beta+8.14/opam
+++ b/released/packages/coq-certicoq/coq-certicoq.0.9~beta+8.14/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "The CertiCoq Team"
+homepage: "https://certicoq.org/"
+dev-repo: "git+https://github.com/CertiCoq/certicoq"
+bug-reports: "https://github.com/CertiCoq/certicoq/issues"
+authors: ["Andrew Appel"
+          "Yannick Forster"
+          "Anvay Grover"
+          "Joomy Korkut"
+          "John Li"
+          "Zoe Paraskevopoulou"
+          "Matthieu Sozeau"
+          "Matthew Weaver"
+          "Abhishek Anand"
+          "Greg Morrisett"
+          "Randy Pollack"
+          "Olivier Savary Belanger"
+  ]
+license: "MIT"
+build: [
+  [make "all"]
+  [make "plugins"]
+  [make "bootstrap"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.14" & < "8.15~"}
+  "coq-compcert" {= "3.11"}
+  "coq-equations" {= "1.3+8.14"}
+  "coq-metacoq-erasure" {>= "1.1.1+8.14" }
+  "coq-ext-lib" {>= "0.11.5"}
+]
+
+synopsis: "A Verified Compiler for Gallina, Written in Gallina "
+url {
+  src: "https://github.com/CertiCoq/certicoq/archive/refs/tags/v0.9-beta.tar.gz"
+  checksum: "sha512=dd5269d4666cdf7410e828472584ca59bf62729c9ac9ad47fb654da5723d7d16e5b27325aa89086f880c13890a62701af40f8719889dc7be2e522aba413b14e1"
+}


### PR DESCRIPTION
Depends on PR #2345 