### PR TITLE
relax bounds of coq-mathcomp-ssreflect.2.0.0 to include 8.18+rc1

### DIFF
--- a/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
+++ b/released/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.2.0.0/opam
@@ -9,7 +9,7 @@ license: "CECILL-B"
 build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
-  "coq" { ((>= "8.16" & < "8.18~") | (= "dev"))}
+  "coq" { ((>= "8.16" & < "8.19~") | (= "dev"))}
   "coq-hierarchy-builder" { >= "1.4.0"}
 ]
 


### PR DESCRIPTION
Unfortunately, CI will not test with 8.18+rc1, but it works based on local testing.