### PR TITLE
Fix coq version restriction for coq-coqprime.1.2.0

### DIFF
--- a/released/packages/coq-coqprime/coq-coqprime.1.2.0/opam
+++ b/released/packages/coq-coqprime/coq-coqprime.1.2.0/opam
@@ -13,7 +13,7 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {>= "8.13~" & < "8.16"}
+  "coq" {>= "8.13~" & < "8.17"}
   "coq-bignums"
 ]
 synopsis: "Certifying prime numbers in Coq"


### PR DESCRIPTION
The recent change from @thery for coq-coqprime.1.2.0 was likely an error.

coq-coqprime.1.2.0 is included in Coq Platform 2022.09 for Coq 8.16 so this is known to work and this change breaks the Coq Platform build for Coq 8.16.
