### PR TITLE
Package coq-elpi.1.19.0

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.1.19.0/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.1.19.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Elpi extension language for Coq"
+description: """\
+Coq-elpi provides a Coq plugin that embeds ELPI.
+It also provides a way to embed Coq's terms into λProlog using
+the Higher-Order Abstract Syntax approach
+and a way to read terms back.  In addition to that it exports to ELPI a
+set of Coq's primitives, e.g. printing a message, accessing the
+environment of theorems and data types, defining a new constant and so on.
+For convenience it also provides a quotation and anti-quotation for Coq's
+syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
+numbers, or `{{A -> B}}` to the representation of a product by unfolding
+ the `->` notation. Finally it provides a way to define new vernacular commands
+and
+new tactics."""
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: "Enrico Tassi"
+license: "LGPL-2.1-or-later"
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:λProlog"
+  "keyword:higher order abstract syntax"
+  "logpath:elpi"
+]
+homepage: "https://github.com/LPCIC/coq-elpi"
+bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
+depends: [
+  "stdlib-shims"
+  "elpi" {>= "1.16.5" & < "1.18.0~"}
+  "coq" {>= "8.18" & < "8.19~"}
+]
+build: [
+  [make "build" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN="]
+  [make "test" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"] {with-test}
+]
+install: [make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi"]
+dev-repo: "git+https://github.com/LPCIC/coq-elpi"
+url {
+  src:
+    "https://github.com/LPCIC/coq-elpi/releases/download/v1.19.0/coq-elpi-1.19.0.tar.gz"
+  checksum: [
+    "md5=ef80c7f1a8d5af83b4e54088d1fc7b29"
+    "sha512=c38dcc9060dc4f13ccb2067664a653a9ad0fbea87e5accbf76401e287c37f55ed330a9e3c4f6235057cee6e693372977bb1496d6d0f03e91a418e85ad00efc47"
+  ]
+}


### PR DESCRIPTION
### `coq-elpi.1.19.0`
Elpi extension language for Coq
Coq-elpi provides a Coq plugin that embeds ELPI.
It also provides a way to embed Coq's terms into λProlog using
the Higher-Order Abstract Syntax approach
and a way to read terms back.  In addition to that it exports to ELPI a
set of Coq's primitives, e.g. printing a message, accessing the
environment of theorems and data types, defining a new constant and so on.
For convenience it also provides a quotation and anti-quotation for Coq's
syntax in λProlog.  E.g. `{{nat}}` is expanded to the type name of natural
numbers, or `{{A -> B}}` to the representation of a product by unfolding
 the `->` notation. Finally it provides a way to define new vernacular commands
and
new tactics.



---
* Homepage: https://github.com/LPCIC/coq-elpi
* Source repo: git+https://github.com/LPCIC/coq-elpi
* Bug tracker: https://github.com/LPCIC/coq-elpi/issues

---
:camel: Pull-request generated by opam-publish v2.2.0