### PR TITLE
`coq-mathcomp-algebra-tactics` conflicts with `coq-mathcomp-word.2.0`

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.1.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.1.0/opam
@@ -24,6 +24,7 @@ depends: [
   "coq-mathcomp-zify" {(>= "1.1.0")}
   "coq-elpi" {(>= "1.10.1")}
 ]
+conflicts: [ "coq-mathcomp-word" { = "2.0" } ]
 
 tags: [
   "logpath:mathcomp.algebra_tactics"

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.2.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.2.0/opam
@@ -24,6 +24,7 @@ depends: [
   "coq-mathcomp-zify" {(>= "1.1.0")}
   "coq-elpi" {(>= "1.10.1")}
 ]
+conflicts: [ "coq-mathcomp-word" { = "2.0" } ]
 
 tags: [
   "logpath:mathcomp.algebra_tactics"

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.3.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.0.3.0/opam
@@ -25,6 +25,7 @@ depends: [
   "coq-mathcomp-zify" {(>= "1.1.0")}
   "coq-elpi" {(>= "1.10.1")}
 ]
+conflicts: [ "coq-mathcomp-word" { = "2.0" } ]
 
 tags: [
   "logpath:mathcomp.algebra_tactics"

--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.0.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.0.0/opam
@@ -25,6 +25,7 @@ depends: [
   "coq-mathcomp-zify" {(>= "1.1.0")}
   "coq-elpi" {(>= "1.10.1")}
 ]
+conflicts: [ "coq-mathcomp-word" { = "2.0" } ]
 
 tags: [
   "logpath:mathcomp.algebra_tactics"


### PR DESCRIPTION
Note: These are not my packages

Starting with `coq-mathcomp-word` `2.0`, this package lives in the namespace `mathcomp.word`, and it includes a file `ssrZ` that conflicts with a corresponding file from `coq-mathcomp-zify`. See
https://github.com/jasmin-lang/coqword/issues/15 for the discussion upstream.

`coq-mathcomp-algebra-tactics <= 1.0.0` imports `ssrZ` while only qualifying `mathcomp` and not `mathcomp.zify`. This has been fixed in `dev`, but is still a problem for the released packages:
https://github.com/math-comp/algebra-tactics/blob/fb87fb0434c17e825b22e3bac9904c8e4f6cd1c2/theories/ring.v#L5

We declare a conflict with `coq-mathcomp-word.2.0` to resolve this.