### PR TITLE
relax bounds to allow 8.18 for fourcolor 1.2.5, graph-theory 0.9.2

### DIFF
--- a/released/packages/coq-fourcolor/coq-fourcolor.1.2.5/opam
+++ b/released/packages/coq-fourcolor/coq-fourcolor.1.2.5/opam
@@ -16,7 +16,7 @@ basic plane topology definitions, and a theory of combinatorial hypermaps."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.11" & < "8.18~"}
+  "coq" {>= "8.11" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.12" & < "1.18~"}
   "coq-mathcomp-algebra" 
 ]

--- a/released/packages/coq-graph-theory-planar/coq-graph-theory-planar.0.9.2/opam
+++ b/released/packages/coq-graph-theory-planar/coq-graph-theory-planar.0.9.2/opam
@@ -14,7 +14,7 @@ as part of the Coq proof of the Four-Color Theorem."""
 
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "coq" {>= "8.14" & < "8.18~"}
+  "coq" {>= "8.14" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.13" & < "1.18~"}
   "coq-graph-theory" {= version}
   "coq-fourcolor"

--- a/released/packages/coq-graph-theory/coq-graph-theory.0.9.2/opam
+++ b/released/packages/coq-graph-theory/coq-graph-theory.0.9.2/opam
@@ -15,7 +15,7 @@ from the literature (e.g., Menger's Theorem and Hall's Marriage Theorem)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.14" & < "8.18~"}
+  "coq" {>= "8.14" & < "8.19~"}
   "coq-mathcomp-ssreflect" {>= "1.13" & < "1.18~"}
   "coq-mathcomp-algebra" 
   "coq-mathcomp-finmap" 


### PR DESCRIPTION
Tested locally with 8.18+rc1.

ci-skip: coq-fourcolor.1.2.5