### PR TITLE
coq-addition-chains.0.9 compiles with Coq 8.17 and MC 2.0.0

### DIFF
--- a/released/packages/coq-addition-chains/coq-addition-chains.0.9/opam
+++ b/released/packages/coq-addition-chains/coq-addition-chains.0.9/opam
@@ -16,9 +16,9 @@ correctness."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.13" & < "8.16~"}
+  "coq" {>= "8.13" & < "8.18~"}
   "coq-paramcoq" {>= "1.1.3" & < "1.2~"}
-  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "1.15~"}
+  "coq-mathcomp-ssreflect" {>= "1.12.0" & < "2.1~"}
   "coq-mathcomp-algebra"
 ]
 


### PR DESCRIPTION
As well as Coq 8.16 and MC 1.16.0 and 1.17.0