### PR TITLE
coq-ott.0.32 is incompatible with Coq 8.5.0

### DIFF
--- a/released/packages/coq-ott/coq-ott.0.32/opam
+++ b/released/packages/coq-ott/coq-ott.0.32/opam
@@ -18,7 +18,7 @@ patches: ["locality-warnings.patch"]
 build: [make "-j%{jobs}%" "-C" "coq"]
 install: [make "-C" "coq" "install"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.5.1"}
 ]
 conflicts: [
   "ott" { != version }


### PR DESCRIPTION
per https://coq-bench.github.io/clean/Linux-x86_64-4.04.2-2.0.5/released/8.5.0~camlp4/ott/0.32.html