### PR TITLE
allow 8.18 for coq-mathcomp-finmap.1.5.2 and coq-mathcomp-bigenough.1.0.1

### DIFF
--- a/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
+++ b/released/packages/coq-mathcomp-bigenough/coq-mathcomp-bigenough.1.0.1/opam
@@ -18,7 +18,7 @@ library."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.18~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.19~") | (= "dev")}
   "coq-mathcomp-ssreflect" {>= "1.6"}
 ]
 

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.2/opam
@@ -17,7 +17,7 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.13" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.13" & < "8.19~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.12.0" & < "1.18~") | (= "dev") }
 ]
 

--- a/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.0.0/opam
+++ b/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.2.0.0/opam
@@ -17,7 +17,7 @@ which will be used to subsume notations for finite sets, eventually."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.16" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.16" & < "8.19~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "2.0.0" & < "2.1~") | (= "dev") }
 ]
 


### PR DESCRIPTION
cc: @CohenCyril @proux01 

I tested with 8.18+rc1 locally since CI here can't test this with packages in `released`.