### PR TITLE
Interval 4.6.1

### DIFF
--- a/released/packages/coq-interval/coq-interval.4.6.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8"}
+  "coq" {>= "8.12" & < "8.17~"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
   "coq-mathcomp-ssreflect" {>= "1.6"}

--- a/released/packages/coq-interval/coq-interval.4.6.1/opam
+++ b/released/packages/coq-interval/coq-interval.4.6.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["./remake" "install"]
 depends: [
-  "coq" {>= "8.8" & < "8.17~"}
+  "coq" {>= "8.8"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
   "coq-mathcomp-ssreflect" {>= "1.6"}
@@ -28,7 +28,7 @@ tags: [
   "category:Mathematics/Real Calculus and Topology"
   "category:Computer Science/Decision Procedures and Certified Algorithms/Decision procedures"
   "logpath:Interval"
-  "date:2022-08-25"
+  "date:2022-12-06"
 ]
 authors: [
   "Guillaume Melquiond <guillaume.melquiond@inria.fr>"
@@ -38,6 +38,6 @@ authors: [
 ]
 synopsis: "A Coq tactic for proving bounds on real-valued expressions automatically"
 url {
-  src: "https://coqinterval.gitlabpages.inria.fr/releases/interval-4.5.2.tar.gz"
-  checksum: "sha512=74be5915cb242f3a9fecab6a60d33169ddf20a21dd4479258fe869e59d77e212ec08890864d2adfcc9d27c132a9839b50d88e3d8ba8f791adba4dcc3c067b903"
+  src: "https://coqinterval.gitlabpages.inria.fr/releases/interval-4.6.1.tar.gz"
+  checksum: "sha512=2a99099bb3250fa3167f2f8d28772c51ad800a184e1dd4dc27dbc1d9f04b291bc21384da495b873fedb0a3077b33b3744c72cbb471cb8c2e7207fcebeb85d33b"
 }


### PR DESCRIPTION
This pull request also fixes bounds on previous versions.

ci-skip: coq-interval.4.5.2 coq-interval.4.6.0