### PR TITLE
Release coq-mathcomp-algebra-tactics.1.1.0

### DIFF
--- a/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.0/opam
+++ b/released/packages/coq-mathcomp-algebra-tactics/coq-mathcomp-algebra-tactics.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "kazuhiko.sakaguchi@inria.fr"
+
+homepage: "https://github.com/math-comp/algebra-tactics"
+dev-repo: "git+https://github.com/math-comp/algebra-tactics.git"
+bug-reports: "https://github.com/math-comp/algebra-tactics/issues"
+license: "CECILL-B"
+
+synopsis: "Ring, field, lra, nra, and psatz tactics for Mathematical Components"
+description: """
+This library provides `ring`, `field`, `lra`, `nra`, and `psatz` tactics for
+algebraic structures of the Mathematical Components library. The `ring` and
+`field` tactics respectively work with any `comRingType` and `fieldType`. The
+other (Micromega) tactics work with any `realDomainType` or `realFieldType`.
+Their instance resolution is done through canonical structure inference.
+Therefore, they work with abstract rings and do not require `Add Ring` and
+`Add Field` commands. Another key feature of this library is that they
+automatically push down ring morphisms and additive functions to leaves of
+ring/field expressions before applying the proof procedures."""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "coq" {>= "8.16" & < "8.18~"}
+  "coq-mathcomp-ssreflect" {>= "1.15" & < "1.17~"}
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-zify" {>= "1.1.0"}
+  "coq-elpi" {>= "1.15.0" & != "1.17.0"}
+]
+
+tags: [
+  "logpath:mathcomp.algebra_tactics"
+]
+authors: [
+  "Kazuhiko Sakaguchi"
+  "Pierre Roux"
+]
+url {
+  src: "https://github.com/math-comp/algebra-tactics/archive/refs/tags/1.1.0.tar.gz"
+  checksum: "sha256=72f618bd9387616d32584ce8ab6766aaede3ce2c410e75776b078fb9dd651f1d"
+}


### PR DESCRIPTION
https://github.com/math-comp/algebra-tactics/releases/tag/1.1.0