### PR TITLE
Added new version 2.1 for coq-mathcomp-word

### DIFF
--- a/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.1/opam
+++ b/released/packages/coq-mathcomp-word/coq-mathcomp-word.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "pierre-yves@strub.nu"
+
+homepage: "https://github.com/jasmin-lang/coqword"
+bug-reports: "https://github.com/jasmin-lang/coqword/issues"
+dev-repo: "git+https://github.com/jasmin-lang/coqword.git"
+license: "MIT"
+
+synopsis: "Yet Another Coq Library on Machine Words"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "dune" {>= "2.8"}
+  "coq" {>= "8.12"}
+  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.17~"}
+  "coq-mathcomp-algebra"
+]
+tags: [
+  "category:Computer Science/Data Types and Data Structures"
+  "keyword:machine words"
+  "logpath:mathcomp.word"
+  "date:2023-02-28"
+]
+authors: ["Pierre-Yves Strub"]
+
+url {
+  src: "https://github.com/jasmin-lang/coqword/archive/refs/tags/v2.1.tar.gz"
+  checksum: "sha512=1378c023f34fad41db77f6e45995dd72f041e216f191a5c1d92f5be5cf69873a5e54ebb312bae1f5ff470cca2da378acbc5544ef841016c77648dafb5d2e2561"
+}


### PR DESCRIPTION
See also

https://github.com/jasmin-lang/coqword/issues/18.

Please note that the issue with the duplicate ssrZ.vo file has been resolved in this release, so the conflicts have been removed.