### PR TITLE
add coq-serapi.8.18+rc1+0.18.0 to extra-dev

### DIFF
--- a/extra-dev/packages/coq-serapi/coq-serapi.8.18+rc1+0.18.0/opam
+++ b/extra-dev/packages/coq-serapi/coq-serapi.8.18+rc1+0.18.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.18" & < "8.19"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/archive/refs/tags/8.18+rc1+0.18.0.tar.gz"
+  checksum: [
+    "sha256=de1bb01f00c2e515b0da5167a36b7a63a144e43197128411f1ecf5935d5c9b58"
+    "sha512=2dd7f8d8114d2b5c07adedb13454ab6a5e95f1024cdd1e8a70404182c0079501f996e369df5f9717f06fce0a7537cd6ee5334f13df971035435b6e3674ea2766"
+  ]
+}


### PR DESCRIPTION
cc: @ejgallego @erikmd 

Because the opam changes discussed [here](https://github.com/coq/coq/wiki/Coq-Call-2023-03-08) were not implemented due to lack of resources for release management (see #2643), we add SerAPI package for inclusion in the Docker image for 8.18+rc1.