### PR TITLE
add coq-coinduction.dev to extra-dev

### DIFF
--- a/extra-dev/packages/coq-coinduction/coq-coinduction.dev/opam
+++ b/extra-dev/packages/coq-coinduction/coq-coinduction.dev/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/damien-pous/coinduction"
+dev-repo: "git+https://github.com/damien-pous/coinduction.git"
+bug-reports: "https://github.com/damien-pous/coinduction/issues"
+license: "LGPL-3.0-or-later"
+
+synopsis: "A library and plugin for doing proofs by (enhanced) coinduction"
+description: """
+Coinductive predicates are greatest fixpoints of monotone functions.
+The `companion' makes it possible to enhance the associated coinduction scheme.
+This library provides a formalisation on enhancements based on the companion, as well as tactics in making it straightforward to perform proofs by enhanced coinduction.
+"""
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+]
+
+tags: [
+  "keyword:coinduction"
+  "keyword:up to techniques"
+  "keyword:companion"
+  "logpath:Coinduction"
+]
+authors: [
+  "Damien Pous"
+]
+
+url {
+  src: "git+https://github.com/damien-pous/coinduction.git#master"
+}


### PR DESCRIPTION
This is a git-based package to enable easy testing in CI of projects depending on `coq-coinduction` with `coq.dev` (`dev` Docker image tag), now that the plugin has joined Coq's CI.

cc: @damien-pous @YaZko