### PR TITLE
coq-hott.8.16: relax Coq version restriction to allow 8.17

### DIFF
--- a/released/packages/coq-hott/coq-hott.8.16/opam
+++ b/released/packages/coq-hott/coq-hott.8.16/opam
@@ -10,7 +10,7 @@ install: [make "install"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "coq" {>= "8.16" & < "8.17~"}
+  "coq" {>= "8.16" & < "8.18~"}
 ]
 authors: ["The Coq-HoTT Development Team"]
 dev-repo: "git+https://github.com/HoTT/Coq-HoTT.git"


### PR DESCRIPTION
See https://github.com/HoTT/Coq-HoTT/issues/1727