### PR TITLE
allow 8.18 for coq-mathcomp-classical.0.6.4

### DIFF
--- a/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.0.6.4/opam
+++ b/released/packages/coq-mathcomp-classical/coq-mathcomp-classical.0.6.4/opam
@@ -14,11 +14,11 @@ the Coq proof-assistant and using the Mathematical Components library."""
 build: [make "-C" "classical" "-j%{jobs}%"]
 install: [make "-C" "classical" "install"]
 depends: [
-  "coq" { (>= "8.14" & < "8.18~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.13.0" & < "1.18~") | (= "dev") }
+  "coq" { (>= "8.14" & < "8.19~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.13.0" & < "1.18~") }
   "coq-mathcomp-fingroup"
   "coq-mathcomp-algebra"
-  "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") | (= "dev") }
+  "coq-mathcomp-finmap" { (>= "1.5.1" & < "1.6~") }
   "coq-hierarchy-builder" { (>= "1.2.0") }
 ]
 


### PR DESCRIPTION
cc: @affeldt-aist 

This has been tested locally on 8.18+rc1, unfortunately CI won't test due to 8.18+rc1 living in `core-dev` opam repo.

The other removed bounds are due to them making no sense (`mathcomp-X.dev` packages won't work since they are all MC2 at this point).