### PR TITLE
Package vscoq-language-server.1.9.1+coq8.18

### DIFF
--- a/extra-dev/packages/vscoq-language-server/vscoq-language-server.1.9.1+coq8.18/opam
+++ b/extra-dev/packages/vscoq-language-server/vscoq-language-server.1.9.1+coq8.18/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/coq-community/vscoq"
+bug-reports: "https://github.com/coq-community/vscoq/issues"
+dev-repo: "git+https://github.com/coq-community/vscoq"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.13.1" }
+  "coq-core" { >= "8.18" < "8.19" }
+  "coq-stdlib" { >= "8.18" < "8.19" }
+  "yojson"
+  "ocamlfind"
+  "ppx_inline_test"
+  "ppx_assert"
+  "ppx_sexp_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
+  "ppx_deriving"
+  "sexplib"
+  "ppx_yojson_conv"
+  "ppx_import"
+  "lsp"
+]
+synopsis: "VSCoq language server"
+description: """
+LSP based language server for Coq and its VSCoq user interface
+"""
+url {
+  src:
+    "https://github.com/coq-community/vscoq/releases/download/v1.9.1+coq8.18/vscoq-language-server-1.9.1-coq8.18.tar.gz"
+  checksum: [
+    "md5=1a1d73c8fb0bf44c542557d397986356"
+    "sha512=53f9dbcff1b87ac07165a46d02df1c7ba377d6798fa40fa65ffc11839bd9bb5f4483c8bc5ce19f3997b354da212c0a886e089620c054a5b1b3cbeea9628147d7"
+  ]
+}


### PR DESCRIPTION
### `vscoq-language-server.1.9.1+coq8.18`
VSCoq language server
LSP based language server for Coq and its VSCoq user interface



---
* Homepage: https://github.com/coq-community/vscoq
* Source repo: git+https://github.com/coq-community/vscoq
* Bug tracker: https://github.com/coq-community/vscoq/issues

---
:camel: Pull-request generated by opam-publish v2.0.3