### PR TITLE
Package coq-ext-lib.0.11.8

### DIFF
--- a/released/packages/coq-ext-lib/coq-ext-lib.0.11.8/opam
+++ b/released/packages/coq-ext-lib/coq-ext-lib.0.11.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A library of Coq definitions, theorems, and tactics"
+description:
+  "A collection of theories and plugins that may be useful in other Coq developments."
+maintainer: "gmalecha@gmail.com"
+authors: "Gregory Malecha"
+license: "BSD-2-Clause"
+tags: "logpath:ExtLib"
+homepage: "https://github.com/coq-community/coq-ext-lib"
+bug-reports: "https://github.com/coq-community/coq-ext-lib/issues"
+depends: [
+  "ocaml"
+  "coq" {>= "8.9" & (< "8.10" | >= "8.11")}
+]
+build: [make "-j%{jobs}%" "theories"]
+run-test: [make "-j%{jobs}%" "examples"]
+install: [make "install"]
+dev-repo: "git+https://github.com/coq-community/coq-ext-lib.git"
+url {
+  src:
+    "https://github.com/coq-community/coq-ext-lib/archive/refs/tags/v0.11.8.tar.gz"
+  checksum: [
+    "md5=5f5baefeb5f89f2185e132d8166d1725"
+    "sha512=83521bcaa561485d483b3bc0957f3591f96e2c367841cdbfc3ec0b2cf9c75fd2866c98c9e0c2541f89ca1fdaefda654a8a37d7c974ab464234ff7b4f77a5e6e8"
+  ]
+}


### PR DESCRIPTION
### `coq-ext-lib.0.11.8`
A library of Coq definitions, theorems, and tactics
A collection of theories and plugins that may be useful in other Coq developments.



---
* Homepage: https://github.com/coq-community/coq-ext-lib
* Source repo: git+https://github.com/coq-community/coq-ext-lib.git
* Bug tracker: https://github.com/coq-community/coq-ext-lib/issues

---
:camel: Pull-request generated by opam-publish v2.2.0