### PR TITLE
versionless conflicts for coq-mathcomp-word.2.0

### DIFF
--- a/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.0/opam
+++ b/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.0/opam
@@ -16,9 +16,7 @@ depends: [
   "coq-mathcomp-algebra"
 ]
 conflicts: [
-  "coq-prosa" { = "0.5" }
-  "coq-mathcomp-apery" { <= "1.0.2" }
-  "coq-mathcomp-algebra-tactics" { <= "1.0.0" }
+  "coq-mathcomp-zify"
 ]
 
 tags: [


### PR DESCRIPTION
After some thought about the discussion in #2454, I don't think we have resources for updating the possibly-limitless conflicts that `coq-mathcomp-word.2.0` may have in the future with anything that uses `coq-mathcomp-zify`. So here I make current package conflicts versionless. Hopefully these problems are fixed in `coq-mathcomp-word.2.1` or similar (jasmin-lang/coqword#15), and will thus not affect many people.

cc: @silene 