### PR TITLE
Coq Ott library compatibility fixes

### DIFF
--- a/extra-dev/packages/coq-ott/coq-ott.dev/opam
+++ b/extra-dev/packages/coq-ott/coq-ott.dev/opam
@@ -17,7 +17,7 @@ this library.
 build: [make "-j%{jobs}%" "-C" "coq"]
 install: [make "-C" "coq" "install"]
 depends: [
-  "coq" {(>= "8.5" & < "8.13~") | (= "dev")}
+  "coq" {>= "8.5"}
 ]
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"

--- a/released/packages/coq-ott/coq-ott.0.32/opam
+++ b/released/packages/coq-ott/coq-ott.0.32/opam
@@ -17,7 +17,7 @@ this library.
 build: [make "-j%{jobs}%" "-C" "coq"]
 install: [make "-C" "coq" "install"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.5" & < "8.17"}
 ]
 conflicts: [
   "ott" { != version }


### PR DESCRIPTION
cc: @MSoegtropIMC 

The fix to make the Ott repo compatible with Coq 8.17 and beyond was [trivial](https://github.com/ott-lang/ott/commit/c6b0c2c0843a36a3e19acd6c20138257cb412cf9).

If there is no new Ott release for the next Platform, we can add a patch in opam for `coq-ott.0.32`. However, my hope is that there will soon be an Ott release that is compatible with both OCaml 5 and Coq 8.17.