### PR TITLE
fix(coq-elpi.dev): Update spec w.r.t. [1], also allowing coq.dev

### DIFF
--- a/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
+++ b/extra-dev/packages/coq-elpi/coq-elpi.dev/opam
@@ -2,16 +2,24 @@ opam-version: "2.0"
 maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
 authors: [ "Enrico Tassi" ]
 license: "LGPL-2.1-or-later"
-homepage: "http://github.com/LPCIC/coq-elpi"
-doc: "http://github.com/LPCIC/coq-elpi"
-dev-repo: "git+http://github.com/LPCIC/coq-elpi"
+homepage: "https://github.com/LPCIC/coq-elpi"
+bug-reports: "https://github.com/LPCIC/coq-elpi/issues"
+dev-repo: "git+https://github.com/LPCIC/coq-elpi"
 
-build: [ make "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN=" ]
+build: [ [ make "build"   "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" "OCAMLWARN=" ]
+         [ make "test"    "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ] {with-test}
+       ]
 install: [ make "install" "COQBIN=%{bin}%/" "ELPIDIR=%{prefix}%/lib/elpi" ]
-
 depends: [
-  "elpi" {>= "1.16.5" & < "1.17.0~"}
-  "coq" {= "dev"}
+  "stdlib-shims"
+  "elpi" {>= "1.16.5" & < "1.18.0~"}
+  "coq" {>= "8.18"}
+]
+tags: [
+  "category:Miscellaneous/Coq Extensions"
+  "keyword:λProlog"
+  "keyword:higher order abstract syntax"
+  "logpath:elpi"
 ]
 synopsis: "Elpi extension language for Coq"
 description: """


### PR DESCRIPTION
[1] = https://github.com/LPCIC/coq-elpi/blob/master/coq-elpi.opam

Cc @gares: FYI this PR appears to be necessary given this failure:

* job https://gitlab.inria.fr/math-comp/math-comp/-/jobs/3343343
* in pipeline https://gitlab.inria.fr/math-comp/math-comp/-/pipelines/844235

~~Do you approve the two commits? or just the coq-elpi.dev commit?~~ (**edit:** see [this comment](https://github.com/coq/opam-coq-archive/pull/2668#issuecomment-1675161366))

Cc @palmskog 