### PR TITLE
Hierarchy-builder 1.4.0 no longer compiles on master

### DIFF
--- a/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.4.0/opam
+++ b/released/packages/coq-hierarchy-builder/coq-hierarchy-builder.1.4.0/opam
@@ -11,7 +11,7 @@ build: [ [ make "build"]
          [ make "test-suite" ] {with-test}
        ]
 install: [ make "install" ]
-depends: [ "coq-elpi" { (>= "1.14" & < "1.18~") | = "dev" } ]
+depends: [ "coq-elpi" {>= "1.14" & < "1.18~"} ]
 conflicts: [ "coq-hierarchy-builder-shim" ]
 synopsis: "High level commands to declare and evolve a hierarchy based on packed classes"
 description: """


### PR DESCRIPTION
It builds but the test-suite no longer goes through.