### PR TITLE
Package coq-matrix.1.0.1

### DIFF
--- a/released/packages/coq-matrix/coq-matrix.1.0.1/opam
+++ b/released/packages/coq-matrix/coq-matrix.1.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Formal matrix theory with multiple implementations in Coq" # One-line description
+description: """
+  Matrix is an important mathematical tool. Although there are at least five matrix 
+  models/libraries in Coq community, the massive verification project involving matrix 
+  are still facing some problems:
+  (1). There havn't a full-feature formal matrix library, because the matrix theory is 
+  complex and need more time to formalize it.
+  (2). Different libraries of these implementations cannot be easily switched at the 
+  later stage of a verification process, because the type of operations and theorems 
+  are different. But some project maybe need more matrix theories while the needed 
+  theorems only avaiable in another libraries.
+
+  Thus, we provide a unified framework for different implementations of formal matrix
+  models, so as to decouple the difference between underlying technologies and 
+  upper-level applications.
+""" # Longer description, can span several lines
+
+homepage: "https://github.com/zhengpushi/CoqMatrix"
+dev-repo: "git+https://github.com/zhengpushi/CoqMatrix.git"
+bug-reports: "https://github.com/zhengpushi/CoqMatrix/issues"
+doc: "https://zhengpushi.github.io/coq-matrix.html"
+maintainer: "zhengpushi@nuaa.edu.cn"
+authors: [
+  "ZhengPu Shi"
+]
+license: "MIT" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.13"}
+  "coq-mathcomp-algebra" {>="1.15.0"}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+  url {
+  src: "https://github.com/zhengpushi/CoqMatrix/archive/refs/tags/1.0.1.tar.gz"
+  checksum: "sha256=e114edfd6b1ce8a4f8711da54bb249a99b2da26371d4aeed0468895a4c547004"
+}
+
+tags: [
+  "keyword:matrix"
+  "category:Mathematics/Algebra"
+  "date:2023-01-20"
+  "logpath:CoqMatrix"
+]


### PR DESCRIPTION
Sorry, coq-matrix.1.0.0 has a build problem. Now, I have fixed this problem and want to publish coq-matrix.1.0.1 to the community.
Change Log
1. remove the dependency for CoqExt library, which is charged by myself.
2. add dependency of coq-mathcomp-algebra, >=8.15.0