### PR TITLE
Released CoqEAL versions (coq-coqeal-1.0.*) are not compatible with coq-bignums >= 9~ and coq-mathcomp-multinomials.dev

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.0.4/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.4/opam
@@ -17,9 +17,9 @@ build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "coq" {>= "8.7" & < "8.13~"}
-  "coq-bignums"
+  "coq-bignums" {< "9~"}
   "coq-paramcoq" {>= "1.1.1"}
-  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.7~"}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
   "coq-mathcomp-algebra" {>= "1.11.0" & < "1.12~"}
 ]
 

--- a/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.5/opam
@@ -18,9 +18,9 @@ install: [make "install"]
 depends: [
   "coq" {>= "8.10" & < "8.14~"}
   "coq-bignums" {< "9~"}
-  "coq-paramcoq" {(>= "1.1.1") | (= "dev")}
-  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
-  "coq-mathcomp-algebra" {((>= "1.11.0" & < "1.13~") | = "dev")}
+  "coq-paramcoq" {>= "1.1.1"}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
+  "coq-mathcomp-algebra" {>= "1.11.0" & < "1.13~"}
 ]
 
 tags: [

--- a/released/packages/coq-coqeal/coq-coqeal.1.0.6/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.0.6/opam
@@ -16,11 +16,11 @@ of the ForMath EU FP7 project (2009-2013). It has two parts:
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.10" & < "8.15~"}
-  "coq-bignums" 
-  "coq-paramcoq" {(>= "1.1.1") | (= "dev")}
-  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
-  "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.14~") | = "dev")}
+  "coq" {>= "8.10" & < "8.16~"}
+  "coq-bignums" {< "9~"}
+  "coq-paramcoq" {>= "1.1.1"}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
+  "coq-mathcomp-algebra" {>= "1.12.0" & < "1.15~"}
 ]
 
 tags: [


### PR DESCRIPTION
The sources of incompatibilities are respectively:
- coq-community/bignums#74 (fixed by coq-community/coqeal#76), and
- math-comp/multinomials#65 (fixed by coq-community/coqeal#77).