### PR TITLE
coq-compcert-32: fix coq version restriction + editorial changes

### DIFF
--- a/released/packages/coq-compcert-32/coq-compcert-32.3.12/opam
+++ b/released/packages/coq-compcert-32/coq-compcert-32.3.12/opam
@@ -24,12 +24,12 @@ tags: [
   "keyword:C"
   "keyword:compiler"
   "logpath:compcert32"
-  "date:2022-11-21"
+  "date:2022-11-25"
 ]
 homepage: "http://compcert.inria.fr/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"
 depends: [
-  "coq" {>= "8.12.0" & < "8.17~"}
+  "coq" {>= "8.12.0" & < "8.18~"}
   "menhir" {>= "20190626"}
   "ocaml" {>= "4.05.0"}
   "coq-flocq" {>= "4.1.0" & < "5~"}

--- a/released/packages/coq-compcert/coq-compcert.3.12/opam
+++ b/released/packages/coq-compcert/coq-compcert.3.12/opam
@@ -11,7 +11,7 @@ tags: [
   "keyword:C"
   "keyword:compiler"
   "logpath:compcert"
-  "date:2022-11-21"
+  "date:2022-11-25"
 ]
 homepage: "http://compcert.inria.fr/"
 bug-reports: "https://github.com/AbsInt/CompCert/issues"


### PR DESCRIPTION
sorry - a few minor things to fix in my earlier PR on coq-compcert.3.12.