### PR TITLE
Release coq-formalv packages, versions 1.0.1 and 1.1.0

### DIFF
--- a/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.0.1/opam
+++ b/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Tactics to automatically prove Boolean goals involving Uint63/Sint63 variables" # One-line description
+description: """
+FV Check Range provides tactics to automatically prove Boolean goals
+involving 1, 2 or 3 Uint63.int/Sint63.int bounded variables through
+brute-force computation.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://gitlab.com/formalv/formalv/-/jobs/3104990375/artifacts/file/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:automation"
+  "keyword:primitive integers"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.14" & < "8.16~"}
+  "coq-mathcomp-algebra" {>= "1.12" & < "1.15~" }
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.15~" }
+  "coq-formalv-prim63_mathcomp" {= version}
+]
+
+build: [
+  [make "-C" "theories/check_range" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/check_range" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.0.1/formalv-1.0.1.tar.gz"
+  checksum: "sha256=d00453d3f553c988df1ea1fd3a33413af03a2e21952b75b0c47f9290ae31b3bc"
+}

--- a/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.1.0/opam
+++ b/released/packages/coq-formalv-check_range/coq-formalv-check_range.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Tactics to automatically prove Boolean goals involving Uint63/Sint63 variables" # One-line description
+description: """
+FV Check Range provides tactics to automatically prove Boolean goals
+involving 1, 2 or 3 Uint63.int/Sint63.int bounded variables through
+brute-force computation.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/-/formalv/-/jobs/3323865053/artifacts/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:automation"
+  "keyword:primitive integers"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.15" & < "8.17~"}
+  "coq-mathcomp-algebra" {>= "1.15" & < "1.16~" }
+  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.16~" }
+  "coq-formalv-prim63_mathcomp" {= version}
+]
+
+build: [
+  [make "-C" "theories/check_range" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/check_range" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.1.0/formalv-1.1.0.tar.gz"
+  checksum: "sha256=b571d859f20038aa10c51d863e8a0cce92646fc926ef706aa3d2d801a92ddac5"
+}

--- a/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.0.1/opam
+++ b/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Refinements from MathComp nat and int to Coq primitive integers Uint63/Sint63" # One-line description
+description: """
+FV Prim63 to MathComp provides conversions from the Coq primitive integers
+Uint63 and Sint63 to the MathComp natural and integer numbers nat and int,
+and vice versa, as well as lemmas to rewrite between their respective
+operations.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://gitlab.com/formalv/formalv/-/jobs/3104990375/artifacts/file/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:refinement"
+  "keyword:primitive integers"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.14" & < "8.16~"}
+  "coq-mathcomp-algebra" {>= "1.12" & < "1.15~" }
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.15~" }
+]
+
+build: [
+  [make "-C" "theories/prim63_mathcomp" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/prim63_mathcomp" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.0.1/formalv-1.0.1.tar.gz"
+  checksum: "sha256=d00453d3f553c988df1ea1fd3a33413af03a2e21952b75b0c47f9290ae31b3bc"
+}

--- a/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.1.0/opam
+++ b/released/packages/coq-formalv-prim63_mathcomp/coq-formalv-prim63_mathcomp.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Refinements from MathComp nat and int to Coq primitive integers Uint63/Sint63" # One-line description
+description: """
+FV Prim63 to MathComp provides conversions from the Coq primitive integers
+Uint63 and Sint63 to the MathComp natural and integer numbers nat and int,
+and vice versa, as well as lemmas to rewrite between their respective
+operations.
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/-/formalv/-/jobs/3323865053/artifacts/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:refinement"
+  "keyword:primitive integers"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.15" & < "8.17~"}
+  "coq-mathcomp-algebra" {>= "1.15" & < "1.16~" }
+  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.16~" }
+]
+
+build: [
+  [make "-C" "theories/prim63_mathcomp" "-j" "%{jobs}%"]
+]
+install: [
+  [make "-C" "theories/prim63_mathcomp" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.1.0/formalv-1.1.0.tar.gz"
+  checksum: "sha256=b571d859f20038aa10c51d863e8a0cce92646fc926ef706aa3d2d801a92ddac5"
+}

--- a/released/packages/coq-formalv-time/coq-formalv-time.1.0.1/opam
+++ b/released/packages/coq-formalv-time/coq-formalv-time.1.0.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A Coq library for time and date arithmetic according to the UTC standard with leap seconds" # One-line description
+description: """
+FV Time is a library for managing conversions between time formats (UTC and
+timestamps), as well as commonly used functions for time arithmetic. As a
+library for time conversions, its novelty is the implementation of leap
+seconds (which are part of the UTC standard but usually not implemented in
+commercial libraries).
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://gitlab.com/formalv/formalv/-/jobs/3104990375/artifacts/file/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:time"
+  "keyword:date"
+  "keyword:timestamp"
+  "keyword:coq formalization"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.14" & < "8.16~"}
+  "coq-mathcomp-algebra" {>= "1.12" & < "1.15~" }
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.15~" }
+  "coq-formalv-prim63_mathcomp" {= version}
+  "coq-formalv-check_range" {= version}
+]
+
+build: [
+  [make "-C" "theories/time" "-j" "%{jobs}%"]
+]
+
+install: [
+  [make "-C" "theories/time" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.0.1/formalv-1.0.1.tar.gz"
+  checksum: "sha256=d00453d3f553c988df1ea1fd3a33413af03a2e21952b75b0c47f9290ae31b3bc"
+}

--- a/released/packages/coq-formalv-time/coq-formalv-time.1.1.0/opam
+++ b/released/packages/coq-formalv-time/coq-formalv-time.1.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A Coq library for time and date arithmetic according to the UTC standard with leap seconds" # One-line description
+description: """
+FV Time is a library for managing conversions between time formats (UTC and
+timestamps), as well as commonly used functions for time arithmetic. As a
+library for time conversions, its novelty is the implementation of leap
+seconds (which are part of the UTC standard but usually not implemented in
+commercial libraries).
+""" # Longer description, can span several lines
+
+homepage: "https://gitlab.com/formalv/formalv"
+dev-repo: "git+https://gitlab.com/formalv/formalv"
+bug-reports: "https://gitlab.com/formalv/formalv/-/issues"
+doc: "https://formalv.gitlab.io/-/formalv/-/jobs/3323865053/artifacts/public/index.html"
+maintainer: "Mireia González Bedmar <mireia.gbedmar@formalv.com>"
+
+tags: [
+  "keyword:time"
+  "keyword:date"
+  "keyword:timestamp"
+  "keyword:coq formalization"
+  "logpath:formalv"
+]
+
+authors: [
+  "Ana de Almeida Borges"
+  "Quim Casals Buñuel"
+  "Juan Conejero Rodriguez"
+  "Mireia González Bedmar"
+  "Eduardo Hermo Reyes"
+]
+
+license: "PolyForm Noncommercial License 1.0.0" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.15" & < "8.17~"}
+  "coq-mathcomp-algebra" {>= "1.15" & < "1.16~" }
+  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.16~" }
+  "coq-formalv-prim63_mathcomp" {= version}
+  "coq-formalv-check_range" {= version}
+]
+
+build: [
+  [make "-C" "theories/time" "-j" "%{jobs}%"]
+]
+
+install: [
+  [make "-C" "theories/time" "install"]
+]
+
+url {
+  src: "https://gitlab.com/formalv/formalv/-/archive/1.1.0/formalv-1.1.0.tar.gz"
+  checksum: "sha256=b571d859f20038aa10c51d863e8a0cce92646fc926ef706aa3d2d801a92ddac5"
+}


### PR DESCRIPTION
See [home page](https://formalv.gitlab.io/formalv/) or the [FormalV repository](https://gitlab.com/formalv/formalv).

Package list:
- coq-formalv-time
- coq-formalv-check_range
- coq-formalv-prim63_mathcomp