### PR TITLE
`coq-goedel` is not compatible with coq 8.16

### DIFF
--- a/released/packages/coq-goedel/coq-goedel.8.13.0/opam
+++ b/released/packages/coq-goedel/coq-goedel.8.13.0/opam
@@ -16,7 +16,7 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.11" & < "8.17~"}
-  "coq-hydra-battles" {>= "0.4"}
+  "coq-hydra-battles" {>= "0.4" & <= "0.9"}
   "coq-pocklington" {>= "8.12"}
 ]
 


### PR DESCRIPTION
Note: Not my package.

The previous constraint was `< 8.17` and it is possible that in the past this was possible while installing the `dev` version of `coq-hydra-battles`. However, the current `dev` version of hydra-battles is no longer compatible with goedel. The non-dev versions only support up to 8.16.

And in any case, `coq-goedel` has been  deprecated andmerged into `coq-hydra-batlles` anyway...