### PR TITLE
coq-mathcomp-zify supports 8.18

### DIFF
--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.3.0+1.12+8.13/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.3.0+1.12+8.13/opam
@@ -15,7 +15,7 @@ by extending the zify tactic."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.13" & < "8.18~")}
+  "coq" {(>= "8.13" & < "8.19~")}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.18~")}
   "coq-mathcomp-algebra" 
 ]

--- a/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
+++ b/released/packages/coq-mathcomp-zify/coq-mathcomp-zify.1.5.0+2.0+8.16/opam
@@ -15,7 +15,7 @@ by extending the zify tactic."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16" & < "8.18~")}
+  "coq" {(>= "8.16" & < "8.19~")}
   "coq-mathcomp-ssreflect" {(>= "2.0" & < "2.1~")}
   "coq-mathcomp-algebra" 
 ]


### PR DESCRIPTION
cc: @pi8027 

Tested on 8.18+rc1.