### PR TITLE
fix mca 0.4.0, 0.5.0, 0.5.1, 0.5.2

### DIFF
--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.4.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field"
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (>= "1.2.0") }
+  "coq-hierarchy-builder" { (= "1.2.0") }
 ]
 
 tags: [
@@ -47,6 +47,6 @@ authors: [
   "Laurent Théry"
 ]
 url {
-  http: "https://github.com/math-comp/analysis/archive/0.4.0.tar.gz"
+  src: "https://github.com/math-comp/analysis/archive/0.4.0.tar.gz"
   checksum: "sha512=ca1489fc86a3593803612d78e16f8d236758206cfdb5d1b85a1b8a290377ad7beaa22fb10c77a46846934d1ffc9a0eddc71c08bd52f2cd96bb33cb5a3d54b483"
 }

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (>= "1.2.0") }
+  "coq-hierarchy-builder" { (= "1.2.0") }
 ]
 
 tags: [
@@ -48,6 +48,6 @@ authors: [
   "Laurent Théry"
 ]
 url {
-  http: "https://github.com/math-comp/analysis/archive/0.5.0.tar.gz"
+  src: "https://github.com/math-comp/analysis/archive/0.5.0.tar.gz"
   checksum: "sha512=57e5ec7e71338de65f1a07a9036c6d19a3584f757be76e8375a2f984d1fd05265928113a57c44d942e0ef9be7753299240763052d60661cb59551f7abb33b1e8"
 }

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.1/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (>= "1.2.0") }
+  "coq-hierarchy-builder" { (= "1.2.0") }
 ]
 
 tags: [
@@ -47,6 +47,6 @@ authors: [
   "Laurent Théry"
 ]
 url {
-  http: "https://github.com/math-comp/analysis/archive/0.5.1.tar.gz"
+  src: "https://github.com/math-comp/analysis/archive/0.5.1.tar.gz"
   checksum: "sha512=668bdc47114376529d9aa9b355afbbf74dedbdb8cf372433d11f72251265604bd83fbf8c5a6c5d6868f7e7c5f113e14c84df330f01a8f678c95294621148fab8"
 }

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.2/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.2/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field"
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (>= "1.2.0") }
+  "coq-hierarchy-builder" { (= "1.2.0") }
 ]
 
 tags: [


### PR DESCRIPTION
same fix as in PR #2367 (errors reported on Zulip on October 23)