### PR TITLE
coq-fourcolor.1.3.0 works on Coq 8.18

### DIFF
--- a/released/packages/coq-fourcolor/coq-fourcolor.1.3.0/opam
+++ b/released/packages/coq-fourcolor/coq-fourcolor.1.3.0/opam
@@ -16,7 +16,7 @@ basic plane topology definitions, and a theory of combinatorial hypermaps."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16" & < "8.18~") | (= "dev")}
+  "coq" {(>= "8.16" & < "8.19~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "2.0.0" & < "2.1~") | (= "dev")}
   "coq-mathcomp-algebra" 
 ]


### PR DESCRIPTION
Tested locally that it works with 8.18+rc1.