### PR TITLE
monae.0.4.2 does not support Coq 8.14

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.4.2/opam
+++ b/released/packages/coq-monae/coq-monae.0.4.2/opam
@@ -14,7 +14,7 @@ in several examples of monadic equational reasoning."""
 build: [make "-j%{jobs}%"]
 install: [make "install_full"]
 depends: [
-  "coq" { (>= "8.14" & < "8.17~") | (= "dev") }
+  "coq" { (>= "8.15" & < "8.17~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.13.0" & < "1.16~") | (= "dev")  }
   "coq-mathcomp-fingroup" { (>= "1.13.0" & < "1.16~") | (= "dev")  }
   "coq-mathcomp-algebra" { (>= "1.13.0" & < "1.16~") | (= "dev")  }


### PR DESCRIPTION
As per https://coq-bench.github.io/clean/Linux-x86_64-4.07.1-2.0.6/released/8.14.0/monae/0.4.2.html

cc: @affeldt-aist 