### PR TITLE
coq-vst.2.10 is incompatible with Coq 8.12

### DIFF
--- a/released/packages/coq-vst/coq-vst.2.10/opam
+++ b/released/packages/coq-vst/coq-vst.2.10/opam
@@ -37,7 +37,7 @@ run-test: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.12" & < "8.17~"}
+  "coq" {>= "8.13" & < "8.17~"}
   "coq-compcert" {= "3.11"}
   "coq-flocq" {>= "4.1.0"}
 ]


### PR DESCRIPTION
Per https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.6/released/8.12.1/vst/2.10.html