### PR TITLE
Change VST license to BSD-2-Clause in spdx format

### DIFF
--- a/released/packages/coq-vst/coq-vst.2.11/opam
+++ b/released/packages/coq-vst/coq-vst.2.11/opam
@@ -20,7 +20,7 @@ maintainer: "VST team"
 homepage: "http://vst.cs.princeton.edu/"
 dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
-license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+license: "BSD-2-Clause"
 
 build: [
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=64"]


### PR DESCRIPTION
It was already the case that the VST opam distribution was licensed by BSD-2-Clause, as you can see in the VST repo in the file LICENSE-OPAM which has existed for some time now.
   Other parts of the VST repo, which are not distributed in the opam distribution, may have other licenses, as described in the VST repo in file LICENSE.