### PR TITLE
allow HB 1.2.1 for mathcomp-analysis 0.5.2 and below

### DIFF
--- a/released/packages/coq-infotheo/coq-infotheo.0.3.7/opam
+++ b/released/packages/coq-infotheo/coq-infotheo.0.3.7/opam
@@ -24,7 +24,6 @@ depends: [
   "coq-mathcomp-solvable" { (>= "1.13.0" & < "1.15~") | (= "dev")  }
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev")  }
   "coq-mathcomp-analysis" { (>= "0.4.0") & (<= "0.5.1")}
-  "coq-hierarchy-builder" { <= "1.2.0" }
 ]
 
 tags: [

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.4.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field"
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (= "1.2.0") }
+  "coq-hierarchy-builder" { (< "1.3.0") }
 ]
 
 tags: [

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.0/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (= "1.2.0") }
+  "coq-hierarchy-builder" { (< "1.3.0") }
 ]
 
 tags: [

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.1/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field" { (>= "1.13.0" & < "1.15~") | (= "dev") }
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (= "1.2.0") }
+  "coq-hierarchy-builder" { (< "1.3.0") }
 ]
 
 tags: [

--- a/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.2/opam
+++ b/released/packages/coq-mathcomp-analysis/coq-mathcomp-analysis.0.5.2/opam
@@ -22,7 +22,7 @@ depends: [
   "coq-mathcomp-field"
   "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0") }
-  "coq-hierarchy-builder" { (= "1.2.0") }
+  "coq-hierarchy-builder" { (< "1.3.0") }
 ]
 
 tags: [


### PR DESCRIPTION
This should allow the Platform CI to work as expected again.

cc: @MSoegtropIMC @affeldt-aist 