### PR TITLE
Change VST license to BSD-2-Clause

### DIFF
--- a/released/packages/coq-vst-32/coq-vst-32.2.11/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.11/opam
@@ -20,7 +20,7 @@ maintainer: "VST team"
 homepage: "http://vst.cs.princeton.edu/"
 dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
 bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
-license: "https://raw.githubusercontent.com/PrincetonUniversity/VST/master/LICENSE"
+license: "BSD-2-Clause"
 
 build: [
   [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]


### PR DESCRIPTION
See also p.r. #2402 which contains this commit comment, which also applies here:

It was already the case that the VST opam distribution was licensed by BSD-2-Clause, as you can see in the VST repo in the file LICENSE-OPAM which has existed for some time now. Other parts of the VST repo, which are not distributed in the opam distribution, may have other licenses, as described in the VST repo in file LICENSE.