### PR TITLE
coq-mathcomp-finmap.1.5.2 and coq-mathcomp-bigenough.1.0.1 version bumps

### DIFF
--- a/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
+++ b/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
@@ -18,7 +18,7 @@ library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.18~") | (= "dev")}
   "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
 

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
@@ -17,8 +17,8 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.13" & < "8.17~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.16~") | (= "dev") }
+  "coq" { (>= "8.13" & < "8.18~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.17~") | (= "dev") }
 ]
 
 tags: [


### PR DESCRIPTION
Compatible with Coq 8.17 and MathComp 1.16.0.

cc: @CohenCyril @proux01 