### PR TITLE
adjust some Platform package releases on 8.17 compatibility

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.2.0/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.2.0/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.13~"}
+  "coq" {>= "8.13~" & < "8.17"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"

--- a/released/packages/coq-libhyps/coq-libhyps.2.0.6/opam
+++ b/released/packages/coq-libhyps/coq-libhyps.2.0.6/opam
@@ -16,7 +16,7 @@ build: [
 install: [make "install"]
 
 depends: [
-  "coq" {(>= "8.11" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.11" & < "8.18~") | (= "dev")}
 ]
 
 tags: [

--- a/released/packages/coq-record-update/coq-record-update.0.3.0/opam
+++ b/released/packages/coq-record-update/coq-record-update.0.3.0/opam
@@ -16,7 +16,7 @@ simple typeclass that lists out the record fields."""
 build: [make "-j%{jobs}%" "NO_TEST=1"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.18~") | (= "dev")}
 ]
 
 tags: [

--- a/released/packages/coq-simple-io/coq-simple-io.1.8.0/opam
+++ b/released/packages/coq-simple-io/coq-simple-io.1.8.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
-  "coq" {>= "8.11" & < "8.17~"}
+  "coq" {>= "8.11" & < "8.18~"}
   "coq-ext-lib" {>= "0.10.0"}
   "ocamlbuild" {with-test & >= "0.9.0"}
   "cppo" {build & >= "1.6.8"}


### PR DESCRIPTION
- coq-coqprime.1.2.0 is **not** compatible with 8.17+rc1
- coq-record-update.0.3.0 is compatible with 8.17+rc1
- coq-simple-io.1.8.0 is compatible with 8.17+rc1
- coq-libhyps.2.0.6 is compatible with 8.17+rc1