### PR TITLE
Package coq-matrix.1.0.4

### DIFF
--- a/released/packages/coq-matrix/coq-matrix.1.0.4/opam
+++ b/released/packages/coq-matrix/coq-matrix.1.0.4/opam
@@ -27,7 +27,7 @@ authors: [
 license: "MIT" # Make sure this is reflected by a LICENSE file in your sources
 
 depends: [
-  "coq" {>= "8.13" & <= "8.16~"}
+  "coq" {>= "8.13" & <= "8.16.1"}
 ]
 
 build: [

--- a/released/packages/coq-matrix/coq-matrix.1.0.4/opam
+++ b/released/packages/coq-matrix/coq-matrix.1.0.4/opam
@@ -39,7 +39,7 @@ install: [
 
   url {
   src: "https://github.com/zhengpushi/CoqMatrix/archive/refs/tags/1.0.4.tar.gz"
-  checksum: "sha256=4b30fa6289ceafa17361f9c344bfdc354e65cd236e643e0003e13b1c7237d0ef"
+  checksum: "sha256=694648b083fec06d43f0da570a26cffd6e81970f99af249f14faf7789166b6be"
 }
 
 tags: [

--- a/released/packages/coq-matrix/coq-matrix.1.0.4/opam
+++ b/released/packages/coq-matrix/coq-matrix.1.0.4/opam
@@ -27,7 +27,7 @@ authors: [
 license: "MIT" # Make sure this is reflected by a LICENSE file in your sources
 
 depends: [
-  "coq" {>= "8.13"}
+  "coq" {>= "8.13" & <= "8.16~"}
 ]
 
 build: [

--- a/released/packages/coq-matrix/coq-matrix.1.0.4/opam
+++ b/released/packages/coq-matrix/coq-matrix.1.0.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Formal matrix theory with multiple implementations in Coq" # One-line description
+description: """
+  Matrix is an important mathematical tool. Although there are at least five matrix 
+  models/libraries in Coq community, the massive verification project involving matrix 
+  are still facing some problems:
+  (1). There havn't a full-feature formal matrix library, because the matrix theory is 
+  complex and need more time to formalize it.
+  (2). Different libraries of these implementations cannot be easily switched at the 
+  later stage of a verification process, because the type of operations and theorems 
+  are different. But some project maybe need more matrix theories while the needed 
+  theorems only avaiable in another libraries.
+
+  Thus, we provide a unified framework for different implementations of formal matrix
+  models, so as to decouple the difference between underlying technologies and 
+  upper-level applications.
+""" # Longer description, can span several lines
+
+homepage: "https://github.com/zhengpushi/CoqMatrix"
+dev-repo: "git+https://github.com/zhengpushi/CoqMatrix.git"
+bug-reports: "https://github.com/zhengpushi/CoqMatrix/issues"
+doc: "https://zhengpushi.github.io/coq-matrix.html"
+maintainer: "zhengpushi@nuaa.edu.cn"
+authors: [
+  "ZhengPu Shi"
+]
+license: "MIT" # Make sure this is reflected by a LICENSE file in your sources
+
+depends: [
+  "coq" {>= "8.13"}
+]
+
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+
+  url {
+  src: "https://github.com/zhengpushi/CoqMatrix/archive/refs/tags/1.0.4.tar.gz"
+  checksum: "sha256=4b30fa6289ceafa17361f9c344bfdc354e65cd236e643e0003e13b1c7237d0ef"
+}
+
+tags: [
+  "keyword:matrices"
+  "category:Mathematics/Algebra"
+  "date:2023-05-19"
+  "logpath:CoqMatrix"
+]


### PR DESCRIPTION
1. a new module SafeNatFun, and additionally, determinant of generic matrix and inversion matrix by adjoint matrix.
2. preliminary calculus theory.
3. better notation for mnth function, with "m!i!j" instead of "m$i$j".
4. rename A0,A1 to Azero,Aone, to avoiding conflict of A1 in Reals library.
5. temporarily block the "FinFun" model, because the upgrade of math-comp library to 2.0.
6. only working <= Coq 8.16.1, because Coq 8.17 have some change, we prepared to publish another version.