### PR TITLE
[extra-dev] mathcomp: Use (coq-hierarchy-builder >= 1.5.0, elpi >= 1.17.0) to expect better perfs

### DIFF
--- a/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
+++ b/extra-dev/packages/coq-mathcomp-ssreflect/coq-mathcomp-ssreflect.dev/opam
@@ -11,7 +11,8 @@ build: [ make "-C" "mathcomp/ssreflect" "-j" "%{jobs}%" ]
 install: [ make "-C" "mathcomp/ssreflect" "install" ]
 depends: [
   "coq" {>= "8.16"}
-  "coq-hierarchy-builder" {>= "1.4.0"}
+  "coq-hierarchy-builder" {>= "1.5.0"}
+  "elpi" {>= "1.17.0"}
 ]
 
 tags: [ "keyword:small scale reflection" "keyword:mathematical components" "keyword:odd order theorem" "logpath:mathcomp.ssreflect" ]


### PR DESCRIPTION
Follow-up of https://github.com/math-comp/math-comp/pull/1056#issuecomment-1672803535

@gares, do you approve this PR?