### PR TITLE
coq-vcfloat.2.1 is not compatible with coq-interval.4.8.0

### DIFF
--- a/released/packages/coq-vcfloat/coq-vcfloat.2.1/opam
+++ b/released/packages/coq-vcfloat/coq-vcfloat.2.1/opam
@@ -27,7 +27,7 @@ run-test: [
 depends: [
   "coq" {>= "8.16" & < "8.18~"}
   "coq-flocq" {>= "4.1.0" & < "5.0"}
-  "coq-interval" {>= "4.5.2"}
+  "coq-interval" {>= "4.5.2" & < "4.8.0"}
   "coq-compcert" {>= "3.11"}
   "coq-bignums"
 ]


### PR DESCRIPTION
cc: @andrew-appel 

With the recently released `coq-interval.4.8.0`, the package `coq-vcfloat.2.1` breaks with the following error:
```
coqc -Q . vcfloat Prune.v
File "./Prune.v", line 8, characters 50-54:
Error: Cannot find module I2.T.
```