### PR TITLE
modernize coq-sudoku.8.16.0 package

### DIFF
--- a/released/packages/coq-sudoku/coq-sudoku.8.16.0/opam
+++ b/released/packages/coq-sudoku/coq-sudoku.8.16.0/opam
@@ -1,32 +1,35 @@
 opam-version: "2.0"
-maintainer: "Hugo.Herbelin@inria.fr"
-homepage: "https://github.com/ftp://ftp-sop.inria.fr/lemme/Laurent.Thery/Sudoku.zip"
-license: "LGPL 2.1"
-build: [make "-j%{jobs}%"]
-install: [make "install"]
-remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Sudoku"]
-depends: [
-  "dune" {>= "2.5"}
-  "coq" {>= "8.12" & < "8.17~"}
-]
-tags: [
-  "keyword: sudoku"
-  "keyword: puzzles"
-  "keyword: Davis-Putnam"
-  "category: Miscellaneous/Logical Puzzles and Entertainment"
-  "date: 2006-02"
-]
-authors: [
-  "Laurent Théry <thery@sophia.inria.fr> [http://www-sop.inria.fr/lemme/personnel/Laurent.Thery/me.html]"
-]
-bug-reports: "https://github.com/coq-community/sudoku/issues"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/coq-community/sudoku"
 dev-repo: "git+https://github.com/coq-community/sudoku.git"
-synopsis: "A certified Sudoku solver"
+bug-reports: "https://github.com/coq-community/sudoku/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Sudoku solver certified in Coq"
 description: """
 A formalisation of Sudoku in Coq. It implements a naive
-Davis-Putnam procedure to solve sudokus."""
-flags: light-uninstall
+Davis-Putnam procedure to solve Sudokus."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.12" & < "8.17~"}
+]
+
+tags: [
+  "category:Miscellaneous/Logical Puzzles and Entertainment"
+  "keyword:puzzles"
+  "keyword:Davis-Putnam"
+  "keyword:sudoku"
+  "logpath:Sudoku"
+  "date:2022-10-19"
+]
+authors: [
+  "Laurent Théry"
+]
+
 url {
   src: "https://github.com/coq-community/sudoku/archive/refs/tags/v8.16.0.tar.gz"
-  checksum: "md5=21ee3e2aa3c55825beefea0397088837"
+  checksum: "sha512=4d3c9f25218d48dd68df3db19d2b84f0d9f95eb96a3206627095b76cbdfb4a36a7492067743882769f0afd4fc73b935ebf4fa4301af04ba3f75aaaeea898c2d8"
 }


### PR DESCRIPTION
This now uses the templated opam boilerplate.

cc: @thery 