### PR TITLE
coq-dpdgraph 1.0+8.16 survives to coq-8.17

### DIFF
--- a/released/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
+++ b/released/packages/coq-dpdgraph/coq-dpdgraph.1.0+8.16/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install" "BINDIR=%{bin}%"]
 depends: [
   "ocaml" {>= "4.09.0"}
-  "coq" {>= "8.16" & < "8.17~"}
+  "coq" {>= "8.16" & < "8.18~"}
   "ocamlgraph" 
 ]
 


### PR DESCRIPTION
For once, there was no change in Coq that required a modification of coq-dpdgraph, so the dependency range only
requires extending.