### PR TITLE
adjust recent core-dev Coq packages, including for OCaml 5

### DIFF
--- a/core-dev/packages/coq-core/coq-core.8.17.dev/opam
+++ b/core-dev/packages/coq-core/coq-core.8.17.dev/opam
@@ -33,6 +33,8 @@ depends: [
 ]
 conflicts: [
   "coq"   { < "8.17" }
+  "base-nnp"
+  "ocaml-option-nnpchecker"
 ]
 build: [
   # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219

--- a/core-dev/packages/coq-stdlib/coq-stdlib.8.17.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.8.17.dev/opam
@@ -24,9 +24,6 @@ depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
 ]
-conflicts: [
-  "coq"  { < "8.17" }
-]
 build: [
   # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
   # ["dune" "subst"] {pinned}

--- a/core-dev/packages/coq-stdlib/coq-stdlib.dev/opam
+++ b/core-dev/packages/coq-stdlib/coq-stdlib.dev/opam
@@ -26,9 +26,6 @@ depends: [
   "dune" {>= "2.9"}
   "coq-core" {= version}
 ]
-conflicts: [
-  "coq"  { < "8.17" }
-]
 build: [
   # Requires dune 2.8 due to https://github.com/ocaml/dune/issues/3219
   # ["dune" "subst"] {pinned}


### PR DESCRIPTION
- mark `coq-core.8.17.dev` as incompatible with OCaml 5 (for the time being)
- the conflict with Coq for `coq-stdlib` is superfluous due to existing conflict in  `coq-core`, which is a dependency

cc: @Zimmi48 