### PR TITLE
Update fiat-crypto and dependencies with new versions

### DIFF
--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.5/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.5/opam
@@ -16,8 +16,8 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
 depends: [
   "conf-findutils" {build}
   "coq" {>= "8.15~"}
-  "coq-bedrock2" {= "0.0.4"}
-  "coq-riscv" {= "0.0.3"}
+  "coq-bedrock2" {= "0.0.5"}
+  "coq-riscv" {= "0.0.4"}
   "zarith" {>= "1.11"}
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
@@ -33,6 +33,6 @@ No code is shared between bedrock and bedrock2.
 """
 tags: ["logpath:bedrock2"]
 url {
-  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.4.tar.gz"
-  checksum: "sha512=7abf5e6553d4844f3563c99b3ff4a0a3f96a901473d824623029c82efe4d22c3bdf0bacd710e61619cf3fa2cf9f88db68ca650ba7a251e782c3e92357ba20d9f"
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.5.tar.gz"
+  checksum: "sha512=a4101b4a526dd691fcce8e5d86c16001736c465d4bccbf2e913b4f17b4ee24fe4d51731955480d4b69e04823dda860388994eff2ccc087d046ef15e4ef429b72"
 }

--- a/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.5/opam
+++ b/released/packages/coq-bedrock2-compiler/coq-bedrock2-compiler.0.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  # No reason to build compiler_ex since there's no install_compiler_ex target; the install_compiler target installs only compiler_noex
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "compiler_noex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_compiler"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+  "coq-bedrock2" {= "0.0.4"}
+  "coq-riscv" {= "0.0.3"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming (compiler part)"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  This package includes a verified compiler targeting RISC-V
+from this language.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.4.tar.gz"
+  checksum: "sha512=7abf5e6553d4844f3563c99b3ff4a0a3f96a901473d824623029c82efe4d22c3bdf0bacd710e61619cf3fa2cf9f88db68ca650ba7a251e782c3e92357ba20d9f"
+}

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.5/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/bedrock2"
+bug-reports: "https://github.com/mit-plv/bedrock2/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "bedrock2_ex"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install_bedrock2"]
+run-test: [
+  [make "-j%{jobs}%" "-C" "bedrock2" "EXTERNAL_DEPENDENCIES=1" "test"]
+]
+depends: [
+  "conf-findutils" {build}
+  "conf-python-3" {build & with-test}
+  "coq" {>= "8.15~"}
+  "coq-coqutil" {= "0.0.2"}
+  "zarith" {>= "1.11"}
+]
+dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming"
+description: """
+bedrock2 is a low-level systems programming language. This language is
+equipped with a simple program logic for proving correctness of the
+programs.  A verified compiler targeting RISC-V from this language
+exists in the coq-bedrock2-compiler package on opam.
+
+The project has similar goals as bedrock, but uses a different design.
+No code is shared between bedrock and bedrock2.
+"""
+tags: ["logpath:bedrock2"]
+url {
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.4.tar.gz"
+  checksum: "sha512=7abf5e6553d4844f3563c99b3ff4a0a3f96a901473d824623029c82efe4d22c3bdf0bacd710e61619cf3fa2cf9f88db68ca650ba7a251e782c3e92357ba20d9f"
+}

--- a/released/packages/coq-bedrock2/coq-bedrock2.0.0.5/opam
+++ b/released/packages/coq-bedrock2/coq-bedrock2.0.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "conf-findutils" {build}
   "conf-python-3" {build & with-test}
   "coq" {>= "8.15~"}
-  "coq-coqutil" {= "0.0.2"}
+  "coq-coqutil" {= "0.0.3"}
   "zarith" {>= "1.11"}
 ]
 dev-repo: "git+https://github.com/mit-plv/bedrock2.git"
@@ -35,6 +35,6 @@ No code is shared between bedrock and bedrock2.
 """
 tags: ["logpath:bedrock2"]
 url {
-  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.4.tar.gz"
-  checksum: "sha512=7abf5e6553d4844f3563c99b3ff4a0a3f96a901473d824623029c82efe4d22c3bdf0bacd710e61619cf3fa2cf9f88db68ca650ba7a251e782c3e92357ba20d9f"
+  src: "https://github.com/mit-plv/bedrock2/archive/refs/tags/v0.0.5.tar.gz"
+  checksum: "sha512=a4101b4a526dd691fcce8e5d86c16001736c465d4bccbf2e913b4f17b4ee24fe4d51731955480d4b69e04823dda860388994eff2ccc087d046ef15e4ef429b72"
 }

--- a/released/packages/coq-coqutil/coq-coqutil.0.0.3/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.3/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 depends: [
   "conf-findutils" {build}
-  "coq" {>= "8.11~"}
+  "coq" {>= "8.15~"}
 ]
 conflict-class: [
   "coq-coqutil"
@@ -35,6 +35,6 @@ Each feature is intended to be as minimal and as independent of the other featur
 """
 tags: ["logpath:coqutil"]
 url {
-  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.2.tar.gz"
-  checksum: "sha512=f3d37d57fb4301cbf6ab0bdd65c78bf5906607775b483e4f1b29e02e2a09980ef97ed7a9f19629d41bec45e281d7212cbb150e2602a26d30f408dd012ba51230"
+  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.3.tar.gz"
+  checksum: "sha512=3e24a56daa7f10d4dd507ada0be1581c238156bcbbfa642ab4f1b535106c501bafa271320b09d6b3de888a11f97381fda8394d466c9dd5906db3cf5b65509309"
 }

--- a/released/packages/coq-coqutil/coq-coqutil.0.0.3/opam
+++ b/released/packages/coq-coqutil/coq-coqutil.0.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.11~"}
+]
+conflict-class: [
+  "coq-coqutil"
+]
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+description: """
+### coqutil -- Various Coq Utilities
+
+Contents:
+* [Datatypes](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Datatypes): Some utilities for existing datatypes, and new datatypes.
+* [Decidable](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Decidable.v): `BoolSpec`-based decidability typeclasses. Allows one to write `if MyType_eqb a b then ... else ...` where `MyType_eqb a b` returns a `bool`, instead of writing `if MyType_eq_dec a b then ... else ...` where `MyType_eq_dec a b` returns a `sumbool`, while still getting `a = b` and `a <> b` as hypotheses (as opposed to `MyType_eqb a b = true` and `MyType_eqb a b = false`) after destructing the `if` (need to use [`destr`](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Tactics/destr.v) instead of `destruct`). So one gets the benefits of `Sumbool` without getting its disadvantage of having to carry around proof terms, which can cause a blow-up under reduction if one is not careful.
+* [Map](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Map): A typeclass based map library allowing one to abstract over the concrete implementation of maps. The implementations have to be extensional, which excludes certain efficient implementations, but simplifies proofs, because one can `replace mapA with mapB` if one can prove that `mapA` and `mapB` have the same contents. Comes with a [solver](https://github.com/mit-plv/coqutil/blob/master/src/coqutil/Map/Solver.v) which works reasonably fast on most map goals we have encountered so far.
+* [Tactics](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Tactics): A collection of useful general-purpose tactics.
+* [Word](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Word): Fixed width words for any width, in the same typeclass based style as the map library. Designed for the case where all words have the same (potentially abstract) bit width. Therefore, it does not provide functions to concatenate and split words, which is better addressed by [bbv](https://github.com/mit-plv/bbv/).
+* [Z](https://github.com/mit-plv/coqutil/tree/master/src/coqutil/Z): Utilities to work with the `Z` type from Coq's standard library, including a tactic to prove `Z` equalities by splitting the equality into equalities on bit index ranges, a tactic to make `lia` capable of reasoning about goals with division and modulo, and a tactic to simplify expressions containing nested occurrences of `mod`, and more misc utilities.
+* Various macros, notations, and desirable default settings.
+
+Each feature is intended to be as minimal and as independent of the other features as possible, so that users can pick just what they need.
+"""
+tags: ["logpath:coqutil"]
+url {
+  src: "https://github.com/mit-plv/coqutil/archive/refs/tags/v0.0.2.tar.gz"
+  checksum: "sha512=f3d37d57fb4301cbf6ab0bdd65c78bf5906607775b483e4f1b29e02e2a09980ef97ed7a9f19629d41bec45e281d7212cbb150e2602a26d30f408dd012ba51230"
+}

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
@@ -20,9 +20,9 @@ depends: [
   "ocamlfind" {build}
   "coq" {>= "8.15~"}
   "coq-coqprime" {>= "1.2.0"}
-  "coq-rewriter" {>= "0.0.6" & <= "0.0.7"}
-  "coq-rupicola" {= "0.0.6"}
-  "coq-bedrock2-compiler" {= "0.0.4"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.8"}
+  "coq-rupicola" {= "0.0.7"}
+  "coq-bedrock2-compiler" {= "0.0.5"}
 ]
 conflict-class: [
   "coq-fiat-crypto"
@@ -36,6 +36,6 @@ Target languages include C, Rust, Zig, Go, and bedrock2.
 """
 tags: ["logpath:Crypto"]
 url {
-  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.0.17.tar.gz"
-  checksum: "sha512=c7688c84fcc10cc063cff24d5d3d52edd04f26b16adb00e7389d648964e2a0cc0d81fa615d9091e491edd6fed81859f1ea4a12e19ba6793975be2b301369778a"
+  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.0.20.tar.gz"
+  checksum: "sha512=742933b8a0d34470946251fad584fb51fb5badcf393bc42e906e530206fcf5acf3951eff6b61f0f71f1ef56683fdda664b82d2da7464cbf7f14cc841ecccc04e"
 }

--- a/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
+++ b/released/packages/coq-fiat-crypto/coq-fiat-crypto.0.0.20/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+authors: [
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/fiat-crypto"
+bug-reports: "https://github.com/mit-plv/fiat-crypto/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "coq" "standalone-ocaml"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "SKIP_COQSCRIPTS_INCLUDE=1" "BINDIR=%{bin}%" "install" "install-standalone-ocaml"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build & >= "4.08~"}
+  "ocamlfind" {build}
+  "coq" {>= "8.15~"}
+  "coq-coqprime" {>= "1.2.0"}
+  "coq-rewriter" {>= "0.0.6" & <= "0.0.7"}
+  "coq-rupicola" {= "0.0.6"}
+  "coq-bedrock2-compiler" {= "0.0.4"}
+]
+conflict-class: [
+  "coq-fiat-crypto"
+]
+dev-repo: "git+https://github.com/mit-plv/fiat-crypto.git"
+synopsis: "Cryptographic Primitive Code Generation by Fiat"
+description: """
+Coq code and proofs for a command-line binary that can synthesize proven-correct
+big-integer modular field arithmetic operations for cryptography.
+Target languages include C, Rust, Zig, Go, and bedrock2.
+"""
+tags: ["logpath:Crypto"]
+url {
+  src: "https://github.com/mit-plv/fiat-crypto/archive/refs/tags/v0.0.17.tar.gz"
+  checksum: "sha512=c7688c84fcc10cc063cff24d5d3d52edd04f26b16adb00e7389d648964e2a0cc0d81fa615d9091e491edd6fed81859f1ea4a12e19ba6793975be2b301369778a"
+}

--- a/released/packages/coq-kami/coq-kami.0.0.3-rv32i/opam
+++ b/released/packages/coq-kami/coq-kami.0.0.3-rv32i/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+  "Kevix"
+  "SiFive"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/kami"
+bug-reports: "https://github.com/mit-plv/kami/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "coq"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "coq" {>= "8.15~"}
+  "coq-riscv" {= "0.0.1"}
+]
+dev-repo: "git+https://github.com/mit-plv/kami.git"
+synopsis: "A work-in-progress language and compiler for verified low-level programming"
+tags: ["logpath:kami"]
+url {
+  src: "https://github.com/mit-plv/kami/archive/refs/tags/v0.0.1.tar.gz"
+  checksum: "sha512=160f02f07733173d6237a7b5efebd51d2c98d34fbc3b668228a47296738b80d8987f98443d0581b3ca06bdeb6541e0f09a3316559ae6d5545aa3903767801b6d"
+}

--- a/released/packages/coq-kami/coq-kami.0.0.3-rv32i/opam
+++ b/released/packages/coq-kami/coq-kami.0.0.3-rv32i/opam
@@ -14,12 +14,12 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
-  "coq-riscv" {= "0.0.1"}
+  "coq-riscv" {= "0.0.4"}
 ]
 dev-repo: "git+https://github.com/mit-plv/kami.git"
 synopsis: "A work-in-progress language and compiler for verified low-level programming"
 tags: ["logpath:kami"]
 url {
-  src: "https://github.com/mit-plv/kami/archive/refs/tags/v0.0.1.tar.gz"
-  checksum: "sha512=160f02f07733173d6237a7b5efebd51d2c98d34fbc3b668228a47296738b80d8987f98443d0581b3ca06bdeb6541e0f09a3316559ae6d5545aa3903767801b6d"
+  src: "https://github.com/mit-plv/kami/archive/refs/tags/v0.0.3.tar.gz"
+  checksum: "sha512=c76f047b4ade255ce22d1a25a702e69a9ae213e50b7cf3f754c32a80e3fb38ec0f4dda6217e9f34176033f6079efb0ab91b74d3e96f377c65f870f03b8d43a9d"
 }

--- a/released/packages/coq-rewriter/coq-rewriter.0.0.8/opam
+++ b/released/packages/coq-rewriter/coq-rewriter.0.0.8/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+authors: [
+  "Google Inc."
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rewriter"
+bug-reports: "https://github.com/mit-plv/rewriter/issues"
+license: "MIT OR Apache-2.0 OR BSD-1-Clause"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+depends: [
+  "conf-findutils" {build}
+  "ocaml" {build}
+  "coq" {>= "8.15~"}
+]
+dev-repo: "git+https://github.com/mit-plv/rewriter.git"
+synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"
+tags: ["logpath:Rewriter"]
+url {
+  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: "sha512=771bbf9f1161406149d162e6c1f4cd5beb2e34f74877e8185d34b0b074412793690f41243e9aecc442330ef3f7dfb025ad4e628585fdaaa272f2af565cf4c4ee"
+}

--- a/released/packages/coq-rewriter/coq-rewriter.0.0.8/opam
+++ b/released/packages/coq-rewriter/coq-rewriter.0.0.8/opam
@@ -20,6 +20,6 @@ dev-repo: "git+https://github.com/mit-plv/rewriter.git"
 synopsis: "Reflective PHOAS rewriting/pattern-matching-compilation framework for simply-typed equalities and let-lifting, experimental and tailored for use in Fiat Cryptography"
 tags: ["logpath:Rewriter"]
 url {
-  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.7.tar.gz"
-  checksum: "sha512=771bbf9f1161406149d162e6c1f4cd5beb2e34f74877e8185d34b0b074412793690f41243e9aecc442330ef3f7dfb025ad4e628585fdaaa272f2af565cf4c4ee"
+  src: "https://github.com/mit-plv/rewriter/archive/refs/tags/v0.0.8.tar.gz"
+  checksum: "sha512=257e3a3ac5d47e6a463bc835925170979d9a4ed274737c54a19ac3a307357c3a2686d5fecfe590030502417f64fa71bd822f79c57fd6f5d4e202387446e5f4ca"
 }

--- a/released/packages/coq-riscv/coq-riscv.0.0.4/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.4/opam
@@ -12,13 +12,13 @@ build: [
 install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "coq" {>= "8.15~"}
-  "coq-coqutil" {= "0.0.2"}
+  "coq-coqutil" {= "0.0.3"}
   "coq-record-update" {>= "0.3.0"}
 ]
 dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
 synopsis: "RISC-V Specification in Coq, somewhat experimental"
 tags: ["logpath:riscv"]
 url {
-  src: "https://github.com/mit-plv/riscv-coq/archive/refs/tags/v0.0.3.tar.gz"
-  checksum: "sha512=55c6a2aa84c89b5b4224729ccad23504d906d174d8bab9b5e1ff62dd7e76efef4935978c3ba517870d25700a1e563e2b352bb3fba94936807561840f26af75e8"
+  src: "https://github.com/mit-plv/riscv-coq/archive/refs/tags/v0.0.4.tar.gz"
+  checksum: "sha512=466fc8ef9fa8e998f4362bf30dd5bb03a13454672a3acd4bbfc567d059a6f2c1109a7131b98b3539340dcf78184dca6f3d8a6d3c51c71a394d2120686667a9af"
 }

--- a/released/packages/coq-riscv/coq-riscv.0.0.4/opam
+++ b/released/packages/coq-riscv/coq-riscv.0.0.4/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: [
+  "Massachusetts Institute of Technology"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/riscv-coq"
+bug-reports: "https://github.com/mit-plv/riscv-coq/issues"
+license: "BSD-3-Clause"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "coq" {>= "8.15~"}
+  "coq-coqutil" {= "0.0.2"}
+  "coq-record-update" {>= "0.3.0"}
+]
+dev-repo: "git+https://github.com/mit-plv/riscv-coq.git"
+synopsis: "RISC-V Specification in Coq, somewhat experimental"
+tags: ["logpath:riscv"]
+url {
+  src: "https://github.com/mit-plv/riscv-coq/archive/refs/tags/v0.0.3.tar.gz"
+  checksum: "sha512=55c6a2aa84c89b5b4224729ccad23504d906d174d8bab9b5e1ff62dd7e76efef4935978c3ba517870d25700a1e563e2b352bb3fba94936807561840f26af75e8"
+}

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.7/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.7/opam
@@ -17,12 +17,12 @@ install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
 depends: [
   "conf-findutils" {build}
   "coq" {>= "8.15~"}
-  "coq-bedrock2" {>= "0.0.2" & <= "0.0.4"}
+  "coq-bedrock2" {= "0.0.5"}
 ]
 dev-repo: "git+https://github.com/mit-plv/rupicola.git"
 synopsis: "Gallina to imperative code compilation, currently in design phase"
 tags: ["logpath:Rupicola"]
 url {
-  src: "https://github.com/mit-plv/rupicola/archive/refs/tags/v0.0.6.tar.gz"
-  checksum: "sha512=eca8735a2d741d8a759f46992b66cd1c1d00d228e7ac3cc6d8e4a6b740ee650485cf241336ea7e383f8a5f928e42d7212690c6f5f7d2121e9f1a3037369f0e90"
+  src: "https://github.com/mit-plv/rupicola/archive/refs/tags/v0.0.7.tar.gz"
+  checksum: "sha512=558a3a77c9fd7a6f0bdccaf06e7c4fa0396a2ee7e80c8a801b6fa5754ec5ab4c14f4038418d86ea9b49e3386cdaeb99be761510e8d77deec12ec9191a90d70d1"
 }

--- a/released/packages/coq-rupicola/coq-rupicola.0.0.7/opam
+++ b/released/packages/coq-rupicola/coq-rupicola.0.0.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: [
+  "Clément Pit-Claudel <clement.pitclaudel@live.com>"
+  "Jade Philipoom"
+  "Dustin Jamner"
+  "Andres Erbsen"
+  "Adam Chlipala"
+]
+maintainer: "Jason Gross <jgross@mit.edu>"
+homepage: "https://github.com/mit-plv/rupicola"
+bug-reports: "https://github.com/mit-plv/rupicola/issues"
+license: "MIT"
+build: [
+  [make "-j%{jobs}%" "EXTERNAL_DEPENDENCIES=1" "all"]
+]
+install: [make "EXTERNAL_DEPENDENCIES=1" "install"]
+depends: [
+  "conf-findutils" {build}
+  "coq" {>= "8.15~"}
+  "coq-bedrock2" {>= "0.0.2" & <= "0.0.4"}
+]
+dev-repo: "git+https://github.com/mit-plv/rupicola.git"
+synopsis: "Gallina to imperative code compilation, currently in design phase"
+tags: ["logpath:Rupicola"]
+url {
+  src: "https://github.com/mit-plv/rupicola/archive/refs/tags/v0.0.6.tar.gz"
+  checksum: "sha512=eca8735a2d741d8a759f46992b66cd1c1d00d228e7ac3cc6d8e4a6b740ee650485cf241336ea7e383f8a5f928e42d7212690c6f5f7d2121e9f1a3037369f0e90"
+}


### PR DESCRIPTION
For future reference, the sha512 updates were made in each directory by running
```
src="$(grep -o 'src: "[^"]*' opam | sed s'/src: "//g')"; out="$(echo -- "$src" | grep -o '[^/]*$')"; wget "$src" -O "$out"; sha="$(sha512sum "$out" | cut -f1 -d' ')"; sed 's/sha512=[^"]*/sha512='"$sha"'/g' -i opam
```