### PR TITLE
coq-autosubst.1.8 works on Coq 8.18

### DIFF
--- a/released/packages/coq-autosubst/coq-autosubst.1.8/opam
+++ b/released/packages/coq-autosubst/coq-autosubst.1.8/opam
@@ -19,7 +19,7 @@ substitutions."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.19~") | (= "dev")}
 ]
 
 tags: [


### PR DESCRIPTION
Tested locally that it works on 8.18+rc1.