### PR TITLE
Package coq-kruskal-trees.1.0

### DIFF
--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem"
+description: """
+   Several implementations for roses trees are proposed with proper induction principles. 
+   Sons of the root are collected into dependent vectors, vectors, lists, etc.
+"""  
+maintainer: ["Dominique Larchey-Wendling (https://github.com/DmxLarchey)" "Jerome Hugues (https://github.com/jjhugues)"] 
+authors: "Dominique Larchey-Wendling (https://github.com/DmxLarchey)"
+license: "CeCILL-B"
+homepage: "https://github.com/DmxLarchey/Kruskal-Trees/"
+bug-reports: "https://github.com/DmxLarchey/Kruskal-Trees/issues"
+dev-repo: "git+https://github.com:DmxLarchey/Kruskal-Trees/"
+
+build: [
+  [ make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+depends: [
+  "coq" {dev & >= "8.14"}
+]
+url {
+  src: "https://github.com/DmxLarchey/Kruskal-Trees/archive/1.0.tar.gz"
+  checksum: [
+    "md5=f796c38e7135572042830784d99cfcfc"
+    "sha512=10a0935933e68795966136c265c7929e3359e640c2eef7562b4d2fe688356ac8ff97da0a75e178b442b7507fb0d37640f8faf700d02c851c6f9905c79c471523"
+  ]
+}
+
+#url { git: "https://github.com/DmxLarchey/Kruskal-Trees.git" }

--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
@@ -20,7 +20,6 @@ install: [
 
 depends: [
   "ocaml"
-  "ocamlfind"
   "coq" {>= "8.14" & < "8.17~" }
 ]
 url {

--- a/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
+++ b/released/packages/coq-kruskal-trees/coq-kruskal-trees.1.0/opam
@@ -19,7 +19,9 @@ install: [
 ]
 
 depends: [
-  "coq" {dev & >= "8.14"}
+  "ocaml"
+  "ocamlfind"
+  "coq" {>= "8.14" & < "8.17~" }
 ]
 url {
   src: "https://github.com/DmxLarchey/Kruskal-Trees/archive/1.0.tar.gz"


### PR DESCRIPTION
### `coq-kruskal-trees.1.0`
Coq library for manipulating rose trees (ie finitely branching) as used in proof of Kruskal's tree theorem
Several implementations for roses trees are proposed with proper induction principles. 
   Sons of the root are collected into dependent vectors, vectors, lists, etc.



---
* Homepage: https://github.com/DmxLarchey/Kruskal-Trees/
* Source repo: git+https://github.com:DmxLarchey/Kruskal-Trees/
* Bug tracker: https://github.com/DmxLarchey/Kruskal-Trees/issues

---
:camel: Pull-request generated by opam-publish v2.1.0