### PR TITLE
bump Coq lower bound for vst-zlist due to build errors

### DIFF
--- a/released/packages/coq-vst-zlist/coq-vst-zlist.2.11/opam
+++ b/released/packages/coq-vst-zlist/coq-vst-zlist.2.11/opam
@@ -16,7 +16,7 @@ build: [
 run-test: []
 install: [make "-C" "zlist" "install"]
 depends: [
-  "coq" {>= "8.11.0"}
+  "coq" {>= "8.12"}
 ]
 url {
   src: "https://github.com/PrincetonUniversity/VST/archive/refs/tags/v2.11.tar.gz"


### PR DESCRIPTION
To fix https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.6/released/8.11.0/vst-zlist/2.11.html