### PR TITLE
Interval: Add upper bound on MathComp (fix #2649).

### DIFF
--- a/released/packages/coq-interval/coq-interval.4.5.2/opam
+++ b/released/packages/coq-interval/coq-interval.4.5.2/opam
@@ -14,7 +14,7 @@ depends: [
   "coq" {>= "8.8" & < "8.17~"}
   "coq-bignums" {< "9~"}
   "coq-flocq" {>= "3.1"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2~"}
   "coq-coquelicot" {>= "3.0"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})

--- a/released/packages/coq-interval/coq-interval.4.6.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "coq" {>= "8.12" & < "8.17~"}
   "coq-bignums" {< "9~"}
   "coq-flocq" {>= "3.1"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2~"}
   "coq-coquelicot" {>= "3.0"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})

--- a/released/packages/coq-interval/coq-interval.4.6.1/opam
+++ b/released/packages/coq-interval/coq-interval.4.6.1/opam
@@ -14,7 +14,7 @@ depends: [
   "coq" {>= "8.8.1"}
   "coq-bignums" {< "9~"}
   "coq-flocq" {>= "3.1"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2~"}
   "coq-coquelicot" {>= "3.0"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})

--- a/released/packages/coq-interval/coq-interval.4.7.0/opam
+++ b/released/packages/coq-interval/coq-interval.4.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "coq" {>= "8.11"}
   "coq-bignums"
   "coq-flocq" {>= "3.1"}
-  "coq-mathcomp-ssreflect" {>= "1.6"}
+  "coq-mathcomp-ssreflect" {>= "1.6" & < "2~"}
   "coq-coquelicot" {>= "3.0"}
   "conf-autoconf" {build & dev}
   ("conf-g++" {build} | "conf-clang" {build})


### PR DESCRIPTION
ci-skip: coq-interval.4.5.2 coq-interval.4.6.0 coq-interval.4.7.0