### PR TITLE
allow Coq 8.17 and MathComp 1.16.0 for coq-reglang.1.1.3

### DIFF
--- a/released/packages/coq-reglang/coq-reglang.1.1.3/opam
+++ b/released/packages/coq-reglang/coq-reglang.1.1.3/opam
@@ -18,8 +18,8 @@ decidability results and closure properties of regular languages."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.10" & < "8.17~"}
-  "coq-mathcomp-ssreflect" {>= "1.11" & < "1.16~"}
+  "coq" {>= "8.10" & < "8.18~"}
+  "coq-mathcomp-ssreflect" {>= "1.11" & < "1.17~"}
 ]
 
 tags: [


### PR DESCRIPTION
cc: @MSoegtropIMC 