### PR TITLE
bonak: require coq 8.16.1

### DIFF
--- a/extra-dev/packages/bonak/bonak.dev/opam
+++ b/extra-dev/packages/bonak/bonak.dev/opam
@@ -1,17 +1,16 @@
 opam-version: "2.0"
 name: "bonak"
-version: "master"
-synopsis: "An indexed construction of truncated n-types"
+synopsis: "An indexed construction of semi-simplicial and semi-cubical types"
 maintainer: "Ramkumar Ramachandra <r@artagnon.com>"
 authors: [ "Ramkumar Ramachandra <r@artagnon.com>"
-           "Hugo Herbelin <hugo.herbelin@inria.fr>" ]
+          "Hugo Herbelin <hugo.herbelin@inria.fr>" ]
 license: "MIT"
 homepage: "https://github.com/artagnon/bonak"
 bug-reports: "https://github.com/artagnon/bonak/issues"
 dev-repo: "git+https://github.com/artagnon/bonak"
 depends: [
-  "coq"  { >= "8.15.1" & < "8.16" }
-  "dune" { >= "2.9.1" }
+  "coq"  { >= "8.16.1" }
+  "dune" { >= "3.6.0" }
 ]
 build: [
   ["dune" "build"]


### PR DESCRIPTION
Due to a regression in coq.8.16.0, bonak failed to build. This bug has since been reported and fixed in 8.16.1.