### PR TITLE
coq-itauto.dev requires Dune 2.9 or later

### DIFF
--- a/extra-dev/packages/coq-itauto/coq-itauto.dev/opam
+++ b/extra-dev/packages/coq-itauto/coq-itauto.dev/opam
@@ -22,7 +22,7 @@ install: [make "install"]
 depends: [
   "ocaml" {>= "4.9~"}
   "coq" {= "dev"}
-  "dune"
+  "dune" {>= "2.9"}
 ]
 depopts: [ "ocamlformat" {build} ]
 


### PR DESCRIPTION
It was clarified on Zulip that the Dune build is for 2.9 or later.