### PR TITLE
`coq-io-list` is not compatible with coq 8.16

### DIFF
--- a/released/packages/coq-io-list/coq-io-list.1.0.0/opam
+++ b/released/packages/coq-io-list/coq-io-list.1.0.0/opam
@@ -15,7 +15,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/List.vo"]
 depends: [
   "ocaml"
-  "coq" {>= "8.4pl4"}
+  "coq" {>= "8.4pl4" & < "8.16~"}
   "coq-io" {>= "3.0.0" & < "3.1.0"}
 ]
 synopsis: "Generic functions on lists with effects"

--- a/released/packages/coq-io-list/coq-io-list.1.1.0/opam
+++ b/released/packages/coq-io-list/coq-io-list.1.1.0/opam
@@ -15,7 +15,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Io/List.vo"]
 depends: [
   "ocaml"
-  "coq" {>= "8.4pl4"}
+  "coq" {>= "8.4pl4" & < "8.16~"}
   "coq-io" {>= "3.1.0" & < "4"}
 ]
 synopsis: "Generic functions on lists with effects"


### PR DESCRIPTION
Note: Not my library.

Note2: This library is deprecated anyway (merged into `coq-io`).