### PR TITLE
Released CoqEAL versions (coq-coqeal-1.1.*) are not compatible with coq-bignums >= 9~ and coq-mathcomp-multinomials.dev

### DIFF
--- a/released/packages/coq-coqeal/coq-coqeal.1.1.0/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.1.0/opam
@@ -20,8 +20,8 @@ depends: [
   "coq" {>= "8.10" & < "8.16~"}
   "coq-bignums" {< "9~"}
   "coq-paramcoq" {>= "1.1.3"}
-  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
-  "coq-mathcomp-algebra" {((>= "1.12.0" & < "1.15~") | = "dev")}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
+  "coq-mathcomp-algebra" {>= "1.12.0" & < "1.15~"}
   "coq-mathcomp-real-closed" {(>= "1.1.2" & < "1.2~") | (= "dev")}
 ]
 

--- a/released/packages/coq-coqeal/coq-coqeal.1.1.1/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.1.1/opam
@@ -20,7 +20,7 @@ depends: [
   "coq" {(>= "8.13" & < "8.18~") | (= "dev")}
   "coq-bignums" {< "9~"}
   "coq-paramcoq" {>= "1.1.3"}
-  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
   "coq-mathcomp-algebra" {((>= "1.13.0" & < "1.17~") | = "dev")}
   "coq-mathcomp-real-closed" {(>= "1.1.2" & < "1.2~") | (= "dev")}
 ]

--- a/released/packages/coq-coqeal/coq-coqeal.1.1.2/opam
+++ b/released/packages/coq-coqeal/coq-coqeal.1.1.2/opam
@@ -20,7 +20,7 @@ depends: [
   "coq" {(>= "8.15" & < "8.18~") | (= "dev")}
   "coq-bignums" {< "9~"}
   "coq-paramcoq" {>= "1.1.3"}
-  "coq-mathcomp-multinomials" {((>= "1.5.1" & < "1.7~") | = "dev")}
+  "coq-mathcomp-multinomials" {>= "1.5.1" & < "1.6~"}
   "coq-mathcomp-algebra" {((>= "1.13.0" & < "1.17~") | = "dev")}
   "coq-mathcomp-real-closed" {(>= "1.1.2" & < "1.2~") | (= "dev")}
 ]


### PR DESCRIPTION
Another half of #2521 (I decided to split the PR to workaround the timeout issue in CI.)