### PR TITLE
Added opam package for VST-32 2.12

### DIFF
--- a/released/packages/coq-vst-32/coq-vst-32.2.12/opam
+++ b/released/packages/coq-vst-32/coq-vst-32.2.12/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Verified Software Toolchain"
+description: "The software toolchain includes static analyzers to check assertions about your program; optimizing compilers to translate your program to machine language; operating systems and libraries to supply context for your program. The Verified Software Toolchain project assures with machine-checked proofs that the assertions claimed at the top of the toolchain really hold in the machine-language program, running in the operating-system context."
+authors: [
+  "Andrew W. Appel"
+  "Lennart Beringer"
+  "Josiah Dodds"
+  "Qinxiang Cao"
+  "Aquinas Hobor"
+  "Gordon Stewart"
+  "Qinshi Wang"
+  "Sandrine Blazy"
+  "Santiago Cuellar"
+  "Robert Dockins"
+  "Nick Giannarakis"
+  "Samuel Gruetter"
+  "Jean-Marie Madiot"
+]
+maintainer: "VST team"
+homepage: "http://vst.cs.princeton.edu/"
+dev-repo: "git+https://github.com/PrincetonUniversity/VST.git"
+bug-reports: "https://github.com/PrincetonUniversity/VST/issues"
+license: "BSD-2-Clause"
+
+build: [
+  [make "-j%{jobs}%" "vst" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+]
+install: [
+  [make "install" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+]
+run-test: [
+  [make "-j%{jobs}%" "test" "IGNORECOQVERSION=true" "ZLIST=platform" "BITSIZE=32"]
+]
+depends: [
+  "ocaml"
+  "coq" {>= "8.14" & < "8.18~"}
+  "coq-compcert-32" {= "3.12"}
+  "coq-vst-zlist" {= version}
+  "coq-flocq" {>= "4.1.0"}
+]
+conflicts: [
+  "coq-vst"
+]
+tags: [
+  "category:Computer Science/Semantics and Compilation/Semantics"
+  "keyword:C"
+  "logpath:VST"
+  "date:2023-03-31"
+]
+url {
+  src: "https://github.com/PrincetonUniversity/VST/archive/refs/tags/v2.12.tar.gz"
+  checksum: "sha512=7ca3bf55a7e5888dbfd271d9955c463d00de0e7125c60a45ca568d7de2a75104f0e740ba002e10ce7fd1ab94761c0b876816ffac4ac3f2c49af187891be604b5"
+}


### PR DESCRIPTION
This PR adds a package for version 2.12 of the 32 bit variant of VST (the 64 bit variant already exists).

ci-skip: coq-vst-32.2.12

@palmskog : this is a Coq Platform left over (I have it locally) - I would appreciate a quick merge (CI will anyway timeout for VST)