### PR TITLE
release monae 0.4.4

### DIFF
--- a/released/packages/coq-monae/coq-monae.0.4.4/opam
+++ b/released/packages/coq-monae/coq-monae.0.4.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Reynald Affeldt <reynald.affeldt@aist.go.jp>"
+
+homepage: "https://github.com/affeldt-aist/monae"
+dev-repo: "git+https://github.com/affeldt-aist/monae.git"
+bug-reports: "https://github.com/affeldt-aist/monae/issues"
+license: "LGPL-2.1-or-later"
+
+synopsis: "Monads and equational reasoning in Coq"
+description: """
+This Coq library contains a hierarchy of monads with their laws used
+in several examples of monadic equational reasoning."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install_full"]
+depends: [
+  "coq" { (>= "8.15" & < "8.16~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.14.0" & < "1.16~") | (= "dev")  }
+  "coq-mathcomp-fingroup" { (>= "1.14.0" & < "1.16~") | (= "dev")  }
+  "coq-mathcomp-algebra" { (>= "1.14.0" & < "1.16~") | (= "dev")  }
+  "coq-mathcomp-solvable" { (>= "1.14.0" & < "1.16~") | (= "dev")  }
+  "coq-mathcomp-field" { (>= "1.14.0" & < "1.16~") | (= "dev")  }
+  "coq-mathcomp-analysis" { (>= "0.5.4") }
+  "coq-infotheo" { >= "0.5.0" & < "0.6~"}
+  "coq-paramcoq" { >= "1.1.3" & < "1.2~" }
+  "coq-hierarchy-builder" { >= "1.3.0" }
+  "coq-equations" { >= "1.3" & < "1.4~" }
+]
+
+tags: [
+  "keyword:monae"
+  "keyword:effects"
+  "keyword:probability"
+  "keyword:nondeterminism"
+  "logpath:monae"
+  "date:2023-01-03"
+]
+authors: [
+  "Reynald Affeldt"
+  "David Nowak"
+  "Takafumi Saikawa"
+  "Jacques Garrigue"
+  "Ayumu Saito"
+  "Celestine Sauvage"
+  "Kazunari Tanaka"
+]
+url {
+  src: "https://github.com/affeldt-aist/monae/archive/0.4.4.tar.gz"
+  checksum: "sha512=bdd0c8b4325d4d7ac1a4d742c0ad58894cc5cb13850d2b76bae617abdcfe358a7e5cd6e4885d6452074cc3e5768928029f815980bdb2a6349fd48dc19195af11"
+}


### PR DESCRIPTION
When using paramcoq, we write
```coq
Declare ML Module "paramcoq".
```
with Coq 8.15, hence the incompatibility with Coq 8.16 where we need to write
```coq
Declare ML Module "coq-paramcoq.plugin".
```