### PR TITLE
allow coq-hierarchy-builder.dev as dep for coq-mathcomp-ssreflect.dev

### DIFF
--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -11,7 +11,7 @@ build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
   "coq" {>= "8.16"}
-  "coq-hierarchy-builder" { = "1.4.0"}
+  "coq-hierarchy-builder" {>= "1.4.0"}
 ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]


### PR DESCRIPTION
cc: @CohenCyril @proux01 

This matches what is currently in the MathComp repo and allows `coq-mathcomp-ssreflect.dev` to be installed without activating the `released` repo.